### PR TITLE
Better tracking of mempool. Add some RPC calls.

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -195,6 +195,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "searchdeterministiczerocoin", 1, "range"},
     { "searchdeterministiczerocoin", 2, "threads"},
     { "spendzerocoinmints", 0, "mints_list"},
+    { "abandontransaction", 1, "remove_mempool"},
 };
 
 class CRPCConvertTable

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -97,7 +97,8 @@ private:
     int64_t nSigOpCostWithAncestors;
 
     //Zerocoin data
-    std::set<CBigNum> setSerialHashes;
+    std::set<uint256> setSerialHashes;
+    std::set<uint256> setPubcoinHashes;
 
 public:
     CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
@@ -118,7 +119,10 @@ public:
     size_t DynamicMemoryUsage() const { return nUsageSize; }
     const LockPoints& GetLockPoints() const { return lockPoints; }
     bool IsZerocoinSpend() const { return !setSerialHashes.empty(); }
-    const std::set<CBigNum> GetSetSerialHashes() const { return setSerialHashes; }
+    bool IsZerocoinMint() const { return !setPubcoinHashes.empty(); }
+    const std::set<uint256> GetSetSerialHashes() const { return setSerialHashes; }
+    bool HasSerial(const uint256& hashSerial) const { return setSerialHashes.count(hashSerial) > 0; }
+    bool HasPubcoin(const uint256& hashPubcoin) const { return setPubcoinHashes.count(hashPubcoin) > 0; }
 
     // Adjusts the descendant state.
     void UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
@@ -561,6 +565,7 @@ public:
     void removeRecursive(const CTransaction &tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction &tx) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removePubcoins(const std::set<uint256>& setPubcoinHashes) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
 
     void clear();
@@ -583,6 +588,7 @@ public:
     void ClearPrioritisation(const uint256 hash);
 
     bool HaveKeyImage(const CCmpPubKey &ki, uint256 &hash) const;
+    bool HasZerocoinSerial(const uint256& hashSerial) const;
 
 public:
     /** Remove a set of transactions from the mempool.

--- a/src/veil/zerocoin/zchain.h
+++ b/src/veil/zerocoin/zchain.h
@@ -26,6 +26,8 @@ class uint256;
 
 bool BlockToMintValueVector(const CBlock& block, const libzerocoin::CoinDenomination denom, std::vector<CBigNum>& vValues);
 bool BlockToPubcoinList(const CBlock& block, std::list<libzerocoin::PublicCoin>& listPubcoins);
+bool TxToPubcoinHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes);
+bool TxToSerialHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes);
 bool BlockToZerocoinMintList(const CBlock& block, std::list<CZerocoinMint>& vMints);
 void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMintsToUpdate, std::vector<CMintMeta>& vMissingMints);
 int GetZerocoinStartHeight();

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -694,7 +694,7 @@ UniValue ResetSpends(CWallet* pwallet)
     list<CZerocoinSpend> listSpends = walletdb.ListSpentCoins();
     list<CZerocoinSpend> listUnconfirmedSpends;
 
-    for (CZerocoinSpend spend : listSpends) {
+    for (CZerocoinSpend& spend : listSpends) {
         CTransactionRef txRef;
         uint256 hashBlock;
         if (!GetTransaction(spend.GetTxHash(), txRef, Params().GetConsensus(), hashBlock)) {
@@ -709,7 +709,7 @@ UniValue ResetSpends(CWallet* pwallet)
 
     UniValue objRet(UniValue::VOBJ);
     UniValue arrRestored(UniValue::VARR);
-    for (CZerocoinSpend spend : listUnconfirmedSpends) {
+    for (CZerocoinSpend& spend : listUnconfirmedSpends) {
         for (auto& meta : setMints) {
             if (meta.hashSerial == GetSerialHash(spend.GetSerial())) {
                 zTracker->SetPubcoinNotUsed(meta.hashPubcoin);


### PR DESCRIPTION
RPC:
- Add `findserial` from PIVX. Returns txid associated with zerocoin serial.
- Add clear mempool option to `abandontransaction`
- Add `rescanzerocoinwallet` which combines `resetzerocoinmint` `resetzerocoinspend` `reconsiderzerocoins`

Mempool:
- Add better filtering of zerocoin serials and pubcoins that currently reside in the mempool.