### PR TITLE
Fix a wide range of transaction issues.

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -268,14 +268,11 @@ public:
     bool getPrivKey(const CKeyID& address, CKey& key) override { return m_wallet.GetKey(address, key); }
     bool isSpendable(const CTxDestination& dest) override { return IsMine(m_wallet, dest) & ISMINE_SPENDABLE; }
 
-    std::string mintZerocoin(
-            CAmount nValue,
-            std::vector<CDeterministicMint>& vDMints,
-            bool fAllowBasecoin,
-            const CCoinControl* coinControl
-    ) override {
+    std::string mintZerocoin(CAmount nValue, std::vector<CDeterministicMint>& vDMints, OutputTypes inputtype,
+            const CCoinControl* coinControl) override
+    {
         CWalletTx wtx(&m_wallet, nullptr);
-        return m_wallet.MintZerocoin(nValue, wtx ,  vDMints, fAllowBasecoin,coinControl);
+        return m_wallet.MintZerocoin(nValue, wtx , vDMints, inputtype,coinControl);
     }
 
     std::unique_ptr<PendingWalletTx> spendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendReceipt& receipt,
@@ -620,6 +617,9 @@ public:
                 result.ring_ct_immature_balance + result.zerocoin_immature_balance;
         result.total_unconfirmed_balance = result.basecoin_unconfirmed_balance + result.ct_unconfirmed_balance +
                 result.ring_ct_unconfirmed_balance + result.zerocoin_unconfirmed_balance;
+
+        //Total balance should include any immature or unconfirmed
+        result.total_balance += result.total_immature_balance + result.total_unconfirmed_balance;
 
         return result;
     }

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -619,7 +619,7 @@ public:
                 result.ring_ct_unconfirmed_balance + result.zerocoin_unconfirmed_balance;
 
         //Total balance should include any immature or unconfirmed
-        result.total_balance += result.total_immature_balance + result.total_unconfirmed_balance;
+        result.total_balance += result.total_immature_balance;
 
         return result;
     }

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -106,12 +106,8 @@ public:
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CTxDestination& dest) = 0;
 
-    virtual std::string mintZerocoin(
-            CAmount nValue,
-            std::vector<CDeterministicMint>& vDMints,
-            bool fAllowBasecoin,
-            const CCoinControl* coinControl
-    ) = 0;
+    virtual std::string mintZerocoin(CAmount nValue, std::vector<CDeterministicMint>& vDMints, OutputTypes inputtype,
+            const CCoinControl* coinControl) = 0;
 
     virtual std::unique_ptr<PendingWalletTx> spendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendReceipt& receipt,
             std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -146,7 +146,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         }
     }
 
-    LOCK2(cs_main, mempool.cs);
+    LOCK(cs_main);
+    TRY_LOCK(mempool.cs, fLockMem);
+    if (!fLockMem)
+        return nullptr;
+
     CBlockIndex* pindexPrev = chainActive.Tip();
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;

--- a/src/qt/veil/settings/settingsminting.cpp
+++ b/src/qt/veil/settings/settingsminting.cpp
@@ -120,21 +120,24 @@ void SettingsMinting::mintzerocoins(){
         return;
     }
 
-    bool fAllowBasecoin = ui->useBasecoin->isChecked();
+    bool fUseBasecoin = ui->useBasecoin->isChecked();
 
     interfaces::Wallet& wallet = walletModel->wallet();
     std::vector<CDeterministicMint> vDMints;
     std::vector<COutPoint> vOutpts;
-    OutputTypes inputtype;
+    OutputTypes inputtype = OUTPUT_NULL;
 
     interfaces::WalletBalances balances = wallet.getBalances();
-    if (balances.ring_ct_balance > nAmount && chainActive.Tip()->nAnonOutputs > 20)
-        inputtype = OUTPUT_RINGCT;
-    else if (balances.ct_balance > nAmount)
-        inputtype = OUTPUT_CT;
-    else if (fAllowBasecoin && balances.basecoin_balance > nAmount)
+    if (!fUseBasecoin) {
+        if (balances.ring_ct_balance > nAmount && chainActive.Tip()->nAnonOutputs > 20)
+            inputtype = OUTPUT_RINGCT;
+        else if (balances.ct_balance > nAmount)
+            inputtype = OUTPUT_CT;
+    } else if (balances.basecoin_balance > nAmount) {
         inputtype = OUTPUT_STANDARD;
-    else {
+    }
+
+    if (inputtype == OUTPUT_NULL) {
         openToastDialog("Insufficient Balance", this);
         return;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1854,8 +1854,11 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
 
                     if (out->IsType(OUTPUT_STANDARD))
                         txout.nValue = out->GetValue();
+
                     bool is_spent = view.SpendCoin(op, &coin);
                     if (!is_spent || txout != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.fCoinBase) {
+                        LogPrintf("tx: is_coinbase=%d height=%d coinheight=%d\n", is_coinbase, pindex->nHeight, coin.nHeight);
+                        LogPrintf("%s:%s %s\n  pos=%d spend=%d txout==%d height=%d cbase=%d \n %s\n", __func__, __LINE__, block.GetHash().GetHex(), k, !is_spent, txout != coin.out, pindex->nHeight != coin.nHeight, is_coinbase != coin.fCoinBase, tx.ToString());
                         fClean = false; // transaction output mismatch
                     }
                 }

--- a/src/veil/ringct/anon.cpp
+++ b/src/veil/ringct/anon.cpp
@@ -56,7 +56,7 @@ bool VerifyMLSAG(const CTransaction &tx, CValidationState &state)
         uint32_t nInputs, nRingSize;
         txin.GetAnonInfo(nInputs, nRingSize);
 
-        if (nInputs < 1 || nInputs > MAX_ANON_INPUTS) // TODO: Select max inputs size
+        if (nInputs < 1 || nInputs > MAX_ANON_INPUTS)
             return state.DoS(100, false, REJECT_INVALID, "bad-anon-num-inputs");
 
         if (nRingSize < MIN_RINGSIZE || nRingSize > MAX_RINGSIZE)
@@ -132,15 +132,16 @@ bool VerifyMLSAG(const CTransaction &tx, CValidationState &state)
             const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
 
             if (!setHaveKI.insert(ki).second) {
-                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-ki");
+                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-ki-tx-double");
             }
 
             if (mempool.HaveKeyImage(ki, txhashKI) && txhashKI != txhash) {
-                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-ki");
+                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-ki-mempool");
             }
 
             if (pblocktree->ReadRCTKeyImage(ki, txhashKI) && txhashKI != txhash) {
-                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-ki");
+                LogPrintf("%s: Key image in tx %s\n", __func__, txhashKI.GetHex());
+                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-keyimage");
             }
         }
 

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -31,22 +31,6 @@ class UniValue;
 
 const uint16_t OR_PLACEHOLDER_N = 0xFFFF; // index of a fake output to contain reconstructed amounts for txns with undecodeable outputs
 
-enum RTxAddonValueTypes
-{
-    RTXVT_EPHEM_PATH            = 1, // path ephemeral keys are derived from packed 4bytes no separators
-
-    RTXVT_REPLACES_TXID         = 2,
-    RTXVT_REPLACED_BY_TXID      = 3,
-
-    RTXVT_COMMENT               = 4,
-    RTXVT_TO                    = 5,
-
-    /*
-    RTXVT_STEALTH_KEYID     = 2,
-    RTXVT_STEALTH_KEYID_N   = 3, // n0:pk0:n1:pk1:...
-    */
-};
-
 class COutputR
 {
 public:

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -225,6 +225,7 @@ public:
 
     void AddOutputRecordMetaData(CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend);
     bool ExpandTempRecipients(std::vector<CTempRecipient> &vecSend, std::string &sError);
+    void MarkInputsAsPendingSpend(CTransactionRecord &rtx);
 
     int AddCTData(CTxOutBase *txout, CTempRecipient &r, std::string &sError);
 

--- a/src/veil/ringct/outputrecord.cpp
+++ b/src/veil/ringct/outputrecord.cpp
@@ -44,20 +44,28 @@ bool COutputRecord::IsSend() const
 
 bool COutputRecord::IsBasecoin() const
 {
-    return nType == OUTPUT_STANDARD;
+    return nFlags == OUTPUT_STANDARD;
 }
 
 void COutputRecord::MarkSpent(bool isSpent)
 {
     if (isSpent)
-        nType |= ORF_SPENT;
+        nFlags |= ORF_SPENT;
     else
-        nType &= ~ORF_SPENT;
+        nFlags &= ~ORF_SPENT;
 }
 
-bool COutputRecord::IsSpent() const
+void COutputRecord::MarkPendingSpend(bool isSpent)
 {
-    return nType & ORF_SPENT;
+    if (isSpent)
+        nFlags |= ORF_PENDING_SPEND;
+    else
+        nFlags &= ORF_PENDING_SPEND;
+}
+
+bool COutputRecord::IsSpent(bool fIncludePendingSpend) const
+{
+    return nFlags & ORF_SPENT || nFlags & ORF_PENDING_SPEND;
 }
 
 CAmount COutputRecord::GetAmount() const

--- a/src/veil/ringct/outputrecord.h
+++ b/src/veil/ringct/outputrecord.h
@@ -25,7 +25,7 @@ enum OutputRecordFlags
     ORF_SPENT               = (1 << 3),
     ORF_LOCKED              = (1 << 4), // Needs wallet to be unlocked for further processing
     ORF_WATCHONLY           = (1 << 6),
-    ORF_HARDWARE_DEVICE     = (1 << 7),
+    ORF_PENDING_SPEND       = (1 << 7), // Don't use this output because it has been used to spend
 
     ORF_OWN_WATCH           = ORF_WATCHONLY,
     ORF_OWN_ANY             = ORF_OWNED | ORF_OWN_WATCH,
@@ -74,7 +74,8 @@ public:
     bool GetDestination(CTxDestination& dest) const;
     std::string ToString() const;
     void MarkSpent(bool isSpent);
-    bool IsSpent() const;
+    void MarkPendingSpend(bool isSpent);
+    bool IsSpent(bool fIncludePendingSpend = true) const;
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -275,9 +275,16 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
         if (typeOut == OUTPUT_RINGCT && !address.IsValidStealthAddress()) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid stealth address");
         }
-
-        if (!address.IsValid()) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+        CTxDestination dest;
+        if (typeOut == OUTPUT_STANDARD) {
+            dest = DecodeDestination(request.params[0].get_str());
+            if (!IsValidDestination(dest)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid basecoin address");
+            }
+        } else {
+            if (!address.IsValid())
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid stealth address");
+            dest = address.Get();
         }
 
         CAmount nAmount = AmountFromValue(request.params[1]);
@@ -291,7 +298,7 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
             fSubtractFeeFromAmount = request.params[4].get_bool();
         }
 
-        if (0 != AddOutput(typeOut, vecSend, address.Get(), nAmount, fSubtractFeeFromAmount, sError)) {
+        if (0 != AddOutput(typeOut, vecSend, dest, nAmount, fSubtractFeeFromAmount, sError)) {
             throw JSONRPCError(RPC_MISC_ERROR, strprintf("AddOutput failed: %s.", sError));
         }
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -592,6 +592,10 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
+    if (dest.which() == 6) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Must send to a basecoin address");
+    }
+
     // Amount
     CAmount nAmount = AmountFromValue(request.params[1]);
     if (nAmount <= 0)

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -17,6 +17,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 #include <veil/zerocoin/mintmeta.h>
+#include <txmempool.h>
 
 
 #include <boost/assign.hpp>
@@ -73,6 +74,9 @@ UniValue mintzerocoin(const JSONRPCRequest& request)
                 HelpExampleRpc("mintzerocoin", "13, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\""));
 
     LOCK2(cs_main, pwallet->cs_wallet);
+    TRY_LOCK(mempool.cs, fMempoolLocked);
+    if (!fMempoolLocked)
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "failed to lock mempool");
 
 //    if (params.size() == 1) {
 //        RPCTypeCheck(params, boost::assign::list_of(UniValue::VNUM));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -808,7 +808,7 @@ public:
     // Zerocoin
     bool MintableCoins();
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, std::vector<CDeterministicMint>& vDMints,
-            CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, std::vector<CTempRecipient>& vecSend, bool isBasecoin, const CCoinControl* coinControl = NULL,
+            CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, std::vector<CTempRecipient>& vecSend, OutputTypes inputtype, const CCoinControl* coinControl = NULL,
             const bool isZCSpendChange = false);
     bool CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel, CWalletTx& wtxNew, CReserveKey& reserveKey,
             CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vSelectedMints,
@@ -817,7 +817,7 @@ public:
             CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
     std::string MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints,
             const std::vector<COutPoint> vOutpts);
-    std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, bool fAllowBasecoin,
+    std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, OutputTypes inputtype,
             const CCoinControl* coinControl = NULL);
     bool SpendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendReceipt& receipt,
             std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CTxDestination* addressTo = NULL);


### PR DESCRIPTION
**Fixed:**
- Sending zerocoin/RingCT/CT from the GUI send dialog
- Zerocoin mint from CT and RingCT.
- Deadlock when minting zerocoins.
- Zerocoinspend tx meta data not correctly tied to tx because of the txhash changes after signature.
- Basecoin balances
- CT Balances
- Properly select CT/RingCT output type for change situations.
- Allow Basecoin checkbox and rpc flag now used as "Use Basecoins" which will specifically only use basecoins for that tx.
- Automatically archive bad mints if possible.
- Mark anon output as spent if during spending the key image is found on the blockchain DB.
- Mark CT inputs as spent when spending them.
- Don't try to add loose coinstake transactions to mempool.

**Problems not solved:**
- Still seeing a blockchain corruption periodically when restarting, can't yet find the exact cause. 
