### PR TITLE
[WIP] Choose the right transaction type when sending through the GUI

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -46,6 +46,7 @@ public:
     {
         LOCK2(cs_main, m_wallet.cs_wallet);
         CValidationState state;
+
         if (!m_wallet.CommitTransaction(m_tx, std::move(value_map), std::move(order_form), m_key, g_connman.get(), state)) {
             reject_reason = state.GetRejectReason();
             return false;
@@ -361,19 +362,67 @@ public:
         LOCK2(cs_main, m_wallet.cs_wallet);
         return m_wallet.ListLockedCoins(outputs);
     }
-    std::unique_ptr<PendingWalletTx> createTransaction(const std::vector<CRecipient>& recipients,
+    std::unique_ptr<PendingWalletTx> createTransaction(std::vector<CTempRecipient>& recipients,
         const CCoinControl& coin_control,
         bool sign,
         int& change_pos,
         CAmount& fee,
+        OutputTypes inputType,
         std::string& fail_reason) override
     {
         LOCK2(cs_main, m_wallet.cs_wallet);
         auto pending = MakeUnique<PendingWalletTxImpl>(m_wallet);
-        if (!m_wallet.CreateTransaction(recipients, pending->m_tx, pending->m_key, fee, change_pos,
-                fail_reason, coin_control, sign)) {
+        size_t nRingSize = Params().DefaultRingSize();
+        size_t nInputsPerSig = 32;
+
+        CTransactionRef tx_new;
+        auto pwalletAnon = m_wallet.GetAnonWallet();
+
+        CWalletTx wtx(&m_wallet, tx_new);
+        CTransactionRecord rtx;
+
+        CAmount nFeeRet = 0;
+        bool fFailed = false;
+        bool fCheckFeeOnly = false;
+        switch (inputType) {
+            case OUTPUT_STANDARD:
+            {
+                if (0 !=
+                    pwalletAnon->AddStandardInputs(wtx, rtx, recipients, !fCheckFeeOnly, nFeeRet, &coin_control, fail_reason, false))
+                    fFailed = true;
+                break;
+            }
+            case OUTPUT_CT:
+                if (0 != pwalletAnon->AddBlindedInputs(wtx, rtx, recipients, !fCheckFeeOnly, nFeeRet, &coin_control, fail_reason))
+                    fFailed = true;
+                break;
+            case OUTPUT_RINGCT:
+                if (0 != pwalletAnon->AddAnonInputs(wtx, rtx, recipients, !fCheckFeeOnly, nRingSize, nInputsPerSig, nFeeRet, &coin_control, fail_reason))
+                    fFailed = true;
+                break;
+            default:
+                fFailed = true;
+        }
+
+        if (fFailed) {
+            fail_reason = "Failed to add inputs";
             return {};
         }
+
+        CValidationState state;
+        CReserveKey reservekey(&m_wallet);
+
+        pending->m_tx = tx_new;
+//        if (!m_wallet.CommitTransaction(wtx.tx, wtx.mapValue, wtx.vOrderForm, reservekey, g_connman.get(), state)) {
+//            fail_reason = "Transaction commit failed";
+//        }
+
+        fee = nFeeRet;
+
+//        if (!m_wallet.CreateTransaction(recipients, pending->m_tx, pending->m_key, fee, change_pos,
+//                fail_reason, coin_control, sign)) {
+//            return {};
+//        }
         return std::move(pending);
     }
     bool transactionCanBeAbandoned(const uint256& txid) override { return m_wallet.TransactionCanBeAbandoned(txid); }
@@ -548,6 +597,24 @@ public:
     CAmount getAvailableBalance(const CCoinControl& coin_control) override
     {
         return m_wallet.GetAvailableBalance(&coin_control);
+    }
+    CAmount getAvailableCTBalance(const CCoinControl& coin_control) override
+    {
+        if (!m_wallet.GetAnonWallet())
+            return 0;
+        return m_wallet.GetAnonWallet()->GetAvailableBlindBalance(&coin_control);
+    }
+    CAmount getAvailableRingCTBalance(const CCoinControl& coin_control) override
+    {
+        if (!m_wallet.GetAnonWallet()) {
+            std::cout << "Couldn't get anon wallet" << std::endl;
+            return 0;
+        }
+        return m_wallet.GetAnonWallet()->GetAvailableAnonBalance(&coin_control);
+    }
+    CWallet* getWalletPointer() override
+    {
+        return m_shared_wallet.get();
     }
     isminetype txinIsMine(const CTxIn& txin) override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -31,6 +31,7 @@
 class CCoinControl;
 class CFeeRate;
 class CKey;
+class CTempRecipient;
 class CWallet;
 class CWalletTx;
 class CDeterministicMint;
@@ -155,11 +156,12 @@ public:
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 
     //! Create transaction.
-    virtual std::unique_ptr<PendingWalletTx> createTransaction(const std::vector<CRecipient>& recipients,
+    virtual std::unique_ptr<PendingWalletTx> createTransaction(std::vector<CTempRecipient>& recipients,
         const CCoinControl& coin_control,
         bool sign,
         int& change_pos,
         CAmount& fee,
+        OutputTypes inputType,
         std::string& fail_reason) = 0;
 
     //! Return whether transaction can be abandoned.
@@ -223,6 +225,11 @@ public:
 
     //! Get available balance.
     virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
+    virtual CAmount getAvailableCTBalance(const CCoinControl& coin_control) { return 0; }
+    virtual CAmount getAvailableRingCTBalance(const CCoinControl& coin_control) { return 0; }
+
+    //! Create a WalletTx without all the data filled in yet.
+    virtual CWallet* getWalletPointer() { return nullptr; }
 
     //! Return whether transaction input belongs to wallet.
     virtual isminetype txinIsMine(const CTxIn& txin) = 0;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -221,13 +221,13 @@ void SendCoinsDialog::on_sendButton_clicked()
         }
     }
 
-    if(recipients.isEmpty()){
-        openToastDialog("No recipients", this);
+    if(!valid){
+        openToastDialog("Invalid data", this);
         return;
     }
 
-    if(!valid){
-        openToastDialog("Invalid data", this);
+    if(recipients.isEmpty()){
+        openToastDialog("No recipients", this);
         return;
     }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -159,7 +159,8 @@ public:
     };
 
     // prepare transaction for getting txfee before sending coins
-    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl);
+    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl,
+            OutputTypes inputType = OUTPUT_RINGCT);
 
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -2196,6 +2196,14 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
                 r.nType = OUTPUT_CT;
                 r.fChange = true;
 
+                //If no change address is set, then generate a new stealth address to use for change
+                if (!coinControl || ((coinControl && coinControl->destChange.type() == typeid(CNoDestination)))) {
+                    CStealthAddress stealthAddress;
+                    if (!NewStealthKey(stealthAddress, 0, nullptr))
+                        return error("%s: failed to generate stealth address to use for change: %s", __func__, sError);
+                    r.address = stealthAddress;
+                }
+
                 if (!SetChangeDest(coinControl, r, sError)) {
                     return wserrorN(1, sError, __func__, ("SetChangeDest failed: " + sError));
                 }


### PR DESCRIPTION
I'm encountering issues with sending CT, so I haven't been able to thoroughly test this. There will likely be some issues, but it should be close to working. I haven't yet added a checkbox to use basecoin because I wanted to test using blinded inputs first.