### PR TITLE
Wallet scans. Tx Records. Encryption. Mempool filtering.

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -276,6 +276,10 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
             in.pushKV("ring_size", (int) nSigRingSize);
         } else {
             in.pushKV("txid", txin.prevout.hash.GetHex());
+            if (txin.scriptSig.IsZerocoinSpend()) {
+                in.pushKV("type", "zerocoinspend");
+                in.pushKV("denomination", FormatMoney(txin.GetZerocoinSpent()));
+            }
             in.pushKV("vout", (int64_t)txin.prevout.n);
             UniValue o(UniValue::VOBJ);
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -79,6 +79,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
         auto panonwallet = wallet.GetAnonWallet();
         if (panonwallet->mapRecords.count(txid)) {
             result.rtx = panonwallet->mapRecords.at(txid);
+            result.has_rtx = true;
         }
     }
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -410,6 +410,7 @@ struct WalletTx
     bool is_my_zerocoin_spend;
     bool is_anon_send;
     bool is_anon_recv;
+    bool has_rtx;
     std::map<unsigned int, CAmount> map_anon_value_out;
     std::map<unsigned int, CAmount> map_anon_value_in;
     std::pair<int, CAmount> ct_fee;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -244,7 +244,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                 int nHeightTx = 0;
                 if (IsPubcoinInBlockchain(hashPubcoin, nHeightTx, txid, chainActive.Tip())) {
                     setDuplicate.emplace(ptx->GetHash());
-                    LogPrintf("%s: removing duplicate pubcoin tx %s\n", __func__, ptx->GetHash().GetHex());
+                    LogPrintf("%s: removing already in chain pubcoin : tx %s\n", __func__, ptx->GetHash().GetHex());
                     fRemove = true;
                     break;
                 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -195,34 +195,50 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     //! find any coins that are sent to the network address, also make sure no conflicting zerocoin spends are included
     // todo reiterating over the spends here is not ideal, the new mining code is so complicated that this is the easiest solution at the moment
-    std::set<CBigNum> setSerials;
+    std::set<uint256> setSerials;
+    std::set<uint256> setPubcoins;
     std::set<uint256> setDuplicate;
     for (unsigned int i = 0; i < pblock->vtx.size(); i++) {
         if (pblock->vtx[i] == nullptr)
             continue;
 
-        const CTransaction &tx = *(pblock->vtx[i]);
+        //const CTransaction &tx = *(pblock->vtx[i]);
+        const CTransaction* ptx = pblock->vtx[i].get();
+        std::set<uint256> setTxSerialHashes;
+        std::set<uint256> setTxPubcoinHashes;
+        if (ptx->IsZerocoinSpend())
+            TxToSerialHashSet(ptx, setTxSerialHashes);
+        if (ptx->IsZerocoinMint())
+            TxToPubcoinHashSet(ptx, setTxPubcoinHashes);
 
         //double check all zerocoin spends for duplicates
         bool fRemove = false;
-        for (const auto& in : tx.vin) {
-            if (in.scriptSig.IsZerocoinSpend()) {
-                auto spend = TxInToZerocoinSpend(in);
-                if (!spend)
-                    continue;
-                if (setSerials.count(spend->getCoinSerialNumber())) {
-                    setDuplicate.emplace(tx.GetHash());
-                    fRemove = true;
-                    break;
-                }
-
-                setSerials.emplace(spend->getCoinSerialNumber());
+        for (const uint256& hashSerial : setTxSerialHashes) {
+            if (setSerials.count(hashSerial)) {
+                setDuplicate.emplace(ptx->GetHash());
+                LogPrintf("%s: removing duplicate serial tx %s\n", __func__, ptx->GetHash().GetHex());
+                fRemove = true;
+                break;
             }
+            setSerials.emplace(hashSerial);
         }
         if (fRemove)
             continue;
 
-        for (const auto& pout : tx.vpout) {
+        //Double check for mint duplicates
+        for (const uint256& hashPubcoin : setTxPubcoinHashes) {
+            if (setPubcoins.count(hashPubcoin)) {
+                setDuplicate.emplace(ptx->GetHash());
+                LogPrintf("%s: removing duplicate pubcoin tx %s\n", __func__, ptx->GetHash().GetHex());
+                fRemove = true;
+                break;
+            }
+            setPubcoins.emplace(hashPubcoin);
+        }
+        if (fRemove)
+            continue;
+
+        for (const auto& pout : ptx->vpout) {
             if (!pout->IsStandardOutput())
                 continue;
             if (*pout->GetPScriptPubKey() == rewardScript) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2409,9 +2409,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
 
         LOCK(cs_main);
-        if (IsInitialBlockDownload() && !pfrom->fWhitelisted) {
+        if (!HeadersAndBlocksSynced() && !pfrom->fWhitelisted) {
             LogPrint(BCLog::NET, "Ignoring getheaders from peer=%d because node is in initial block download\n", pfrom->GetId());
-            connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), uint256()));;
+            if (pindexBestHeader->GetBlockTime() < GetTime() - 180)
+                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), uint256()));;
             return true;
         }
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -135,10 +135,19 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
         return false;
     }
 
-    for (const CTxIn& txin : tx.vin)
+    bool fZerocoinSpend = false;
+    for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
-        if (txin.scriptSig.IsZerocoinSpend())
+        const CTxIn& txin = tx.vin[i];
+        if (txin.scriptSig.IsZerocoinSpend()) {
+            if (!fZerocoinSpend && i > 0) {
+                reason = "malformed-zerocoinspend";
+                return false;
+            }
+            fZerocoinSpend = true;
             continue;
+        }
+
 
         // Biggest 'standard' txin is a 15-of-15 P2SH multisig with compressed
         // keys (remember the 520 byte limit on redeemScript size). That works

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -101,7 +101,10 @@ public:
         ConvertCtToRingCT,
         ConvertCtToBasecoin,
         ConvertRingCtToCt,
-        ConvertRingCtToBasecoin
+        ConvertRingCtToBasecoin,
+        ConvertZerocoinToCt,
+        ZeroCoinMintFromCt,
+        ZeroCoinMintFromRingCt
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -366,9 +366,9 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::RingCTRecvWithAddress:
         return tr("Received with RingCT Address");
     case TransactionRecord::RingCTSendToAddress:
-        return tr("Sent RingCT to");
+        return tr("RingCT sent to");
     case TransactionRecord::RingCTSendToSelf:
-        return tr("RingCT Payment to yourself");
+        return tr("RingCT payment to yourself");
     case TransactionRecord::RingCTGenerated:
         return tr("Mined");
     case TransactionRecord::ConvertBasecoinToCT:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -383,8 +383,14 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Converted RingCT To Basecoin");
     case TransactionRecord::ConvertRingCtToCt:
         return tr("Converted RingCT To CT");
+    case TransactionRecord::ConvertZerocoinToCt:
+        return tr("Converted Zerocoin to CT");
     case TransactionRecord::ZeroCoinMint:
         return tr("Zerocoin Mint");
+    case TransactionRecord::ZeroCoinMintFromCt:
+        return tr("Zerocoin Mint from CT");
+    case TransactionRecord::ZeroCoinMintFromRingCt:
+        return tr("Zerocoin Mint from RingCT");
     case TransactionRecord::ZeroCoinSpend:
         return tr("Sent Zerocoin");
     case TransactionRecord::ZeroCoinSpendRemint:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -451,11 +451,14 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::RingCTRecvWithAddress:
     case TransactionRecord::RingCTSendToAddress:
     case TransactionRecord::RingCTGenerated:
+    case TransactionRecord::ZeroCoinSpend:
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::RingCTSendToSelf:
         return tr("(n/a) RingCTSendToSelf");
+    case TransactionRecord::ZeroCoinStake:
+        return tr("  ");
     case TransactionRecord::SendToSelf:
     default:
         return tr("(n/a)") + watchAddress;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -449,6 +449,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::RingCTSendToSelf:
+        return tr("(n/a) RingCTSendToSelf");
     case TransactionRecord::SendToSelf:
     default:
         return tr("(n/a)") + watchAddress;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -606,6 +606,28 @@ void CTxMemPool::removePubcoins(const std::set<uint256>& setPubcoinHashes)
     RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::BLOCK);
 }
 
+void CTxMemPool::removeSerials(const std::set<uint256>& setSerialHashes)
+{
+    AssertLockHeld(cs);
+    setEntries txToRemove;
+    for (auto it = mapTx.begin(); it != mapTx.end(); it++) {
+        if (!it->IsZerocoinSpend())
+            continue;
+        for (const uint256& hashSerial : setSerialHashes) {
+            if (it->HasSerial(hashSerial)) {
+                //Remove this transaction from mempool because it contains the pubcoin that has been spent
+                txToRemove.insert(it);
+                break;
+            }
+        }
+    }
+    setEntries setAllRemoves;
+    for (txiter it : txToRemove) {
+        CalculateDescendants(it, setAllRemoves);
+    }
+    RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::BLOCK);
+}
+
 void CTxMemPool::removeConflicts(const CTransaction &tx)
 {
     // Remove transactions which depend on inputs of tx, recursively
@@ -672,11 +694,19 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
             setEntries stage;
             stage.insert(it);
             RemoveStaged(stage, true, MemPoolRemovalReason::BLOCK);
-        } else if (tx->IsZerocoinMint()) {
-            // Remove any mempool mints with the same pubcoin
-            std::set<uint256> setPubcoinHashes;
-            TxToPubcoinHashSet(tx.get(), setPubcoinHashes);
-            removePubcoins(setPubcoinHashes);
+        } else {
+            if (tx->IsZerocoinMint()) {
+                // Remove any mempool mints with the same pubcoin
+                std::set<uint256> setPubcoinHashes;
+                TxToPubcoinHashSet(tx.get(), setPubcoinHashes);
+                removePubcoins(setPubcoinHashes);
+            }
+            if (tx->IsZerocoinSpend()) {
+                //Remove any mempool spends with the same serial
+                std::set<uint256> setSerialHashes;
+                TxToSerialHashSet(tx.get(), setSerialHashes);
+                removeSerials(setSerialHashes);
+            }
         }
 
         removeConflicts(*tx);
@@ -1002,6 +1032,16 @@ bool CTxMemPool::HasZerocoinSerial(const uint256& hashSerial) const
     LOCK(cs);
     for (auto mi = mapTx.begin(); mi != mapTx.end(); ++mi) {
         if (mi->HasSerial(hashSerial))
+            return true;
+    }
+    return false;
+}
+
+bool CTxMemPool::HasPublicCoin(const uint256& hashPubcoin) const
+{
+    LOCK(cs);
+    for (auto mi = mapTx.begin(); mi != mapTx.end(); ++mi) {
+        if (mi->HasPubcoin(hashPubcoin))
             return true;
     }
     return false;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -566,6 +566,7 @@ public:
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction &tx) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removePubcoins(const std::set<uint256>& setPubcoinHashes) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removeSerials(const std::set<uint256>& setSerialHashes) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
 
     void clear();
@@ -590,6 +591,7 @@ public:
 
     bool HaveKeyImage(const CCmpPubKey &ki, uint256 &hash) const;
     bool HasZerocoinSerial(const uint256& hashSerial) const;
+    bool HasPublicCoin(const uint256& hashPubcoin) const;
 
 public:
     /** Remove a set of transactions from the mempool.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -574,6 +574,7 @@ public:
     void queryHashes(std::vector<uint256>& vtxid);
     bool isSpent(const COutPoint& outpoint) const;
     void GetTransactions(std::set<uint256>& stTxids);
+    void GetSerials(std::map<uint256, uint256>& mapSerials) const; //serialhash => txid
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
     /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -738,8 +738,11 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                     return state.Invalid(false, REJECT_DUPLICATE, "zcspend-already-known");
                 if (setSerials.count(bnSerial))
                     return state.Invalid(false, REJECT_INVALID, "zcspend-tx-dupl-serials");
-                if (mempool.HasZerocoinSerial(GetSerialHash(bnSerial)))
+                uint256 hashSerial = GetSerialHash(bnSerial);
+                if (mempool.HasZerocoinSerial(hashSerial)) {
+                    LogPrint(BCLog::NET, "%s: serial:%s already in mempool tx:%s\n", __func__, hashSerial.GetHex(), hash.GetHex());
                     return state.Invalid(false, REJECT_DUPLICATE, "zcspend-already-in-mempool");
+                }
 
                 setSerials.emplace(bnSerial);
                 continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -769,6 +769,17 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             }
         }
 
+        for (auto pout : tx.vpout) {
+            if (pout->IsZerocoinMint()) {
+                CTxOut txout;
+                libzerocoin::PublicCoin coin(Params().Zerocoin_Params());
+                if (!OutputToPublicCoin(pout.get(), coin))
+                    return false;
+                if (pool.HasPublicCoin(GetPubCoinHash(coin.getValue())))
+                    return false;
+            }
+        }
+
         if (!AllAnonOutputsUnknown(tx, state)) // set state.fHasAnonOutput
             return error("%s: already spent anon outputs", __func__); // Already in the blockchain, containing block could have been received before loose tx
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1167,8 +1167,6 @@ bool IsBlockHashInChain(const uint256& hashBlock, int& nHeight, CBlockIndex* pin
     //It is possible that the block is part of chainactive, but we are trying to reorg. If pindex is included, and it is not part of
     //chain active, then see if the blockhash is part of the same chain as pindex
     if (pindex) {
-        if (pindex == pindexCheck)
-            return true;
         //The block we are checking from is a lower height or equal height, then this is not considered in the same chain from this reference point
         if (pindex->nHeight <= nHeight)
             return false;
@@ -1194,7 +1192,7 @@ bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef& 
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, const Consensus::Params& params, CBlockIndex* pindex)
 {
     CTransactionRef tx;
-    return IsTransactionInChain(txId, nHeightTx, tx, params);
+    return IsTransactionInChain(txId, nHeightTx, tx, params, pindex);
 }
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1167,6 +1167,8 @@ bool IsBlockHashInChain(const uint256& hashBlock, int& nHeight, CBlockIndex* pin
     //It is possible that the block is part of chainactive, but we are trying to reorg. If pindex is included, and it is not part of
     //chain active, then see if the blockhash is part of the same chain as pindex
     if (pindex) {
+        if (pindex == pindexCheck)
+            return true;
         //The block we are checking from is a lower height or equal height, then this is not considered in the same chain from this reference point
         if (pindex->nHeight <= nHeight)
             return false;
@@ -1904,8 +1906,11 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
 
                 if (in.scriptSig.IsZerocoinSpend()) {
                     auto spend = TxInToZerocoinSpend(in);
-                    if (spend)
-                        pzerocoinDB->EraseCoinSpend(spend->getCoinSerialNumber());
+                    if (!spend) {
+                        error("DisconnectBlock(): failed to undo zerocoinspend");
+                    }
+
+                    pzerocoinDB->EraseCoinSpend(spend->getCoinSerialNumber());
                     continue;
                 }
 

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -1142,52 +1142,24 @@ void AnonWallet::MarkInputsAsPendingSpend(CTransactionRecord &rtx)
 void AnonWallet::AddOutputRecordMetaData(CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend)
 {
     for (const auto &r : vecSend) {
-        if (r.nType == OUTPUT_STANDARD) {
-            COutputRecord rec;
+        COutputRecord rec;
 
-            rec.n = r.n;
-            if (r.fChange)
-                rec.nFlags |= ORF_CHANGE;
-            if (r.isMine)
-                rec.nFlags |= ORF_OWNED;
-            rec.nType = r.nType;
-            rec.SetValue(r.nAmount);
-            rec.sNarration = r.sNarration;
+        rec.n = r.n;
+        rec.nType = r.nType;
+        rec.SetValue(r.nAmount);
+        rec.sNarration = r.sNarration;
+        rec.scriptPubKey = r.scriptPubKey;
+
+        if (r.fChange)
+            rec.nFlags |= ORF_CHANGE;
+        if (r.isMine)
+            rec.nFlags |= ORF_OWNED;
+
+        if (!r.scriptPubKey.empty())
             rec.scriptPubKey = r.scriptPubKey;
-            rtx.InsertOutput(rec);
-        } else if (r.nType == OUTPUT_CT) {
-            COutputRecord rec;
 
-            rec.n = r.n;
-            rec.nType = r.nType;
-            rec.SetValue(r.nAmount);
-            if (r.fChange)
-                rec.nFlags |= ORF_CHANGE;
-            if (r.isMine)
-                rec.nFlags |= ORF_OWNED;
-
-            rec.scriptPubKey = r.scriptPubKey;
-            rec.sNarration = r.sNarration;
-
-            ParseAddressForMetaData(r.address, rec);
-
-            rtx.InsertOutput(rec);
-        } else if (r.nType == OUTPUT_RINGCT) {
-            COutputRecord rec;
-
-            rec.n = r.n;
-            rec.nType = r.nType;
-            rec.SetValue(r.nAmount);
-            if (r.fChange)
-                rec.nFlags |= ORF_CHANGE;
-            if (r.isMine)
-                rec.nFlags |= ORF_OWNED;
-            rec.sNarration = r.sNarration;
-
-            ParseAddressForMetaData(r.address, rec);
-
-            rtx.InsertOutput(rec);
-        }
+        ParseAddressForMetaData(r.address, rec);
+        rtx.InsertOutput(rec);
     }
 }
 
@@ -2246,7 +2218,7 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
     CAmount nFeeZerocoin = 0;
     bool fHasCTOut = false;
     for (auto& r : vecSend) {
-        if (r.nType == OUTPUT_RINGCT) {
+        if (r.nType == OUTPUT_CT) {
             fHasCTOut = true;
         }
         if (r.fZerocoinMint) {
@@ -4440,7 +4412,6 @@ bool AnonWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlo
         mapValue_t mapNarr;
         size_t nCT = 0, nRingCT = 0;
         bool fIsMine = ScanForOwnedOutputs(tx, nCT, nRingCT, mapNarr);
-        LogPrintf("%s: Found owned outputs anon =%d\n", __func__, fIsMine);
         bool fIsFromMe = false;
         MapRecords_t::const_iterator mir;
         for (const auto &txin : tx.vin) {

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -4458,7 +4458,7 @@ bool AnonWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlo
 
             //Double check for standard outputs from us
             if (!fIsFromMe && !txin.IsAnonInput()) {
-                if (pwalletParent->IsMine(txin))
+                if (pwalletParent->IsMine(txin, /*fCheckZerocoin*/true, /*fCheckAnon*/false))
                     fIsFromMe = true;
             }
         }

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -52,6 +52,7 @@ int CTransactionRecord::InsertOutput(COutputRecord &r)
 {
     for (size_t i = 0; i < vout.size(); ++i) {
         if (vout[i].n == r.n) {
+            vout[i] = r;
             return 0; // duplicate
         }
 
@@ -4434,8 +4435,10 @@ bool AnonWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlo
                     if (!wdb.ReadAnonKeyImage(ki, prevout))
                         continue;
 
+                    MarkOutputSpent(prevout, true);
+
                     fIsFromMe = true;
-                    break;
+                    continue;
                 }
 
                 if (fIsFromMe)
@@ -4902,8 +4905,12 @@ bool AnonWallet::AddToRecord(CTransactionRecord &rtxIn, const CTransaction &tx,
             fHave = true;
         } else {
             pout = &rout;
-            pout->nFlags |= ORF_LOCKED; // mark new output as locked
+            //pout->nFlags |= ORF_LOCKED; // mark new output as locked
         }
+
+        //If there were any spending flags, remove
+        pout->nFlags &= ~ORF_SPENT;
+        pout->nFlags &= ~ORF_PENDING_SPEND;
 
         pout->n = i;
         pout->nType = txout->nVersion;

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -269,7 +269,9 @@ public:
      */
     int LoadStealthAddresses();
     bool AddStealthDestination(const CKeyID& idStealthAddress, const CKeyID& idStealthDestination);
+    bool AddStealthDestinationMeta(const CKeyID& idStealth, const CKeyID& idStealthDestination, std::vector<uint8_t> &vchEphemPK);
     bool AddKeyToParent(const CKey& keySharedSecret);
+    bool CalculateStealthDestinationKey(const CKeyID& idStealthSpend, const CKeyID& idStealthDestination, const CKey& sShared, CKey& keyDestination) const;
     bool RecordOwnedStealthDestination(const CKey& sShared, const CKeyID& idStealth, const CKeyID& destStealth);
     bool GetStealthLinked(const CKeyID &stealthDest, CStealthAddress &sx) const;
     bool GetStealthAddress(const CKeyID& idStealth, CStealthAddress& stealthAddress);

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -275,6 +275,7 @@ public:
     bool RecordOwnedStealthDestination(const CKey& sShared, const CKeyID& idStealth, const CKeyID& destStealth);
     bool GetStealthLinked(const CKeyID &stealthDest, CStealthAddress &sx) const;
     bool GetStealthAddress(const CKeyID& idStealth, CStealthAddress& stealthAddress);
+    bool HaveStealthDestination(const CKeyID& destStealth) { return mapStealthDestinations.count(destStealth) > 0; }
     bool ProcessLockedStealthOutputs();
     bool ProcessLockedBlindedOutputs();
     bool ProcessStealthOutput(const CTxDestination &address,

--- a/src/veil/ringct/anonwalletdb.cpp
+++ b/src/veil/ringct/anonwalletdb.cpp
@@ -45,6 +45,16 @@ bool AnonWalletDB::WriteStealthAddress(const CStealthAddress &sxAddr)
     return WriteIC(std::make_pair(std::string("sxad"), sxAddr.scan_pubkey), sxAddr, true);
 }
 
+bool AnonWalletDB::WriteStealthDestinationMeta(const CKeyID& idStealthDestination, const std::vector<uint8_t>& vchEphemPK)
+{
+    return WriteIC(std::make_pair(std::string("sdmeta"), idStealthDestination), vchEphemPK);
+}
+
+bool AnonWalletDB::ReadStealthDestinationMeta(const CKeyID& idStealthDestination, std::vector<uint8_t>& vchEphemPK)
+{
+    return m_batch.Read(std::make_pair(std::string("sdmeta"), idStealthDestination), vchEphemPK);
+}
+
 bool AnonWalletDB::ReadStealthAddress(CStealthAddress& sxAddr)
 {
     // Set scan_pubkey before reading

--- a/src/veil/ringct/anonwalletdb.cpp
+++ b/src/veil/ringct/anonwalletdb.cpp
@@ -47,7 +47,7 @@ bool AnonWalletDB::WriteStealthAddress(const CStealthAddress &sxAddr)
 
 bool AnonWalletDB::WriteStealthDestinationMeta(const CKeyID& idStealthDestination, const std::vector<uint8_t>& vchEphemPK)
 {
-    return WriteIC(std::make_pair(std::string("sdmeta"), idStealthDestination), vchEphemPK);
+    return WriteIC(std::make_pair(std::string("sdmeta"), idStealthDestination), vchEphemPK, true);
 }
 
 bool AnonWalletDB::ReadStealthDestinationMeta(const CKeyID& idStealthDestination, std::vector<uint8_t>& vchEphemPK)

--- a/src/veil/ringct/anonwalletdb.h
+++ b/src/veil/ringct/anonwalletdb.h
@@ -350,6 +350,9 @@ public:
     bool ReadStealthAddress(CStealthAddress &sxAddr);
     bool EraseStealthAddress(const CStealthAddress &sxAddr);
 
+    bool WriteStealthDestinationMeta(const CKeyID& idStealthDestination, const std::vector<uint8_t>& vchEphemPK);
+    bool ReadStealthDestinationMeta(const CKeyID& idStealthDestination, std::vector<uint8_t>& vchEphemPK);
+
     bool ReadNamedExtKeyId(const std::string &name, CKeyID &identifier, uint32_t nFlags=DB_READ_UNCOMMITTED);
     bool WriteNamedExtKeyId(const std::string &name, const CKeyID &identifier);
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -1837,6 +1837,7 @@ static const CRPCCommand commands[] =
 
                 { "wallet",             "sendstealthtobasecoin", &sendstealthtobasecoin,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },
                 { "wallet",             "sendstealthtostealth", &sendstealthtostealth,              {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },
+                { "wallet",             "sendstealthtoringct", &sendstealthtoringct,              {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },
 
                 { "wallet",             "sendringcttobasecoin", &sendringcttobasecoin,                {"address","amount","comment","comment_to","subtractfeefromamount","narration","ringsize","inputs_per_sig"} },
                 { "wallet",             "sendringcttostealth", &sendringcttostealth,               {"address","amount","comment","comment_to","subtractfeefromamount","narration","ringsize","inputs_per_sig"} },

--- a/src/veil/zerocoin/mintmeta.h
+++ b/src/veil/zerocoin/mintmeta.h
@@ -12,7 +12,8 @@
 enum MintMemoryFlags
 {
     MINT_MATURE = (1 << 0),
-    MINT_CONFIRMED = (1 << 1)
+    MINT_CONFIRMED = (1 << 1),
+    MINT_PENDINGSPEND = (1 << 2)
 };
 
 //struct that is safe to store essential mint data, without holding any information that allows for actual spending (serial, randomness, private key)

--- a/src/veil/zerocoin/zchain.cpp
+++ b/src/veil/zerocoin/zchain.cpp
@@ -153,13 +153,11 @@ void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMin
         CTransactionRef tx;
         uint256 hashBlock;
         if (!GetTransaction(txHash, tx, Params().GetConsensus(), hashBlock, true)) {
-            LogPrintf("%s : cannot find tx %s\n", __func__, txHash.GetHex());
             vMissingMints.push_back(meta);
             continue;
         }
 
         if (!mapBlockIndex.count(hashBlock)) {
-            LogPrintf("%s : cannot find block %s\n", __func__, hashBlock.GetHex());
             vMissingMints.push_back(meta);
             continue;
         }
@@ -167,13 +165,11 @@ void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMin
         //see if this mint is spent
         uint256 hashTxSpend;
         bool fSpent = pzerocoinDB->ReadCoinSpend(meta.hashSerial, hashTxSpend);
-        LogPrintf("%s:%s serial %s spent = %d\n", __func__, __LINE__, meta.hashSerial.GetHex(), fSpent);
 
         //if marked as spent, check that it actually made it into the chain
         CTransactionRef txSpend;
         uint256 hashBlockSpend;
         if (fSpent && !GetTransaction(hashTxSpend, txSpend, Params().GetConsensus(), hashBlockSpend, true)) {
-            LogPrintf("%s : cannot find spend tx %s\n", __func__, hashTxSpend.GetHex());
             meta.isUsed = false;
             vMintsToUpdate.push_back(meta);
             continue;
@@ -184,7 +180,6 @@ void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMin
         uint256 hashSerial = meta.hashSerial;
         uint256 txidSpend;
         if (fSpent && !IsSerialInBlockchain(hashSerial, nHeightTx, txidSpend)) {
-            LogPrintf("%s : cannot find block %s. Erasing coinspend from zerocoinDB.\n", __func__, hashBlockSpend.GetHex());
             meta.isUsed = false;
             vMintsToUpdate.push_back(meta);
             continue;
@@ -198,7 +193,6 @@ void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMin
             CValidationState state;
             OutputToPublicCoin(out.get(), pubcoin);
             if (GetPubCoinHash(pubcoin.getValue()) == meta.hashPubcoin && pubcoin.getDenomination() != meta.denom) {
-                LogPrintf("%s: found mismatched denom pubcoinhash = %s\n", __func__, meta.hashPubcoin.GetHex());
                 meta.denom = pubcoin.getDenomination();
                 vMintsToUpdate.emplace_back(meta);
             }

--- a/src/veil/zerocoin/zchain.cpp
+++ b/src/veil/zerocoin/zchain.cpp
@@ -74,7 +74,7 @@ bool BlockToPubcoinList(const CBlock& block, std::list<libzerocoin::PublicCoin>&
     return true;
 }
 
-bool TxToPubcoinHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes)
+bool TxToPubcoinHashSet(const CTransaction* tx, std::set<uint256>& setHashes)
 {
     for (unsigned int i = 0; i < tx->vpout.size(); i++) {
         const auto pout = tx->vpout[i];
@@ -92,9 +92,9 @@ bool TxToPubcoinHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes)
     return true;
 }
 
-bool TxToSerialHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes)
+bool TxToSerialHashSet(const CTransaction* tx, std::set<uint256>& setHashes)
 {
-    for (const auto& in :tx->vin) {
+    for (const CTxIn& in :tx->vin) {
         auto spend = TxInToZerocoinSpend(in);
         if (spend)
             setHashes.emplace(GetSerialHash(spend->getCoinSerialNumber()));

--- a/src/veil/zerocoin/zchain.cpp
+++ b/src/veil/zerocoin/zchain.cpp
@@ -229,10 +229,13 @@ bool GetZerocoinMint(const CBigNum& bnPubcoin, uint256& txHash)
     return pzerocoinDB->ReadCoinMint(bnPubcoin, txHash);
 }
 
-bool IsPubcoinInBlockchain(const uint256& hashPubcoin, uint256& txid)
+bool IsPubcoinInBlockchain(const uint256& hashPubcoin, int& nHeightTx, uint256& txid, CBlockIndex* pindexChain)
 {
     txid = uint256();
-    return pzerocoinDB->ReadCoinMint(hashPubcoin, txid);
+    if (!pzerocoinDB->ReadCoinMint(hashPubcoin, txid))
+        return false;
+    CTransactionRef txRef;
+    return IsTransactionInChain(txid, nHeightTx, txRef, Params().GetConsensus(), pindexChain);
 }
 
 bool IsSerialKnown(const CBigNum& bnSerial)

--- a/src/veil/zerocoin/zchain.h
+++ b/src/veil/zerocoin/zchain.h
@@ -26,8 +26,8 @@ class uint256;
 
 bool BlockToMintValueVector(const CBlock& block, const libzerocoin::CoinDenomination denom, std::vector<CBigNum>& vValues);
 bool BlockToPubcoinList(const CBlock& block, std::list<libzerocoin::PublicCoin>& listPubcoins);
-bool TxToPubcoinHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes);
-bool TxToSerialHashSet(const CTransactionRef& tx, std::set<uint256>& setHashes);
+bool TxToPubcoinHashSet(const CTransaction* tx, std::set<uint256>& setHashes);
+bool TxToSerialHashSet(const CTransaction* tx, std::set<uint256>& setHashes);
 bool BlockToZerocoinMintList(const CBlock& block, std::list<CZerocoinMint>& vMints);
 void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMintsToUpdate, std::vector<CMintMeta>& vMissingMints);
 int GetZerocoinStartHeight();

--- a/src/veil/zerocoin/zchain.h
+++ b/src/veil/zerocoin/zchain.h
@@ -32,7 +32,7 @@ bool BlockToZerocoinMintList(const CBlock& block, std::list<CZerocoinMint>& vMin
 void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMintsToUpdate, std::vector<CMintMeta>& vMissingMints);
 int GetZerocoinStartHeight();
 bool GetZerocoinMint(const CBigNum& bnPubcoin, uint256& txHash);
-bool IsPubcoinInBlockchain(const uint256& hashPubcoin, uint256& txid);
+bool IsPubcoinInBlockchain(const uint256& hashPubcoin, int& nHeightTx, uint256& txid, CBlockIndex* pindexChain);
 bool IsSerialKnown(const CBigNum& bnSerial);
 bool IsSerialInBlockchain(const CBigNum& bnSerial, int& nHeightTx, CBlockIndex* pindex = nullptr);
 bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend);

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -24,7 +24,7 @@ private:
     std::map<SerialHash, CMintMeta> mapSerialHashes;
     std::map<SerialHash, uint256> mapPendingSpends; //serialhash, txid of spend
     std::map<PubCoinHash, SerialHash> mapHashPubCoin;
-    bool UpdateStatusInternal(const std::set<uint256>& setMempool, CMintMeta& mint);
+    bool UpdateStatusInternal(const std::set<uint256>& setMempoolTx, const std::map<uint256, uint256>& mapMempoolSerials, CMintMeta& mint);
 public:
     CzTracker(CWallet* wallet);
     ~CzTracker();

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -191,13 +191,17 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         {
             const CPubKey &vchPubKey = (*mi).second.first;
             const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
-            CKey key;
-            if (!DecryptKey(vMasterKeyIn, vchCryptedSecret, vchPubKey, key))
-            {
-                keyFail = true;
-                break;
+            if (vchCryptedSecret.empty()) {
+                keyFail = false;
+                keyPass = true;
+            } else {
+                CKey key;
+                if (!DecryptKey(vMasterKeyIn, vchCryptedSecret, vchPubKey, key)) {
+                    keyFail = true;
+                    break;
+                }
+                keyPass = true;
             }
-            keyPass = true;
             if (fDecryptionThoroughlyChecked)
                 break;
         }

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -714,7 +714,7 @@ UniValue ResetSpends(CWallet* pwallet)
             if (meta.hashSerial == GetSerialHash(spend.GetSerial())) {
                 zTracker->SetPubcoinNotUsed(meta.hashPubcoin);
                 walletdb.EraseZerocoinSpendSerialEntry(spend.GetSerial());
-                RemoveSerialFromDB(spend.GetSerial());
+                //RemoveSerialFromDB(spend.GetSerial());
                 UniValue obj(UniValue::VOBJ);
                 obj.push_back(Pair("serial", spend.GetSerial().GetHex()));
                 arrRestored.push_back(obj);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2064,7 +2064,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
                             if (spend)
                                 spendInfo.emplace(*spend, txid);
                             else
-                                error("Faield to getspend *********************************\n");
+                                error("%s: Failed to getspend *********************************\n");
                         }
                         pzerocoinDB->WriteCoinSpendBatch(spendInfo);
                     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3661,7 +3661,7 @@ bool CWallet::CreateCoinStake(unsigned int nBits, CMutableTransaction& txNew, un
             {
                 LOCK(cs_main);
                 //Double check that this will pass time requirements
-                if (nTxNewTime <= chainActive.Tip()->GetMedianTimePast()) {
+                if (nTxNewTime <= chainActive.Tip()->GetMedianTimePast() || nTxNewTime < chainActive.Tip()->GetBlockTime() - MAX_PAST_BLOCK_TIME) {
                     LogPrintf("CreateCoinStake() : kernel found, but it is too far in the past \n");
                     continue;
                 }
@@ -5726,19 +5726,7 @@ bool CWallet::SpendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendRe
 
 bool IsMintInChain(const uint256& hashPubcoin, uint256& txid, int& nHeight)
 {
-    if (!IsPubcoinInBlockchain(hashPubcoin, txid))
-        return false;
-
-    uint256 hashBlock;
-    CTransactionRef tx;
-    if (!GetTransaction(txid, tx, Params().GetConsensus(), hashBlock))
-        return false;
-
-    if (!mapBlockIndex.count(hashBlock) || !chainActive.Contains(mapBlockIndex.at(hashBlock)))
-        return false;
-
-    nHeight = mapBlockIndex.at(hashBlock)->nHeight;
-    return true;
+    return IsPubcoinInBlockchain(hashPubcoin, nHeight, txid, chainActive.Tip());
 }
 
 void CWallet::ReconsiderZerocoins(std::list<CZerocoinMint>& listMintsRestored, std::list<CDeterministicMint>& listDMintsRestored)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -821,6 +821,7 @@ public:
             const CCoinControl* coinControl = NULL);
     bool SpendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendReceipt& receipt,
             std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CTxDestination* addressTo = NULL);
+    bool AvailableZerocoins(std::set<CMintMeta>& setMints);
 //    std::string ResetMintZerocoin();
 //    std::string ResetSpentZerocoin();
     void ReconsiderZerocoins(std::list<CZerocoinMint>& listMintsRestored, std::list<CDeterministicMint>& listDMintsRestored);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1167,6 +1167,7 @@ public:
     void ChainStateFlushed(const CBlockLocator& loc) override;
 
     bool IsMyZerocoinSpend(const CBigNum& bnSerial) const;
+    bool IsMyZerocoinSpend(const uint256& hashSerial) const;
     bool IsMyMint(const CBigNum& bnValue) const;
 
     DBErrors LoadWallet(bool& fFirstRunRet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1137,7 +1137,7 @@ public:
 
     std::set<CTxDestination> GetLabelAddresses(const std::string& label) const;
 
-    isminetype IsMine(const CTxIn& txin) const;
+    isminetype IsMine(const CTxIn& txin, bool fCheckZerocoin = false, bool fCheckAnon = false) const;
     isminetype IsMine(const CTxDestination& dest) const;
 
     /**


### PR DESCRIPTION
- Additional filtering of transactions in mempool
   - Check if there are conflicts with any transactions in the mempool that contain zerocoinspend serials or zerocoinmint pubcoins
   - Check pubcoins and serials to see if they have already been used on the blockchain (fixes #232)
- Additional checks performed in block creation (same checks as were added to mempool)
   - Ensure block time is not out of bounds (fixes #231)
- Remove any conflicting zerocoin spends/mint from mempool when a new block is added.
- Replace certain areas using `IsInitialBlockDownload()` with `HeadersAndBlocksSynced()`.
- Consider certain zerocoinspend as not standard
- Add addresses to transaction records for stealth addresses.
- Better recognition of transaction types for GUI tx records.
- Fix errors that were deleting blockchain zerocoin records when `reconsiderzerocoins` is used.
- Database information about stealth destinations and fix decryption error caused by previous code (fixes #208)
- Fix wallet flags marking outputs as the wrong type.
- Mark RingCT outputs used when rescanning.