### PR TITLE
dont branch based on potentially uninit var

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -183,6 +183,7 @@ public:
         hashMerkleRoot = uint256();
         hashWitnessMerkleRoot = uint256();
         hashPoFN = uint256();
+        fSignaturesVerified = false;
     }
 
     CBlockHeader GetBlockHeader() const


### PR DESCRIPTION
seems to prevent segfault with local stratum; evidenced by waves of nodes reannouncing after connectblock errors..