### PR TITLE
Prevent headers and blocks spamming. Add VIP-1 soft fork.

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -115,6 +115,24 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
     return const_cast<CBlockIndex*>(static_cast<const CBlockIndex*>(this)->GetAncestor(height));
 }
 
+const CBlockIndex* CBlockIndex::GetBestPoWAncestor() const
+{
+    const CBlockIndex* pindexBestPoW = nullptr;
+    if (this->IsProofOfWork()) {
+        pindexBestPoW = this;
+    } else {
+        const CBlockIndex* pprev = this;
+        while (pprev->pprev) {
+            pprev = pprev->pprev;
+            if (pprev->IsProofOfWork()) {
+                pindexBestPoW = pprev;
+                break;
+            }
+        }
+    }
+    return pindexBestPoW;
+}
+
 void CBlockIndex::BuildSkip()
 {
     if (pprev)
@@ -135,6 +153,14 @@ int64_t CBlockIndex::GetBlockWork() const
         nBlockWork += 1001;
 
     return nBlockWork;
+}
+
+arith_uint256 CBlockIndex::GetChainPoW() const
+{
+    const CBlockIndex* pindexLastPoW = GetBestPoWAncestor();
+    if (!pindexLastPoW)
+        return 0;
+    return pindexLastPoW->nChainPoW + (IsProofOfWork() ? GetBlockProof(*this) : 0);
 }
 
 arith_uint256 GetBlockProof(const CBlockIndex& block)

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -141,6 +141,9 @@ void CBlockIndex::BuildSkip()
 
 int64_t CBlockIndex::GetBlockWork() const
 {
+    if (nMemFlags & POS_BADWEIGHT)
+        return -100; //prefer a chain without this
+
     int64_t nTimeSpan = 0;
     if (pprev && pprev->pprev)
         nTimeSpan = pprev->GetBlockTime() - pprev->pprev->GetBlockTime();

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -141,9 +141,6 @@ void CBlockIndex::BuildSkip()
 
 int64_t CBlockIndex::GetBlockWork() const
 {
-    if (nMemFlags & POS_BADWEIGHT)
-        return -100; //prefer a chain without this
-
     int64_t nTimeSpan = 0;
     if (pprev && pprev->pprev)
         nTimeSpan = pprev->GetBlockTime() - pprev->pprev->GetBlockTime();

--- a/src/chain.h
+++ b/src/chain.h
@@ -166,6 +166,10 @@ enum BlockStatus: uint32_t {
     BLOCK_OPT_WITNESS       =   128, //!< block data in blk*.data was received with a witness-enforcing client
 };
 
+enum BlockMemFlags: uint32_t {
+    POS_BADWEIGHT = (1 << 0),
+};
+
 /** The block chain is a tree shaped structure starting with the
  * genesis block at the root, with each block potentially having multiple
  * candidates to be the next block. A blockindex may have multiple pprev pointing
@@ -244,6 +248,9 @@ public:
     //! (memory only) Maximum nTime in the chain up to and including this block.
     unsigned int nTimeMax;
 
+    //! (memory only) Maximum nTime in the chain up to and including this block.
+    uint32_t nMemFlags;
+
     //! Hash value for the accumulator. Can be used to access the zerocoindb for the accumulator value
     std::map<libzerocoin::CoinDenomination ,uint256> mapAccumulatorHashes;
 
@@ -269,6 +276,7 @@ public:
         nStatus = 0;
         nSequenceId = 0;
         nTimeMax = 0;
+        nMemFlags = 0;
         nNetworkRewardReserve = 0;
 
         //Proof of stake

--- a/src/chain.h
+++ b/src/chain.h
@@ -204,6 +204,9 @@ public:
     //! (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
     arith_uint256 nChainWork;
 
+    //! (memory only) Total amount of work (only looking at PoW) in the chain up to and including this block
+    arith_uint256 nChainPoW;
+
     //! Number of transactions in this block.
     //! Note: in a potential headers-first mode, this number cannot be relied upon
     unsigned int nTx;
@@ -260,6 +263,7 @@ public:
         nDataPos = 0;
         nUndoPos = 0;
         nChainWork = arith_uint256();
+        nChainPoW = arith_uint256();
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
@@ -371,6 +375,7 @@ public:
     }
 
     int64_t GetBlockWork() const;
+    arith_uint256 GetChainPoW() const;
 
     /** Returns the hash of the accumulator for the specified denomination. If it doesn't exist then a new uint256 is returned*/
     uint256 GetAccumulatorHash(libzerocoin::CoinDenomination denom) const
@@ -467,6 +472,7 @@ public:
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);
     const CBlockIndex* GetAncestor(int height) const;
+    const CBlockIndex* GetBestPoWAncestor() const;
 
     //!Add an accumulator to the CBlockIndex
     void AddAccumulator(libzerocoin::CoinDenomination denom,CBigNum bnAccumulator);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -299,6 +299,8 @@ public:
 
         /** RingCT/Stealth **/
         nDefaultRingSize = 11;
+
+        nMaxHeaderRequestWithoutPoW = 50;
     }
 };
 
@@ -443,6 +445,8 @@ public:
 
         /** RingCT/Stealth **/
         nDefaultRingSize = 11;
+
+        nMaxHeaderRequestWithoutPoW = 50;
     }
 };
 
@@ -540,6 +544,8 @@ public:
         nDefaultSecurityLevel = 100; //full security level for accumulators
         nZerocoinRequiredStakeDepth = 400; //The required confirmations for a zerocoin to be stakable
         nTimeEnforceWeightReduction = 1548849600; //Stake weight must be reduced for higher denominations (GMT): Wednesday, January 30, 2019 12:00:00 PM
+
+        nMaxHeaderRequestWithoutPoW = 50;
     }
 };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -262,14 +262,15 @@ public:
                 { 1600, uint256S("0xb9f631a0b74b062baa8a01958b66058e8437ed751900ed84165543ec0ed312b5")},
                 { 1880, uint256S("0x862c43c183583b364d8d2a35f9d1ca9198d844c1b972aab06c30520b59f6e4f6")},
                 { 12500, uint256S("0xa36df367e933c731c59caf5b99a7b0a0d893858fead77e6248e01f44f3c621d7")},
+                { 29000, uint256S("0xb1f7b8cc4669ba57c341c3dd49da16d174f9c2a0673c5f3556225b9f8bb4454e")},
             }
         };
 
         chainTxData = ChainTxData{
             // Data from rpc: getchaintxstats 4096 0000000000000000002e63058c023a9a1de233554f28c7b21380b6c9003f36a8
-            /* nTime    */ 1547231092,
-            /* nTxCount */ 36059,
-            /* dTxRate  */ 0.04673
+            /* nTime    */ 1548275821,
+            /* nTxCount */ 88658,
+            /* dTxRate  */ 0.0539
         };
 
         /* disable fallback fee on mainnet */

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -295,6 +295,7 @@ public:
         nProofOfFullNodeRounds = 4;
         nLastPOWBlock = 2000000;
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
+        nTimeEnforceWeightReduction = 1548849600; //Stake weight must be reduced for higher denominations (GMT): Wednesday, January 30, 2019 12:00:00 PM
 
         /** RingCT/Stealth **/
         nDefaultRingSize = 11;
@@ -438,6 +439,7 @@ public:
         nProofOfFullNodeRounds = 4;
         nLastPOWBlock = 2000000;
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
+        nTimeEnforceWeightReduction = 1548849600; //Stake weight must be reduced for higher denominations (GMT): Wednesday, January 30, 2019 12:00:00 PM
 
         /** RingCT/Stealth **/
         nDefaultRingSize = 11;
@@ -537,6 +539,7 @@ public:
         nRequiredAccumulation = 1;
         nDefaultSecurityLevel = 100; //full security level for accumulators
         nZerocoinRequiredStakeDepth = 400; //The required confirmations for a zerocoin to be stakable
+        nTimeEnforceWeightReduction = 1548849600; //Stake weight must be reduced for higher denominations (GMT): Wednesday, January 30, 2019 12:00:00 PM
     }
 };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -197,7 +197,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
 
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548269817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548161817;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -180,8 +180,8 @@ public:
         consensus.nDgwPastBlocks = 30; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.nRuleChangeActivationThreshold = 1080; // 75% of confirmation window
+        consensus.nMinerConfirmationWindow = 1440; // 1 day at 1 block per minute
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -195,6 +195,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1479168000; // November 15th, 2016.
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548269817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -322,8 +326,8 @@ public:
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.nRuleChangeActivationThreshold = 84; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 120; // 2 hours
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -337,6 +341,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548269817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -132,6 +132,7 @@ public:
     int CoinbaseMaturity() const { return nCoinbaseMaturity; }
     int HeightSupplyCreationStop() const { return nHeightSupplyCreationStop; }
     int ProofOfFullNodeRounds() const {return nProofOfFullNodeRounds; }
+    int EnforceWeightReductionTime() const { return nTimeEnforceWeightReduction; }
 
 protected:
     CChainParams() {}
@@ -182,6 +183,9 @@ protected:
     int nCoinbaseMaturity;
     int nProofOfFullNodeRounds;
     int nHeightSupplyCreationStop;
+
+    //Time and height enforcements
+    int nTimeEnforceWeightReduction;
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -133,6 +133,7 @@ public:
     int HeightSupplyCreationStop() const { return nHeightSupplyCreationStop; }
     int ProofOfFullNodeRounds() const {return nProofOfFullNodeRounds; }
     int EnforceWeightReductionTime() const { return nTimeEnforceWeightReduction; }
+    int MaxHeaderRequestWithoutPoW() const { return nMaxHeaderRequestWithoutPoW; }
 
 protected:
     CChainParams() {}
@@ -186,6 +187,9 @@ protected:
 
     //Time and height enforcements
     int nTimeEnforceWeightReduction;
+
+    //Settings that are not chain critical, but should not be edited unless the person changing understands the consequence
+    int nMaxHeaderRequestWithoutPoW;
 };
 
 /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -18,6 +18,7 @@ enum DeploymentPos
     DEPLOYMENT_TESTDUMMY,
     DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
     DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
+    DEPLOYMENT_POS_WEIGHT,
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -31,6 +31,7 @@ private:
         MODE_VALID,   //!< everything ok
         MODE_INVALID, //!< network rule violation (DoS value may be set)
         MODE_ERROR,   //!< run-time error
+        MODE_STAGING, //!< potentially valid, but not processing yet.
     } mode;
     int nDoS;
     std::string strRejectReason;
@@ -67,6 +68,15 @@ public:
         mode = MODE_ERROR;
         return false;
     }
+    bool Stage(const std::string &_strDebugMessage="") {
+        mode = MODE_STAGING;
+        strDebugMessage = _strDebugMessage;
+        return false;
+    }
+    bool IsStaged() {
+        return mode == MODE_STAGING;
+    }
+
     bool IsValid() const {
         return mode == MODE_VALID;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -443,9 +443,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     CValidationState state;
     if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false)) {
         error("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state));
-        error("%s: Clearing mempool because of error", __func__);
-        //todo: instead of clearing mempool, only clear any transactions (if any) that caused the issue
-        // mempool.clear();
         return nullptr;
     }
 
@@ -849,8 +846,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
 
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr)) {
-            LogPrint(BCLog::BLOCKCREATION, "%s : Failed to process new block, clearing mempool txs\n", __func__);
-            //mempool.clear();
+            LogPrint(BCLog::BLOCKCREATION, "%s : Failed to process new block\n", __func__);
             continue;
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2507,6 +2507,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             return true;
         }
 
+        if (!HeadersAndBlocksSynced())
+            return true;
+
         std::deque<COutPoint> vWorkQueue;
         std::vector<uint256> vEraseQueue;
         CTransactionRef ptx;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1669,7 +1669,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         uint256 hashLastBlock;
         for (const CBlockHeader& header : headers) {
             if (!hashLastBlock.IsNull() && header.hashPrevBlock != hashLastBlock) {
-                Misbehaving(pfrom->GetId(), 20, "non-continuous headers sequence");
+                Misbehaving(pfrom->GetId(), 0, "non-continuous headers sequence");
                 return false;
             }
             hashLastBlock = header.GetHash();
@@ -3050,12 +3050,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // mapBlockSource is only used for sending reject messages and DoS scores,
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
-//            if (!mapBlockIndex.count(pblock->hashPrevBlock)) {
-//                //Don't have previous block, instead of processing this one, try to work backwards to common fork
-//                LogPrint(BCLog::NET, "sending getblocks to outbound peer=%d to because sent a block that we do not have prevblock\n", pfrom->GetId());
-//                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETBLOCKS, chainActive.GetLocator(), uint256()));
-//                return true;
-//            }
         }
 
         bool fProcessBlock = false;
@@ -3070,7 +3064,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 //We need the full block data to process it
                 if (pblock->hashPrevBlock == Params().GenesisBlock().GetHash() || pindexPrev->nChainTx > 0) {
                     fProcessBlock = true;
-
                 } else if (forceProcessing && nHeightBlock - nHeightNext < ASK_FOR_BLOCKS + 10 && nHeightNext <= nHeightBlock) {
                     //Keep a few blocks cached so we don't fetch them over and over
                     CDataStream ss(SER_DISK, PROTOCOL_VERSION);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1167,6 +1167,7 @@ static UniValue BIP9SoftForkDesc(const Consensus::Params& consensusParams, Conse
         statsUV.pushKV("threshold", statsStruct.threshold);
         statsUV.pushKV("elapsed", statsStruct.elapsed);
         statsUV.pushKV("count", statsStruct.count);
+        statsUV.pushKV("support", (double)statsStruct.count / (double)statsStruct.elapsed);
         statsUV.pushKV("possible", statsStruct.possible);
         rv.pushKV("statistics", statsUV);
     }
@@ -1198,7 +1199,8 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "  \"mediantime\": xxxxxx,         (numeric) median time for the current best block\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"initialblockdownload\": xxxx, (bool) (debug information) estimate of whether this node is in Initial Block Download mode.\n"
-            "  \"chainwork\": \"xxxx\"           (string) total amount of work in active chain, in hexadecimal\n"
+            "  \"chainwork\": \"xxxx\"         (string) total amount of work in active chain, in hexadecimal\n"
+            "  \"chainpow\": \"xxxx\"          (string) total amount of PoW work in active chain, in hexadecimal\n"
             "  \"size_on_disk\": xxxxxx,       (numeric) the estimated size of the block and undo files on disk\n"
             "  \"pruned\": xx,                 (boolean) if the blocks are subject to pruning\n"
             "  \"pruneheight\": xxxxxx,        (numeric) lowest-height complete block stored (only present if pruning is enabled)\n"
@@ -1248,6 +1250,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.pushKV("verificationprogress",  GuessVerificationProgress(Params().TxData(), chainActive.Tip()));
     obj.pushKV("initialblockdownload",  IsInitialBlockDownload());
     obj.pushKV("chainwork",             chainActive.Tip()->nChainWork.GetHex());
+    obj.pushKV("chainpow",             chainActive.Tip()->nChainPoW.GetHex());
     obj.pushKV("size_on_disk",          CalculateCurrentUsage());
     obj.pushKV("pruned",                fPruneMode);
     if (fPruneMode) {
@@ -1267,18 +1270,18 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
         }
     }
 
-//    const Consensus::Params& consensusParams = Params().GetConsensus();
-//    CBlockIndex* tip = chainActive.Tip();
-//    UniValue softforks(UniValue::VARR);
-//    UniValue bip9_softforks(UniValue::VOBJ);
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+    CBlockIndex* tip = chainActive.Tip();
+    UniValue softforks(UniValue::VARR);
+    UniValue bip9_softforks(UniValue::VOBJ);
 //    softforks.push_back(SoftForkDesc("bip34", 2, tip, consensusParams));
 //    softforks.push_back(SoftForkDesc("bip66", 3, tip, consensusParams));
 //    softforks.push_back(SoftForkDesc("bip65", 4, tip, consensusParams));
-//    for (int pos = Consensus::DEPLOYMENT_CSV; pos != Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++pos) {
-//        BIP9SoftForkDescPushBack(bip9_softforks, consensusParams, static_cast<Consensus::DeploymentPos>(pos));
-//    }
-//    obj.pushKV("softforks",             softforks);
-//    obj.pushKV("bip9_softforks", bip9_softforks);
+    for (int pos = Consensus::DEPLOYMENT_POS_WEIGHT; pos != Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++pos) {
+        BIP9SoftForkDescPushBack(bip9_softforks, consensusParams, static_cast<Consensus::DeploymentPos>(pos));
+    }
+    //obj.pushKV("softforks",             softforks);
+    obj.pushKV("bip9_softforks", bip9_softforks);
 
     obj.pushKV("warnings", GetWarnings("statusbar"));
     return obj;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4825,6 +4825,7 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
         int64_t nTimeSpan = 0;
 
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + pindex->GetBlockWork();
+        pindex->nChainPoW = pindex->GetChainPoW();
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);
         // We can link the chain of blocks for which we've received transactions at some point.
         // Pruned nodes may have deleted the block.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4494,6 +4494,10 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
         return AbortNode(state, std::string("System error: ") + e.what());
     }
 
+    //Possible that block index had more or less trust added after full knowledge of the block. Flush in case changed.
+    pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + pindex->GetBlockWork();
+    setDirtyBlockIndex.emplace(pindex);
+
     FlushStateToDisk(chainparams, state, FlushStateMode::NONE);
 
     CheckBlockIndex(chainparams.GetConsensus());

--- a/src/validation.h
+++ b/src/validation.h
@@ -169,6 +169,7 @@ extern unsigned int nStakeMinAge;
 extern size_t nCoinCacheUsage;
 extern std::map<uint256, unsigned int> mapHashedBlocks; //blockhash, last timestamp hashed
 extern std::map<unsigned int, unsigned int> mapStakeHashCounter;
+extern std::map<uint256, uint256> mapStakeSeen;
 extern std::set<uint256> setBatchVerified;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;

--- a/src/validation.h
+++ b/src/validation.h
@@ -169,6 +169,7 @@ extern unsigned int nStakeMinAge;
 extern size_t nCoinCacheUsage;
 extern std::map<uint256, unsigned int> mapHashedBlocks; //blockhash, last timestamp hashed
 extern std::map<unsigned int, unsigned int> mapStakeHashCounter;
+extern std::set<uint256> setBatchVerified;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction) */

--- a/src/veil/proofofstake/kernel.cpp
+++ b/src/veil/proofofstake/kernel.cpp
@@ -158,7 +158,10 @@ bool CheckProofOfStake(const CTransactionRef txRef, const uint32_t& nBits, const
 
     unsigned int nBlockFromTime = blockprev.nTime;
     unsigned int nTxTime = nTimeBlock;
-    if (!CheckStake(stake->GetUniqueness(), stake->GetValue(), nStakeModifier, ArithToUint256(bnTargetPerCoinDay), nBlockFromTime,
+    CAmount nValue = stake->GetValue();
+    if (nTimeBlock > Params().EnforceWeightReductionTime())
+        WeightStake(nValue, stake->GetDenomination());
+    if (!CheckStake(stake->GetUniqueness(), nValue, nStakeModifier, ArithToUint256(bnTargetPerCoinDay), nBlockFromTime,
                     nTxTime, hashProofOfStake)) {
         return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n",
                      txRef->GetHash().GetHex(), hashProofOfStake.GetHex());

--- a/src/veil/proofofstake/kernel.h
+++ b/src/veil/proofofstake/kernel.h
@@ -12,6 +12,6 @@
 bool CheckStake(const CDataStream& ssUniqueID, CAmount nValueIn, const uint64_t nStakeModifier, const uint256& bnTarget, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake);
 bool stakeTargetHit(arith_uint256 hashProofOfStake, int64_t nValueIn, arith_uint256 bnTargetPerCoinDay);
 bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake);
-bool CheckProofOfStake(const CTransactionRef txRef, const uint32_t& nBits, const unsigned int& nTimeBlock, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake);
+bool CheckProofOfStake(CBlockIndex* pindexCheck, const CTransactionRef txRef, const uint32_t& nBits, const unsigned int& nTimeBlock, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake);
 
 #endif // BITCOIN_KERNEL_H

--- a/src/veil/proofofstake/kernel.h
+++ b/src/veil/proofofstake/kernel.h
@@ -11,7 +11,7 @@
 
 bool CheckStake(const CDataStream& ssUniqueID, CAmount nValueIn, const uint64_t nStakeModifier, const uint256& bnTarget, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake);
 bool stakeTargetHit(arith_uint256 hashProofOfStake, int64_t nValueIn, arith_uint256 bnTargetPerCoinDay);
-bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake);
+bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake, bool fWeightStake);
 bool CheckProofOfStake(CBlockIndex* pindexCheck, const CTransactionRef txRef, const uint32_t& nBits, const unsigned int& nTimeBlock, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake);
 
 #endif // BITCOIN_KERNEL_H

--- a/src/veil/proofofstake/kernel.h
+++ b/src/veil/proofofstake/kernel.h
@@ -11,7 +11,7 @@
 
 bool CheckStake(const CDataStream& ssUniqueID, CAmount nValueIn, const uint64_t nStakeModifier, const uint256& bnTarget, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake);
 bool stakeTargetHit(arith_uint256 hashProofOfStake, int64_t nValueIn, arith_uint256 bnTargetPerCoinDay);
-bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, uint256& hashProofOfStake, bool fWeightStake);
+bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, const CBlockIndex* pindexBest, uint256& hashProofOfStake, bool fWeightStake);
 bool CheckProofOfStake(CBlockIndex* pindexCheck, const CTransactionRef txRef, const uint32_t& nBits, const unsigned int& nTimeBlock, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake);
 
 #endif // BITCOIN_KERNEL_H

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -393,6 +393,21 @@ bool AnonWallet::GetStealthAddressSpendKey(CStealthAddress &sxAddr, CKey &key) c
 }
 
 
+bool AnonWallet::GetAddressMeta(const CStealthAddress& address, CKeyID& idAccount, std::string& strPath) const
+{
+    if (!mapStealthAddresses.count(address.GetID()))
+        return false;
+
+    CStealthAddress sxAddr = mapStealthAddresses.at(address.GetID());
+    if (mapKeyPaths.count(sxAddr.GetID())) {
+        auto accountpair = mapKeyPaths.at(sxAddr.GetID());
+        idAccount = accountpair.first;
+        strPath = BIP32PathToString(accountpair.second);
+    }
+
+    return true;
+}
+
 
 bool AnonWallet::ImportStealthAddress(const CStealthAddress &sxAddr, const CKey &skSpend)
 {
@@ -3565,6 +3580,11 @@ bool AnonWallet::SetMasterKey(const CExtKey& keyMasterIn)
     return wdb.WriteNamedExtKeyId("master", idMaster);
 }
 
+CKeyID AnonWallet::GetSeedHash() const
+{
+    return idMaster;
+}
+
 bool AnonWallet::LoadKeys()
 {
     LOCK(pwalletParent->cs_wallet);
@@ -3641,6 +3661,13 @@ bool AnonWallet::LoadAccountCounters()
     pcursor->close();
 
     return true;
+}
+
+int AnonWallet::GetStealthAccountCount() const
+{
+    if (!mapAccountCounter.count(idStealthAccount))
+        return 0;
+    return mapAccountCounter.at(idStealthAccount);
 }
 
 bool AnonWallet::RegenerateKey(const CKeyID& idKey, CKey& key) const

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -289,6 +289,7 @@ public:
     bool ScanForOwnedOutputs(const CTransaction &tx, size_t &nCT, size_t &nRingCT, mapValue_t &mapNarr);
     bool AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     void MarkOutputSpent(const COutPoint& outpoint, bool isSpent);
+    void RescanWallet();
 
     int InsertTempTxn(const uint256 &txid, const CTransactionRecord *rtx) const;
 

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -156,6 +156,7 @@ public:
     isminetype HaveStealthAddress(const CStealthAddress &sxAddr) const;
     bool GetStealthAddressScanKey(CStealthAddress &sxAddr) const;
     bool GetStealthAddressSpendKey(CStealthAddress &sxAddr, CKey &key) const;
+    bool GetAddressMeta(const CStealthAddress& address, CKeyID& idAccount, std::string& strPath) const;
 
     bool ImportStealthAddress(const CStealthAddress &sxAddr, const CKey &skSpend);
 
@@ -254,6 +255,8 @@ public:
     bool SetMasterKey(const CExtKey& keyMasterIn);
     bool LoadAccountCounters();
     bool LoadKeys();
+    CKeyID GetSeedHash() const;
+    int GetStealthAccountCount() const;
 
     bool HaveKeyID(const CKeyID& id);
     bool NewKeyFromAccount(const CKeyID &idAccount, CKey& key);

--- a/src/veil/ringct/outputrecord.cpp
+++ b/src/veil/ringct/outputrecord.cpp
@@ -60,7 +60,7 @@ void COutputRecord::MarkPendingSpend(bool isSpent)
     if (isSpent)
         nFlags |= ORF_PENDING_SPEND;
     else
-        nFlags &= ORF_PENDING_SPEND;
+        nFlags &= ~ORF_PENDING_SPEND;
 }
 
 bool COutputRecord::IsSpent(bool fIncludePendingSpend) const

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -136,6 +136,26 @@ static UniValue restoreaddresses(const JSONRPCRequest &request)
     return NullUniValue;
 }
 
+static UniValue rescanringctwallet(const JSONRPCRequest &request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || !request.params.empty())
+        throw std::runtime_error(
+                "rescanringctwallet\n"
+                "Rescans all transactions in the ringct wallet (CT and RingCT transactions)"
+                + HelpRequiringPassphrase(wallet.get()));
+
+    EnsureWalletIsUnlocked(wallet.get());
+    auto pAnonWallet = wallet->GetAnonWallet();
+    LOCK2(cs_main, wallet->cs_wallet);
+
+    pAnonWallet->RescanWallet();
+    return NullUniValue;
+}
+
 static void push(UniValue & entry, std::string key, UniValue const & value)
 {
     if (entry[key].getType() == 0) {
@@ -1865,6 +1885,7 @@ static const CRPCCommand commands[] =
                 //  --------------------- ------------------------            -----------------------         ----------
                 { "wallet",             "getnewaddress",             &getnewaddress,          {"label","num_prefix_bits","prefix_num","bech32","makeV2"} },
                 { "wallet",             "restoreaddresses",          &restoreaddresses,          {"generate_count"} },
+                { "wallet",             "rescanringctwallet",          &rescanringctwallet,          {} },
 
                 { "wallet",             "sendbasecointostealth", &sendbasecointostealth,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },
 

--- a/src/veil/zerocoin/accumulators.cpp
+++ b/src/veil/zerocoin/accumulators.cpp
@@ -312,7 +312,6 @@ int AddBlockMintsToAccumulator(const libzerocoin::PublicCoin& coin, const int nH
     list<PublicCoin> listPubcoins;
     //Do not keep cs_main locked during modular exponentiation (unless this is already locked from the validation)
     {
-        LOCK(cs_main);
         //grab mints from this block
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus()))

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -17,7 +17,11 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
     {
         /*.name =*/ "segwit",
         /*.gbt_force =*/ true,
-    }
+    },
+    {
+        /*.name =*/ "pos_weight",
+        /*.gbt_force =*/ true,
+    },
 };
 
 ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -212,8 +212,8 @@ bool WalletInit::Open() const
         pwallet->setZPivAutoBackups(fEnableZPivBackups);
 
         AddWallet(pwallet);
-        pwallet->getZWallet()->LoadMintPoolFromDB();
-        pwallet->getZWallet()->SyncWithChain();
+        pwallet->GetZWallet()->LoadMintPoolFromDB();
+        pwallet->GetZWallet()->SyncWithChain();
     }
 
     return true;

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -1189,16 +1189,16 @@ UniValue generatemintlist(const JSONRPCRequest& request)
 
     int nCount = params[0].get_int();
     int nRange = params[1].get_int();
-    if (pwallet->getZWallet()->HasEmptySeed())
+    if (pwallet->GetZWallet()->HasEmptySeed())
         throw JSONRPCError(RPC_WALLET_ERROR, "Zerocoin seed is not loaded");
 
-    CKeyID seedID = pwallet->getZWallet()->GetMasterSeedID();
+    CKeyID seedID = pwallet->GetZWallet()->GetMasterSeedID();
     UniValue arrRet(UniValue::VARR);
     for (int i = nCount; i < nCount + nRange; i++) {
         libzerocoin::CoinDenomination denom = libzerocoin::CoinDenomination::ZQ_TEN;
         libzerocoin::PrivateCoin coin(Params().Zerocoin_Params(), denom, false);
         CDeterministicMint dMint;
-        pwallet->getZWallet()->GenerateMint(seedID, i, denom, coin, dMint);
+        pwallet->GetZWallet()->GenerateMint(seedID, i, denom, coin, dMint);
         UniValue obj(UniValue::VOBJ);
         obj.push_back(Pair("count", i));
         obj.push_back(Pair("value", coin.getPublicCoin().getValue().GetHex()));
@@ -1234,7 +1234,7 @@ UniValue deterministiczerocoinstate(const JSONRPCRequest& request)
                                             "\nExamples\n" +
                 HelpExampleCli("deterministiczerocoinstate", "") + HelpExampleRpc("deterministiczerocoinstate", ""));
 
-    CzWallet* zwallet = pwallet->getZWallet();
+    CzWallet* zwallet = pwallet->GetZWallet();
     UniValue obj(UniValue::VOBJ);
     int nCount, nCountLastUsed;
     zwallet->GetState(nCount, nCountLastUsed);
@@ -1315,7 +1315,7 @@ UniValue searchdeterministiczerocoin(const JSONRPCRequest& request)
     if (nThreads < 1)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Threads has to be at least 1");
 
-    CzWallet* zwallet = pwallet->getZWallet();
+    CzWallet* zwallet = pwallet->GetZWallet();
 
     boost::thread_group* dzThreads = new boost::thread_group();
     int nRangePerThread = nRange / nThreads;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3698,7 +3698,11 @@ bool CWallet::CreateCoinStake(unsigned int nBits, CMutableTransaction& txNew, un
         }
 
         //iterates each utxo inside of CheckStakeKernelHash()
-        if (Stake(stakeInput.get(), nBits, block.GetBlockTime(), nTxNewTime, hashProofOfStake)) {
+        bool fWeightStake = false;
+        ThresholdState state = VersionBitsState(chainActive.Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_POS_WEIGHT, versionbitscache);
+        if (state == ThresholdState::ACTIVE || state == ThresholdState::LOCKED_IN)
+            fWeightStake = true;
+        if (Stake(stakeInput.get(), nBits, block.GetBlockTime(), nTxNewTime, hashProofOfStake, fWeightStake)) {
             int nHeight = 0;
             {
                 LOCK(cs_main);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -271,6 +271,17 @@ CExtKey DeriveKeyFromPath(const CExtKey& keyAccount, const BIP32Path& vPath)
     return keyDerive;
 }
 
+std::string BIP32PathToString(const BIP32Path& vPath)
+{
+    std::string str;
+    for (auto p : vPath) {
+        str += std::to_string(p.first);
+        if (p.second)
+            str += "'";
+        str += "/";
+    }
+}
+
 // Veil:
 // Pass in {[0, true], [0, false], [0, false]} to match default bip44 matching
 // the same derivation used here https://iancoleman.io/bip39/
@@ -333,6 +344,11 @@ void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey
     // update the chain model in the database
     if (!batch.WriteHDChain(hdChain))
         throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
+}
+
+int CWallet::GetAccountKeyCount() const
+{
+    return hdChain.nExternalChainCounter;
 }
 
 bool CWallet::AddKeyPubKeyWithDB(WalletBatch &batch, const CKey& secret, const CPubKey &pubkey)
@@ -5221,7 +5237,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     zwallet->LoadMintPoolFromDB();
     if (!walletInstance->IsLocked()) {
         assert(walletInstance->GetZerocoinSeed(keyZerocoin));
-        zwallet = walletInstance->getZWallet();
+        zwallet = walletInstance->GetZWallet();
         auto idExpect = zwallet->GetMasterSeedID();
         assert(keyZerocoin.GetPubKey().GetID() == idExpect);
         zwallet->SetMasterSeed(keyZerocoin);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1053,7 +1053,7 @@ public:
     CAmount GetZerocoinBalance(bool fMatureOnly) const;
     CAmount GetUnconfirmedZerocoinBalance() const;
     CAmount GetImmatureZerocoinBalance() const;
-    bool CreateCoinStake(unsigned int nBits, CMutableTransaction& txNew, unsigned int& nTxNewTime);
+    bool CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits, CMutableTransaction& txNew, unsigned int& nTxNewTime);
     bool SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInputs, CAmount nTargetAmount);
 
     // sub wallet seeds

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -646,6 +646,7 @@ struct CoinSelectionParams
 };
 
 CExtKey DeriveKeyFromPath(const CExtKey& keyAccount, const BIP32Path& vPath);
+std::string BIP32PathToString(const BIP32Path& vPath);
 
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
@@ -855,7 +856,7 @@ public:
         zTracker = std::unique_ptr<CzTracker>(new CzTracker(this));
     }
 
-    CzWallet* getZWallet() { return zwalletMain; }
+    CzWallet* GetZWallet() { return zwalletMain; }
 
     bool isZeromintEnabled()
     {
@@ -966,6 +967,7 @@ public:
      * Generate a new key
      */
     CPubKey GenerateNewKey(WalletBatch& batch, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    int GetAccountKeyCount() const;
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool AddKeyPubKeyWithDB(WalletBatch &batch,const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
**VIP-1 Soft Fork:**
---
**VIP link:** [VIP-0001](https://github.com/Veil-Project/VIP/blob/master/vip-0001.mediawiki) 

**Implementation Detail:** The default wallet will now use no stake weight reduction for any denomination of zerocoin, since enforcement was not properly added to the codebase. Once the enforcement threshold is met, stake weight will automatically revert back to reduced weight for larger denomination.

**Soft Fork Detail:** 
   - Bit signal on version bit 2
   - Each voting period 1440 blocks (1 day)
   - Activation threshold 75% 1080 blocks

**Spam and DoS Prevention**
---
**Background Information:** A recent security analysis and associated research paper have identified some areas of concern for DoS attacks against many Proof of Stake based cryptocurrencies ([link](https://medium.com/@dsl_uiuc/fake-stake-attacks-on-chain-based-proof-of-stake-cryptocurrencies-b8b05723f806)). The majority of these attacks focus on headers first syncing and spamming fake headers and invalid blocks. These spam attacks rely on headers because in most headers first implementations you are not able to identify the validity of proof of stake based solely on headers.

While Veil is less vulnerable than some other blockchains, there were a few areas that have been hardened against such attacks, and a few areas where Veil has decided to place more emphasis on the Proof of Work side of Veil's dual consensus system.

**Long Range Headers Syncing:** Veil will now only do "long range" headers syncing if the headers chain has a higher amount of PoW specific work than the client's best known header. This is important because it means that in order to create a spam side chain that might fill up the client's memory (or at least be monitored actively as a potential reorg) the chain would need to have spent money/resources/hash power on the spam chain, which causes a major barrier to entry and significant hurdle to launch such an attack.

**Short Range Headers Syncing:** If there is no established chain with more PoW work than the current main chain, then the Veil client will revert to short range syncing. With short range syncing Veil will only run 50 headers above the current active chain. These 50 headers may in fact be invalid (since they would only be PoS and thus unable to be validated without more information). Since the headers will be a higher dual-consensus work chain, the client will request the blocks for the chain. Once any of the blocks are seen as invalid, the headers chain will be disconnected.

**Active Collection of Headers Garbage:** One of the described attacks relies primarily on filling up the memory of a node by giving them too many headers. Veil's default client will now actively prune irrelevant block indexes that are not candidates for reorg once there are in excess of 1,000 non-main chain indexes.

**Disk Exhaustion:** Veil does full validation of stakes during `AcceptBlock()`, this means that a block will not be stored to disk unless it is associated with a valid stake. Since Veil does not rely on UTXO database for staking and instead relies on cryptographic accumulators (which can be easily instantiated on the fly to a certain block without impacting the state of the mainchain) Veil is able to check that a stake is in fact valid. The Veil client also keeps full indexing of spent zerocoins and the block they were spent on, which allows for quick checking of whether the zerocoin being spent was spent on the chain it is reorganizing to.

A possible disk attack could occur with the following scenario:
![disk_exhaustion](https://user-images.githubusercontent.com/6628210/51641449-64fb0680-1f23-11e9-8235-c2e8cd25e255.png)

An attack could exhaust disk resources by using at least 1 valid stake and continuously repackaging that stake into different variations of the same block, which from the blockchain's perspective gives unique valid blocks. As seen in `Block 98-s3` and `Block 98'-s3`, without proper handling the same stake could be repackaged and have new invalid headers added on top to give the impression of a valid new chain to reorganize to, resulting in each modified version of `Block 98` being stored to disk.

Veil will now circumvent such an attack by keeping track of stakes. If a repacked block with the same stake comes in, the block will be ignored unless a valid Proof of Work header is also on the reorg chain, creating much less likelihood for an exhaustion attack to occur without spending significant resources on the attack. This system will allow for the valid chain with `Block 98''` to be reorganized to.

**Other Miscellaneous Items Included In Pull Request:**
---
- Reduce the likelihood of validating the same zeroknowledge proof multiple times.
- Don't assign DoS score for out of order headers received from peers (will add once root cause is identified)
- Fix some edge cases with block staging slowing down syncing of certain blocks.
- New hard checkpoint added block 29000.
- Don't accept transactions to mempool unless both blocks and headers are synced. 
- Fix bad block index and a few timing issues in stake miner.
- Add rescanringctwallet rpc.
- Add subwallet seed hash and address counts to getwalletinfo rpc.