### PR TITLE
Add ability to start mining using cmd flag -gen

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -735,6 +735,13 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
             }
         }
 
+        if (fGenerateBitcoins && !fProofOfStake) { // If the miner was turned on and we are in IsInitialBlockDownload(), sleep 60 seconds, before trying again
+            if (IsInitialBlockDownload() && !gArgs.GetBoolArg("-genoverride", false)) {
+                MilliSleep(60000);
+                continue;
+            }
+        }
+
         CScript scriptMining;
         if (coinbaseScript)
             scriptMining = coinbaseScript->reserveScript;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -57,6 +57,9 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), true, OptionsCategory::WALLET_DEBUG_TEST);
+
+    gArgs.AddArg("-gen=<n>", strprintf("Enable CPU mining to true on the given number of threads (default: %u)", 0), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-genoverride", strprintf("Allows you to override the IsInitialBlockDownload check in BitcoinMiner for PoW mining (default: %u)", false), false, OptionsCategory::HIDDEN);
 }
 
 bool WalletInit::ParameterInteraction() const


### PR DESCRIPTION
- Added ability to start the wallet PoW CPU mining thread with -gen=numberofthreads
- Added PoW mining sleeps if InitialBlockDownload was found to be true
- Add override flag -genoverride that overrides the InitialBlockDownload check in the miner ( This is hidden and wont be shown in the help screen, but could be useful for developers)

To start the miner with 4 threads miner, you would do the following
Daemon - **./veild -gen=4** 
Qt - **./qt/veil-qt -gen=4**
veil.conf - **gen=4**
