### PR TITLE
[GUI] match FAQ items with their content

### DIFF
--- a/src/qt/veil/forms/settingsfaq.ui
+++ b/src/qt/veil/forms/settingsfaq.ui
@@ -310,7 +310,7 @@ QScrollBar:vertical {
               <x>0</x>
               <y>0</y>
               <width>400</width>
-              <height>546</height>
+              <height>501</height>
              </rect>
             </property>
             <property name="maximumSize">
@@ -847,48 +847,6 @@ Address / Exchange or Service mode?</string>
                   </property>
                   <property name="text">
                    <string>What is the Veil Bounty Program?</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="radioButton_11">
-                  <property name="maximumSize">
-                   <size>
-                    <width>390</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">#radioButton_11 {
-    border-radius: 0;
-    border:  0;
-    background-color:#ffffff;
-    color: #707070;
-    font-size: 18px;
-    padding:10 30 10 30;
-    text-align:center !important;
-}
-
-#radioButton_11:checked {
-    border:  0;
-     background-color:rgba(16,90,239,0.2);
-    color: #707070;
-}
-
-#radioButton_11:unchecked {
-    border:  0;
-    background-color:white;
-    color: #707070;
-}
-
-#radioButton_11::indicator {
-    width:                  0px;
-    height:                 0px;
-    border-radius:          0px;
-}</string>
-                  </property>
-                  <property name="text">
-                   <string>Contact Veil Support for help</string>
                   </property>
                  </widget>
                 </item>

--- a/src/qt/veil/forms/settingsfaq04.ui
+++ b/src/qt/veil/forms/settingsfaq04.ui
@@ -17,7 +17,7 @@
    <string notr="true">font-size:16px;
 color:#707070;</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
    <property name="rightMargin">
     <number>60</number>
    </property>

--- a/src/qt/veil/forms/settingsfaq05.ui
+++ b/src/qt/veil/forms/settingsfaq05.ui
@@ -17,7 +17,7 @@
    <string notr="true">font-size:16px;
 color:#707070;</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
    <property name="rightMargin">
     <number>60</number>
    </property>

--- a/src/qt/veil/forms/settingsfaq06.ui
+++ b/src/qt/veil/forms/settingsfaq06.ui
@@ -17,7 +17,7 @@
    <string notr="true">font-size:16px;
 color:#707070;</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
    <property name="rightMargin">
     <number>60</number>
    </property>

--- a/src/qt/veil/forms/settingsfaq07.ui
+++ b/src/qt/veil/forms/settingsfaq07.ui
@@ -17,7 +17,7 @@
    <string notr="true">font-size:16px;
 color:#707070;</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
    <property name="rightMargin">
     <number>60</number>
    </property>

--- a/src/qt/veil/forms/settingsfaq08.ui
+++ b/src/qt/veil/forms/settingsfaq08.ui
@@ -22,7 +22,7 @@ color:#707070;</string>
     <number>60</number>
    </property>
    <item alignment="Qt::AlignLeft|Qt::AlignTop">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_2">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -33,9 +33,15 @@ color:#707070;</string>
       <string notr="true">font-weight:200;</string>
      </property>
      <property name="text">
-      <string>“Extreme Privacy Mode allows you to set a password to protect sensitive data stored on your device. When enabled, the password will be required to view your balances, transactions, and addresses.
+      <string>“Veil secures its network with an exclusively anonymous Zerocoin-based Proof-of-Stake system. Basecoin veil cannot stake. Only Zerocoin veil can stake.
 
-Losing this password will not result in loss of funds.”					</string>
+Follow these simple steps to begin staking veil:
+
+1. Send veil to the QR code or receiving address displayed in the overview tab to deposit veil to yourself.
+2. Click the Staking Toggle at the bottom left of the Overview screen and input your password to unlock your wallet for Staking/Autominting.
+3. Allow the wallet to automatically mint your Basecoin veil into Zerocoin veil.
+4. After newly minted Zerocoin veil denominations receive 200 confirmations, they will begin staking and can earn staking rewards.
+5. Ensure the staking icon at the bottom left of the Overview screen is turned on. Exiting your wallet will stop staking.”					</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/src/qt/veil/forms/settingsfaq08.ui
+++ b/src/qt/veil/forms/settingsfaq08.ui
@@ -17,7 +17,7 @@
    <string notr="true">font-size:16px;
 color:#707070;</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
    <property name="rightMargin">
     <number>60</number>
    </property>

--- a/src/qt/veil/forms/settingsfaq09.ui
+++ b/src/qt/veil/forms/settingsfaq09.ui
@@ -22,7 +22,7 @@ color:#707070;</string>
     <number>60</number>
    </property>
    <item alignment="Qt::AlignLeft|Qt::AlignTop">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -33,15 +33,11 @@ color:#707070;</string>
       <string notr="true">font-weight:200;</string>
      </property>
      <property name="text">
-      <string>“Veil secures its network with an exclusively anonymous Zerocoin-based Proof-of-Stake system. Basecoin veil cannot stake. Only Zerocoin veil can stake.
+      <string>“The X16RT mining algorithm will be used for at least the first 12 months of mainnet going live (January 1st, 2019) to achieve wide coin supply distribution.
 
-Follow these simple steps to begin staking veil:
+Anyone with NVIDIA or AMD graphics cards will be able to solo mine or pool mine VEIL without concerns about ASIC’s and mining centralization during the mining phase.
 
-1. Send veil to the QR code or receiving address displayed in the overview tab to deposit veil to yourself.
-2. Click the Staking Toggle at the bottom left of the Overview screen and input your password to unlock your wallet for Staking/Autominting.
-3. Allow the wallet to automatically mint your Basecoin veil into Zerocoin veil.
-4. After newly minted Zerocoin veil denominations receive 200 confirmations, they will begin staking and can earn staking rewards.
-5. Ensure the staking icon at the bottom left of the Overview screen is turned on. Exiting your wallet will stop staking.”					</string>
+For the latest mining instructions, please see the Official Veil Announcement thread on the BitcoinTalk forum.”					</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -50,19 +46,6 @@ Follow these simple steps to begin staking veil:
       <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/qt/veil/forms/settingsfaq10.ui
+++ b/src/qt/veil/forms/settingsfaq10.ui
@@ -22,7 +22,7 @@ color:#707070;</string>
     <number>60</number>
    </property>
    <item alignment="Qt::AlignLeft|Qt::AlignTop">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_2">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -33,11 +33,9 @@ color:#707070;</string>
       <string notr="true">font-weight:200;</string>
      </property>
      <property name="text">
-      <string>“The X16RT mining algorithm will be used for at least the first 12 months of mainnet going live (January 1st, 2019) to achieve wide coin supply distribution.
+      <string>“Anyone can earn veil through the Veil Bounty Program. A wide variety of tasks can be performed to earn veil, ranging from traditional bounty tasks, high reward contests, bug bounty, dev bounty, and adopting Veil as a merchant or service.
 
-Anyone with NVIDIA or AMD graphics cards will be able to solo mine or pool mine VEIL without concerns about ASIC’s and mining centralization during the mining phase.
-
-For the latest mining instructions, please see the Official Veil Announcement thread on the BitcoinTalk forum.”					</string>
+For the latest information, please see the Official Veil Bounty Program thread on the BitcoinTalk forum.”					</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/src/qt/veil/settings/settingsfaq.cpp
+++ b/src/qt/veil/settings/settingsfaq.cpp
@@ -34,7 +34,7 @@ SettingsFaq::SettingsFaq(QWidget *parent, bool howToObtainVeil) :
     ui->radioButton_08->setProperty("cssClass" , "radio-button-faq");
     ui->radioButton_09->setProperty("cssClass" , "radio-button-faq");
     ui->radioButton_10->setProperty("cssClass" , "radio-button-faq");
-    ui->radioButton_11->setProperty("cssClass" , "radio-button-faq");
+    //ui->radioButton_11->setProperty("cssClass" , "radio-button-faq");
 
     connect(ui->radioButton_01,SIGNAL(clicked()),this, SLOT(onRadioButton01Clicked()));
     //connect(ui->radioButton_02,SIGNAL(clicked()),this, SLOT(onRadioButton02Clicked()));
@@ -46,7 +46,7 @@ SettingsFaq::SettingsFaq(QWidget *parent, bool howToObtainVeil) :
     connect(ui->radioButton_08,SIGNAL(clicked()),this, SLOT(onRadioButton08Clicked()));
     connect(ui->radioButton_09,SIGNAL(clicked()),this, SLOT(onRadioButton09Clicked()));
     connect(ui->radioButton_10,SIGNAL(clicked()),this, SLOT(onRadioButton10Clicked()));
-    connect(ui->radioButton_11,SIGNAL(clicked()),this, SLOT(onRadioButton11Clicked()));
+    //connect(ui->radioButton_11,SIGNAL(clicked()),this, SLOT(onRadioButton11Clicked()));
 
     faq01 = new SettingsFaq01(this);
 

--- a/src/qt/veil/settings/settingsfaq08.cpp
+++ b/src/qt/veil/settings/settingsfaq08.cpp
@@ -7,11 +7,18 @@ SettingsFaq08::SettingsFaq08(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->label->setText("Extreme Privacy Mode allows you to set a password to protect sensitive data stored on your device.<br><br> When enabled, the password will be required to view your balances, transactions, and addresses.<br><br>"
+    ui->label_2->setText("Veil secures its network with an exclusively anonymous Zerocoin-based Proof-of-Stake system. Basecoin veil cannot stake. Only Zerocoin veil can stake.<br><br>"
 
-                       "Losing this password will not result in loss of funds.");
-    ui->label->setTextFormat( Qt::RichText );
-    ui->label->setWordWrap(true);
+                         "<font color=#105aef>Follow these simple steps to begin staking veil:</font><br><br>"
+
+                            "1. Send veil to the QR code or receiving address displayed in the overview tab to deposit veil to yourself.<br>"
+                            "2. Click the Staking Toggle at the bottom left of the Overview screen and input your password to unlock your wallet for Staking/Autominting.<br>"
+                            "3. Allow the wallet to automatically mind your Basecoin veil into Zerocoin veil.<br>"
+                            "4. After newly minted Zerocoin veil receives 200 confirmations, it will begin staking and can earn staking rewards. <br>"
+                         "5. Ensure the staking icon at the bottom left of the Overview screen is turned on. Exiting your wallet will stop staking.");
+
+    ui->label_2->setTextFormat( Qt::RichText );
+    ui->label_2->setWordWrap(true);
 }
 
 SettingsFaq08::~SettingsFaq08()

--- a/src/qt/veil/settings/settingsfaq09.cpp
+++ b/src/qt/veil/settings/settingsfaq09.cpp
@@ -7,18 +7,14 @@ SettingsFaq09::SettingsFaq09(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->label_2->setText("Veil secures its network with an exclusively anonymous Zerocoin-based Proof-of-Stake system. Basecoin veil cannot stake. Only Zerocoin veil can stake.<br><br>"
+    ui->label->setText("The X16RT mining algorithm will be used for at least the first 12 months of mainnet going live (January 1st, 2019) to achieve wide coin supply distribution.<br><br>"
 
-                         "<font color=#105aef>Follow these simple steps to begin staking veil:</font><br><br>"
+                         "Anyone with NVIDIA or AMD graphics cards will be able to solo mine or pool mine veil without concerns about ASICs and mining centralization during the mining phase.<br><br>"
 
-                            "1. Send veil to the QR code or receiving address displayed in the overview tab to deposit veil to yourself.<br>"
-                            "2. Click the Staking Toggle at the bottom left of the Overview screen and input your password to unlock your wallet for Staking/Autominting.<br>"
-                            "3. Allow the wallet to automatically mind your Basecoin veil into Zerocoin veil.<br>"
-                            "4. After newly minted Zerocoin veil receives 200 confirmations, it will begin staking and can earn staking rewards. <br>"
-                         "5. Ensure the staking icon at the bottom left of the Overview screen is turned on. Exiting your wallet will stop staking.");
+                         "For the latest mining instructions, please see the Official Veil Announcement thread on the <font color=#105aef>BitcoinTalk forum</font>.");
 
-    ui->label_2->setTextFormat( Qt::RichText );
-    ui->label_2->setWordWrap(true);
+    ui->label->setTextFormat( Qt::RichText );
+    ui->label->setWordWrap(true);
 }
 
 SettingsFaq09::~SettingsFaq09()

--- a/src/qt/veil/settings/settingsfaq10.cpp
+++ b/src/qt/veil/settings/settingsfaq10.cpp
@@ -7,14 +7,12 @@ SettingsFaq10::SettingsFaq10(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->label->setText("The X16RT mining algorithm will be used for at least the first 12 months of mainnet going live (January 1st, 2019) to achieve wide coin supply distribution.<br><br>"
+    ui->label_2->setText("Anyone can earn veil through the Veil Bounty Program. A wide variety of tasks can be performed to earn veil, ranging from traditional bounty tasks, high reward contests, bug bounty, dev bounty, and adopting Veil as a merchant or service.<br><br>"
 
-                         "Anyone with NVIDIA or AMD graphics cards will be able to solo mine or pool mine veil without concerns about ASICs and mining centralization during the mining phase.<br><br>"
+                         "For the latest information, please see the Official Veil Bounty Program thread on the <font color=#105aef>BitcoinTalk forum.</font>");
 
-                         "For the latest mining instructions, please see the Official Veil Announcement thread on the <font color=#105aef>BitcoinTalk forum</font>.");
-
-    ui->label->setTextFormat( Qt::RichText );
-    ui->label->setWordWrap(true);
+    ui->label_2->setTextFormat( Qt::RichText );
+    ui->label_2->setWordWrap(true);
 }
 
 SettingsFaq10::~SettingsFaq10()


### PR DESCRIPTION
closes https://github.com/Veil-Project/veil/issues/96 (ordering issue)

- old 'extreme privacy' page is removed since it had no question/radio-button associated.
- 'contact veil support' page (faq11) commented out since there's no content for it yet.