### PR TITLE
[Wallet][Qt] Fix premature Zerocoin spending in GUI

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -52,7 +52,7 @@ public:
         LOCK2(cs_main, m_wallet.cs_wallet);
         CValidationState state;
 
-        if (!m_wallet.CommitTransaction(m_tx, std::move(value_map), std::move(order_form), m_key, g_connman.get(), state)) {
+        if (!m_wallet.CommitTransaction(m_tx, std::move(value_map), std::move(order_form), &m_key, g_connman.get(), state)) {
             reject_reason = state.GetRejectReason();
             return false;
         }

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -322,16 +322,23 @@ public:
         return m_wallet.MintZerocoin(nValue, wtx , vDMints, inputtype,coinControl);
     }
 
-    std::unique_ptr<PendingWalletTx> spendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendReceipt& receipt,
-                               std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange,
-                               CTxDestination* addressTo = NULL) override
+    std::unique_ptr<PendingWalletTx> prepareZerocoinSpend(CAmount nValue, int nSecurityLevel,
+            CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange,
+            bool fMinimizeChange, std::vector<CommitData>& vCommitData, libzerocoin::CoinDenomination denomFilter,
+            CTxDestination* addressTo = NULL) override
     {
         auto pending = MakeUnique<PendingWalletTxImpl>(m_wallet);
-        if (!m_wallet.SpendZerocoin(nValue, nSecurityLevel, receipt, vMintsSelected, fMintChange, fMinimizeChange, libzerocoin::CoinDenomination::ZQ_ERROR, addressTo))
+        if (!m_wallet.PrepareZerocoinSpend(nValue, nSecurityLevel, receipt, vMintsSelected, fMintChange,
+                fMinimizeChange, vCommitData, libzerocoin::CoinDenomination::ZQ_ERROR, addressTo))
             return {};
         auto vtx = receipt.GetTransactions();
         pending->m_tx = vtx[0];
         return std::move(pending);
+    }
+
+    bool commitZerocoinSpend(CZerocoinSpendReceipt& receipt, std::vector<CommitData>& vCommitData) override
+    {
+        return m_wallet.CommitZerocoinSpend(receipt, vCommitData);
     }
 
     bool haveWatchOnly() override { return m_wallet.HaveWatchOnly(); };

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -31,6 +31,7 @@
 class CCoinControl;
 class CFeeRate;
 class CKey;
+class CReserveKey;
 class CTempRecipient;
 class CWallet;
 class CWalletTx;
@@ -109,9 +110,15 @@ public:
     virtual std::string mintZerocoin(CAmount nValue, std::vector<CDeterministicMint>& vDMints, OutputTypes inputtype,
             const CCoinControl* coinControl) = 0;
 
-    virtual std::unique_ptr<PendingWalletTx> spendZerocoin(CAmount nValue, int nSecurityLevel, CZerocoinSpendReceipt& receipt,
-            std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange,
-            CTxDestination* addressTo = NULL) = 0;
+    virtual std::unique_ptr<PendingWalletTx> prepareZerocoinSpend(CAmount nValue, int nSecurityLevel,
+            CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange,
+            bool fMinimizeChange, std::vector<std::tuple<CWalletTx, std::vector<CDeterministicMint>,
+                    std::vector<CZerocoinMint>>>& vCommitData,
+                    libzerocoin::CoinDenomination denomFilter = libzerocoin::CoinDenomination::ZQ_ERROR,
+                    CTxDestination* addressTo = NULL) = 0;
+
+    virtual bool commitZerocoinSpend(CZerocoinSpendReceipt& receipt, std::vector<std::tuple<CWalletTx,
+            std::vector<CDeterministicMint>, std::vector<CZerocoinMint>>>& vCommitData) = 0;
 
     //! Return whether wallet has watch only keys.
     virtual bool haveWatchOnly() = 0;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -249,7 +249,10 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     updateCoinControlState(ctrl);
 
-    prepareStatus = model->prepareTransaction(currentTransaction, ctrl);
+    WalletModelSpendType spendType;
+    CZerocoinSpendReceipt receipt;
+    std::vector<CommitData> vCommitData;
+    prepareStatus = model->prepareTransaction(currentTransaction, ctrl, spendType, receipt, vCommitData);
     // process prepareStatus and on error generate message shown to user
     processSendCoinsReturn(prepareStatus,
         BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), currentTransaction.getTransactionFee()));
@@ -374,7 +377,11 @@ void SendCoinsDialog::on_sendButton_clicked()
     }
 
     // now send the prepared transaction
-    WalletModel::SendCoinsReturn sendStatus = model->sendCoins(currentTransaction);
+    WalletModel::SendCoinsReturn sendStatus;
+    if (spendType == ZCSPEND)
+        sendStatus = model->sendZerocoins(receipt, vCommitData);
+    if (sendStatus.status == WalletModel::OK)
+        sendStatus = model->sendCoins(currentTransaction);
     // process sendStatus and on error generate message shown to user
     processSendCoinsReturn(sendStatus);
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -381,7 +381,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     if (spendType == ZCSPEND)
         sendStatus = model->sendZerocoins(receipt, vCommitData);
     if (sendStatus.status == WalletModel::OK)
-        sendStatus = model->sendCoins(currentTransaction);
+        sendStatus = model->sendCoins(currentTransaction, spendType == ZCSPEND);
     // process sendStatus and on error generate message shown to user
     processSendCoinsReturn(sendStatus);
 
@@ -597,6 +597,9 @@ void SendCoinsDialog::processSendCoinsReturn(const WalletModel::SendCoinsReturn 
     case WalletModel::PaymentRequestExpired:
         msgParams.first = tr("Payment request expired.");
         msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    case WalletModel::ZerocoinSpendFail:
+        msgParams.first = tr("Zerocoinspend transaction failed. ") + msgParams.first;
         break;
     // included to prevent a compiler warning.
     case WalletModel::OK:

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -304,7 +304,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     return SendCoinsReturn(OK);
 }
 
-WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &transaction)
+WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &transaction, bool fSkipCommitTx)
 {
     QByteArray transaction_array; /* store serialized transaction */
 
@@ -330,7 +330,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
 
         auto& newTx = transaction.getWtx();
         std::string rejectReason;
-        if (!newTx->commit({} /* mapValue */, std::move(vOrderForm), rejectReason))
+        if (!fSkipCommitTx && !newTx->commit({} /* mapValue */, std::move(vOrderForm), rejectReason))
             return SendCoinsReturn(TransactionCommitFailed, QString::fromStdString(rejectReason));
 
         CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
@@ -374,8 +374,7 @@ WalletModel::SendCoinsReturn WalletModel::sendZerocoins(CZerocoinSpendReceipt& r
         std::vector<CommitData>& vCommitData)
 {
     if (!m_wallet->commitZerocoinSpend(receipt, vCommitData)) {
-        return SendCoinsReturn(TransactionCommitFailed,
-                QString::fromStdString(receipt.GetStatusMessage()));
+        return SendCoinsReturn(ZerocoinSpendFail, QString::fromStdString(receipt.GetStatusMessage()));
     }
 
     return SendCoinsReturn(OK);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -130,16 +130,9 @@ bool WalletModel::isStealthAddress(const QString &address){
     return veilAddress.IsValidStealthAddress() && IsValidDestinationString(strAddress);
 }
 
-enum WalletModelSpendType
-{
-    ZCSPEND,
-    CTSPEND,
-    RINGCTSPEND,
-    BASECOINSPEND
-};
-
-WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const
-CCoinControl& coinControl, OutputTypes inputType)
+WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction,
+        const CCoinControl& coinControl, WalletModelSpendType &spendType, CZerocoinSpendReceipt &receipt,
+        std::vector<CommitData> &vCommitData, OutputTypes inputType)
 {
     CAmount total = 0;
     bool fSubtractFeeFromAmount = false;
@@ -209,8 +202,6 @@ CCoinControl& coinControl, OutputTypes inputType)
     }
 
     auto& newTx = transaction.getWtx();
-    WalletModelSpendType spendType;
-    CZerocoinSpendReceipt receipt;
     CAmount nBalance = 0;
     OutputTypes outputType;
     if (coinControl.HasSelected()) {
@@ -233,8 +224,9 @@ CCoinControl& coinControl, OutputTypes inputType)
             //todo, this does not support multi recipient spend yet
 
             std::vector<CZerocoinMint> vMintsSelected;
-            newTx = m_wallet->spendZerocoin(total, /*nSecurityLevel*/100, receipt, vMintsSelected, /*fMintChange*/true,
-                    /*fMinimizeChange*/false, &vecSend[0].address);
+            newTx = m_wallet->prepareZerocoinSpend(total, /*nSecurityLevel*/100, receipt, vMintsSelected,
+                    /*fMintChange*/true, /*fMinimizeChange*/false, vCommitData, libzerocoin::CoinDenomination::ZQ_ERROR,
+                    &vecSend[0].address);
             nBalance = balances.zerocoin_balance;
         } else {
             /** If not enough zerocoin balance, spend ringct **/
@@ -270,9 +262,6 @@ CCoinControl& coinControl, OutputTypes inputType)
 
     if(total > nBalance)
     {
-//        std::cout << "Balance: " << nBalance << std::endl;
-//        std::cout << "Total: " << total << std::endl;
-//        std::cout << "Type: " << inputType << std::endl;
         if(inputType == OUTPUT_STANDARD){
             return AmountExceedsBalance;
         }else{
@@ -377,6 +366,17 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
     }
 
     checkBalanceChanged(m_wallet->getBalances()); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
+
+    return SendCoinsReturn(OK);
+}
+
+WalletModel::SendCoinsReturn WalletModel::sendZerocoins(CZerocoinSpendReceipt& receipt,
+        std::vector<CommitData>& vCommitData)
+{
+    if (!m_wallet->commitZerocoinSpend(receipt, vCommitData)) {
+        return SendCoinsReturn(TransactionCommitFailed,
+                QString::fromStdString(receipt.GetStatusMessage()));
+    }
 
     return SendCoinsReturn(OK);
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -45,6 +45,14 @@ QT_BEGIN_NAMESPACE
 class QTimer;
 QT_END_NAMESPACE
 
+enum WalletModelSpendType
+{
+    ZCSPEND,
+    CTSPEND,
+    RINGCTSPEND,
+    BASECOINSPEND
+};
+
 class SendCoinsRecipient
 {
 public:
@@ -163,10 +171,14 @@ public:
 
     // prepare transaction for getting txfee before sending coins
     SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl,
+            WalletModelSpendType &spendType, CZerocoinSpendReceipt& receipt, std::vector<std::tuple<CWalletTx,
+            std::vector<CDeterministicMint>, std::vector<CZerocoinMint>>>& vCommitData,
             OutputTypes inputType = OUTPUT_RINGCT);
 
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);
+    SendCoinsReturn sendZerocoins(CZerocoinSpendReceipt& receipt, std::vector<std::tuple<CWalletTx,
+            std::vector<CDeterministicMint>, std::vector<CZerocoinMint>>>& vCommitData);
 
     // Wallet encryption
     bool setWalletEncrypted(bool encrypted, const SecureString &passphrase);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -176,7 +176,7 @@ public:
             OutputTypes inputType = OUTPUT_RINGCT);
 
     // Send coins to a list of recipients
-    SendCoinsReturn sendCoins(WalletModelTransaction &transaction);
+    SendCoinsReturn sendCoins(WalletModelTransaction &transaction, bool fSkipCommitTx = false);
     SendCoinsReturn sendZerocoins(CZerocoinSpendReceipt& receipt, std::vector<std::tuple<CWalletTx,
             std::vector<CDeterministicMint>, std::vector<CZerocoinMint>>>& vCommitData);
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -540,7 +540,7 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
     CValidationState state;
     CReserveKey reservekey(wallet.get());
    // if (typeIn == OUTPUT_STANDARD && typeOut == OUTPUT_STANDARD) {
-        if (!wallet->CommitTransaction(wtx.tx, wtx.mapValue, wtx.vOrderForm, reservekey, g_connman.get(), state)) {
+        if (!wallet->CommitTransaction(wtx.tx, wtx.mapValue, wtx.vOrderForm, &reservekey, g_connman.get(), state)) {
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Transaction commit failed: %s", FormatStateMessage(state)));
         }
     //} else {

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -242,7 +242,7 @@ Result CommitTransaction(CWallet* wallet, const uint256& txid, CMutableTransacti
 
     CReserveKey reservekey(wallet);
     CValidationState state;
-    if (!wallet->CommitTransaction(tx, std::move(mapValue), oldWtx.vOrderForm, reservekey, g_connman.get(), state)) {
+    if (!wallet->CommitTransaction(tx, std::move(mapValue), oldWtx.vOrderForm, &reservekey, g_connman.get(), state)) {
         // NOTE: CommitTransaction never returns false, so this should never happen.
         errors.push_back(strprintf("The transaction was rejected: %s", FormatStateMessage(state)));
         return Result::WALLET_ERROR;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -536,7 +536,7 @@ static CTransactionRef SendMoney(CWallet * const pwallet, const CTxDestination &
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
     CValidationState state;
-    if (!pwallet->CommitTransaction(tx, std::move(mapValue), {} /* orderForm */, reservekey, g_connman.get(), state)) {
+    if (!pwallet->CommitTransaction(tx, std::move(mapValue), {} /* orderForm */, &reservekey, g_connman.get(), state)) {
         strError = strprintf("Error: The transaction was rejected! Reason given: %s", FormatStateMessage(state));
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
@@ -1369,7 +1369,7 @@ static UniValue sendmany(const JSONRPCRequest& request)
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
     CValidationState state;
-    if (!pwallet->CommitTransaction(tx, std::move(mapValue), {} /* orderForm */, keyChange, g_connman.get(), state)) {
+    if (!pwallet->CommitTransaction(tx, std::move(mapValue), {} /* orderForm */, &keyChange, g_connman.get(), state)) {
         strFailReason = strprintf("Transaction commit failed:: %s", FormatStateMessage(state));
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
     }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -297,7 +297,7 @@ public:
         CCoinControl dummy;
         BOOST_CHECK(wallet->CreateTransaction({recipient}, tx, reservekey, fee, changePos, error, dummy));
         CValidationState state;
-        BOOST_CHECK(wallet->CommitTransaction(tx, {}, {}, reservekey, nullptr, state));
+        BOOST_CHECK(wallet->CommitTransaction(tx, {}, {}, &reservekey, nullptr, state));
         CMutableTransaction blocktx;
         {
             LOCK(wallet->cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1087,7 +1087,7 @@ public:
     bool CreateTransaction(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut,
                            std::string& strFailReason, const CCoinControl& coin_control, bool sign = true);
     bool CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm,
-            CReserveKey& reservekey, CConnman* connman, CValidationState& state);
+            CReserveKey* reservekey, CConnman* connman, CValidationState& state);
 
     bool DummySignTx(CMutableTransaction &txNew, const std::set<CTxOut> &txouts, bool use_max_sig = false) const
     {


### PR DESCRIPTION
This should resolve #272.

I split the ZerocoinSpend into preparation and commit steps. We now prepare the ZerocoinSpend when we first click "Send" in the GUI (just as we were doing with other types of transactions), and we won't commit the ZerocoinSpend until the "Send" button in the confirmation popup is clicked. Previously, these two steps were not separated and were both performed as soon as the first "Send" button was pressed (before the user confirmed sending the zerocoin).