### PR TITLE
Multi Threading of Block Staging and Proof Verifying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1012,6 +1012,6 @@ add_executable(veil
         src/versionbits.h
         src/walletinitinterface.h
         src/warnings.cpp
-        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h)
+        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp)
 
 qt5_use_modules(veil Core Widgets Gui)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -96,7 +96,8 @@ BITCOIN_TESTS =\
   test/libzerocoin_tests.cpp \
   test/zerocoin_denomination_tests.cpp \
   test/zerocoin_implementation_tests.cpp \
-  test/zerocoin_transactions_tests.cpp
+  test/zerocoin_transactions_tests.cpp \
+  test/zerocoin_zkp_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -420,6 +420,7 @@ void SetupServerArgs()
     hidden_args.emplace_back("-sysperms");
 #endif
     gArgs.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-threadbatchverify", strprintf("How many threads to run when batch verifying zeroknowledge proofs (default: %u)", DEFAULT_BATCHVERIFY_THREADS), false, OptionsCategory::OPTIONS);
 
     gArgs.AddArg("-addnode=<ip>", "Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info). This option can be specified multiple times to add multiple nodes.", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-banscore=<n>", strprintf("Threshold for disconnecting misbehaving peers (default: %u)", DEFAULT_BANSCORE_THRESHOLD), false, OptionsCategory::CONNECTION);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1862,7 +1862,8 @@ bool AppInitMain()
         threadGroupStaking.create_thread(&ThreadStakeMiner);
 
     //Start block staging thread
-    threadGroupStaging.create_thread(&ThreadStaging);
+    threadGroupStaging.create_thread(&ThreadStagingBlockProcessing);
+    threadGroupStaging.create_thread(&ThreadStagingBatchVerify);
 
     LinkPoWThreadGroup(&threadGroupPoWMining);
 

--- a/src/libzerocoin/SerialNumberSoK_small.h
+++ b/src/libzerocoin/SerialNumberSoK_small.h
@@ -159,7 +159,8 @@ public:
     CBigNum valueOfCommitmentToCoin;
     uint256 msghash;
 
-    static bool BatchVerify(std::vector<SerialNumberSoKProof> &proofs);
+    static bool BatchVerify(std::vector<const SerialNumberSoKProof*> &proofs, uint8_t* nReturn);
+    static bool BatchVerify(std::vector<const SerialNumberSoKProof*> &proofs);
     static bool BatchBulletproofs(const CBN_matrix ck_inner_g, std::vector<SerialNumberSoKProof2> &proofs);
     static CBN_vector getFinal_gh(const ZerocoinParams* ZCp, CBN_vector gs, std::vector<fBE> forBigExpo);
 };

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -122,6 +122,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::ZEROCOINDB, "zerocoindb"},
     {BCLog::BLOCKCREATION, "blockcreation"},
     {BCLog::CHAINSCORE, "chainscore"},
+    {BCLog::STAGING, "staging"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -56,6 +56,7 @@ namespace BCLog {
         ZEROCOINDB  = (1 << 21),
         BLOCKCREATION = (1 << 22),
         CHAINSCORE = (1 << 23),
+        STAGING     = (1 << 24),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -569,6 +569,7 @@ static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vec
     int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
     nMaxHeight = std::min(nMaxHeight, chainActive.Height() + ASK_FOR_BLOCKS);
     NodeId waitingfor = -1;
+    LOCK(cs_staging);
     while (pindexWalk->nHeight < nMaxHeight) {
         // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
         // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
@@ -597,7 +598,6 @@ static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vec
 
             // Don't ask for a block that is already held in staging, unless it is the next block
             if (pindex->nHeight != nBestHeight + 1) {
-                LOCK(cs_staging);
                 if (mapStagedBlocks.count(pindex->nHeight)) {
                     if (mapStagedBlocks.at(pindex->nHeight).GetHash() == pindex->GetBlockHash())
                         continue;
@@ -1403,23 +1403,6 @@ inline void static SendBlockTransactions(const CBlock& block, const BlockTransac
 bool GetZerocoinSpendProofs(const CTxIn &txin, std::vector<libzerocoin::SerialNumberSoKProof> &proofsOut)
 {
     auto newSpend = TxInToZerocoinSpend(txin);
-    //see if we have record of the accumulator used in the spend tx
-    CBigNum bnAccumulatorValue = 0;
-    {
-        LOCK(cs_main);
-        if (!pzerocoinDB->ReadAccumulatorValue(newSpend->getAccumulatorChecksum(), bnAccumulatorValue))
-            return false;
-    }
-
-    libzerocoin::Accumulator accumulator(Params().Zerocoin_Params(), newSpend->getDenomination(), bnAccumulatorValue);
-
-    //Check that the coin has been accumulated
-    std::string strError;
-    if (!newSpend->Verify(accumulator, strError, false)) {
-        LogPrintf("%s: Zerocoinspend could not verify. Details: %s\n", __func__, strError);
-        return false;
-    }
-
     libzerocoin::SerialNumberSoKProof proof(newSpend->getSmallSoK(), newSpend->getCoinSerialNumber(),
                                newSpend->getSerialComm(), newSpend->getHashSig());
     proofsOut.push_back(proof);
@@ -1427,49 +1410,71 @@ bool GetZerocoinSpendProofs(const CTxIn &txin, std::vector<libzerocoin::SerialNu
     return true;
 }
 
-void ThreadStaging()
+void ThreadStagingBlockProcessing()
 {
     while (true) {
         boost::this_thread::interruption_point();
         try {
-            LogPrintf("ThreadStaging() start\n");
+            LogPrintf("ThreadStagingBlockProcessing() start\n");
             ProcessStaging();
             boost::this_thread::interruption_point();
         } catch (std::exception& e) {
-            LogPrintf("ThreadStaging() exception\n");
+            LogPrintf("ThreadStagingBlockProcessing() exception\n");
         } catch (boost::thread_interrupted) {
-            LogPrintf("ThreadStaging() interrupted\n");
+            LogPrintf("ThreadStagingBlockProcessing() interrupted\n");
         }
 
-        if (ShutdownRequested() /*|| (pindexBestHeader && chainActive.Height() >= pindexBestHeader->nHeight)*/)
+        if (ShutdownRequested())
             break;
     }
     LogPrintf("ThreadStaging exiting\n");
 }
 
-void ProcessStaging()
+void ThreadStagingBatchVerify()
 {
     while (true) {
-        if (ShutdownRequested() /*|| (pindexBestHeader && chainActive.Height() >= pindexBestHeader->nHeight)*/)
+        boost::this_thread::interruption_point();
+        try {
+            LogPrintf("ThreadStagingBatchVerify() start\n");
+            ProcessStagingBatchVerify();
+            boost::this_thread::interruption_point();
+        } catch (std::exception& e) {
+            LogPrintf("ThreadStagingBatchVerify() exception\n");
+        } catch (boost::thread_interrupted) {
+            LogPrintf("ThreadStagingBatchVerify() interrupted\n");
+        }
+
+        if (ShutdownRequested())
+            break;
+    }
+    LogPrintf("ThreadStaging exiting\n");
+}
+
+void ProcessStagingBatchVerify()
+{
+    while (true) {
+        if (ShutdownRequested())
             return;
         boost::this_thread::interruption_point();
 
-        // Process any of the blocks that have been staged, if it is next
-        int nHeightNext;
-        {
-            LOCK(cs_main);
-            nHeightNext = chainActive.Height() + 1;
-        }
-
         std::map<int, CBlock> mapStagedBlocksCopy;
+        bool fNextIter = false;
         {
             LOCK(cs_staging);
-            if (mapStagedBlocks.empty()) {
-                MilliSleep(50);
-                continue;
-            }
+            if (mapStagedBlocks.empty())
+                fNextIter = true;
+            else
+                mapStagedBlocksCopy = mapStagedBlocks;
+        }
+        if (fNextIter) {
+            MilliSleep(500);
+            continue;
+        }
 
-            mapStagedBlocksCopy = mapStagedBlocks;
+        std::set<uint256> setBatchVerified_local;
+        {
+            LOCK(cs_main);
+            setBatchVerified_local = setBatchVerified;
         }
 
         // Perform batch verification for all staged blocks (that haven't yet been verified) to speed up getting blocks
@@ -1477,15 +1482,8 @@ void ProcessStaging()
         std::vector<libzerocoin::SerialNumberSoKProof> vProofs;
         std::set<int> setRemoveBlocks;
         std::set<uint256> setBatchTxHashes;
-        int nBestHeight = nHeightNext -1;
-        int nHaveCheckpointHeight = 10 - (nBestHeight % 10) + nBestHeight;
         int nHighestBlockCheck = 0;
-        for (auto &blockPair : mapStagedBlocksCopy) {
-            // Likely do not have the accumulator checkpoint so cannot verify
-            if (blockPair.first > nHaveCheckpointHeight) {
-                setRemoveBlocks.insert(blockPair.first);
-                continue;
-            }
+        for (auto& blockPair : mapStagedBlocksCopy) {
             // Signatures for this block have already been verified, skip
             if (blockPair.second.fSignaturesVerified)
                 continue;
@@ -1496,12 +1494,18 @@ void ProcessStaging()
             bool fSkipBlock = false;
             std::vector<libzerocoin::SerialNumberSoKProof> vProofsTemp;
 
-            for (auto &tx : blockPair.second.vtx) {
+            for (auto& tx : blockPair.second.vtx) {
+                auto txid = tx->GetHash();
+                //Don't reverify
+                if (setBatchVerified_local.count(txid))
+                    continue;
+
                 if (tx->IsZerocoinSpend()) {
-                    for (auto &txin : tx->vin) {
+                    for (auto& txin : tx->vin) {
                         libzerocoin::CoinSpend spend = *(TxInToZerocoinSpend(txin));
                         if (!GetZerocoinSpendProofs(txin, vProofsTemp) || count(vBlockSerials.begin(),
-                                vBlockSerials.end(), spend.getCoinSerialNumber())) {
+                                                                                vBlockSerials.end(),
+                                                                                spend.getCoinSerialNumber())) {
                             setRemoveBlocks.insert(blockPair.first);
                             fSkipBlock = true;
                             break;
@@ -1509,7 +1513,7 @@ void ProcessStaging()
 
                         vBlockSerials.emplace_back(spend.getCoinSerialNumber());
                     }
-                    setBatchTxHashes.emplace(tx->GetHash());
+                    setBatchTxHashes.emplace(txid);
                 }
 
                 if (fSkipBlock)
@@ -1532,7 +1536,7 @@ void ProcessStaging()
         int nHeightLastCheckpoint = Checkpoints::GetLastCheckpointHeight(Params().Checkpoints());
         if (vProofs.size() > 1) {
             if (nHighestBlockCheck > nHeightLastCheckpoint) {
-                LogPrintf("%s: Batch verifying %d zeroknowledge proofs\n", __func__, vProofs.size());
+                LogPrint(BCLog::STAGING, "%s: Batch verifying %d zeroknowledge proofs\n", __func__, vProofs.size());
                 if (!libzerocoin::SerialNumberSoKProof::BatchVerify(vProofs)) {
                     fVerificationSuccess = false;
                 }
@@ -1540,64 +1544,56 @@ void ProcessStaging()
         }
 
         if (fVerificationSuccess) {
-            {
-                LOCK(cs_staging);
-                for (auto &blockPair : mapStagedBlocksCopy) {
-                    if (!mapStagedBlocks.count(blockPair.first))
-                        continue;
-
-                    mapStagedBlocks[blockPair.first].fSignaturesVerified = true;
-                }
-            }
-            {
-                LOCK(cs_main);
-                for (const uint256 &hash : setBatchTxHashes)
-                    setBatchVerified.emplace(hash);
-            }
+            // Mark as verified
+            LOCK(cs_main);
+            for (const uint256& hash : setBatchTxHashes)
+                setBatchVerified.emplace(hash);
         }
+    }
+}
 
-        while (true) {
-            if (ShutdownRequested())
-                return;
-            boost::this_thread::interruption_point();
+void ProcessStaging()
+{
+    while (true) {
+        if (ShutdownRequested())
+            return;
+        boost::this_thread::interruption_point();
 
-            {
-                LOCK(cs_main);
-                if (chainActive.Height() >= nHeightNext)
-                    nHeightNext++;
-            }
+        // Process any of the blocks that have been staged, if it is next
+        int nHeightNext = chainActive.Height() + 1;
 
-            std::shared_ptr<CBlock> pblockStaged = std::make_shared<CBlock>();
-            {
-                LOCK(cs_staging);
-                if (!mapStagedBlocks.count(nHeightNext))
-                    break;
+        std::shared_ptr<CBlock> pblockStaged = std::make_shared<CBlock>();
+        bool fProcessNext = true;
+        {
+            LOCK(cs_staging);
+            if (mapStagedBlocks.empty() || !mapStagedBlocks.count(nHeightNext)) {
+                fProcessNext = false;
+            } else {
                 CBlock blockStaged = mapStagedBlocks.at(nHeightNext);
                 *pblockStaged = blockStaged;
             }
-
-            bool fProcessNext;
-            {
-                LOCK(cs_main);
-                fProcessNext = mapBlockIndex.at(pblockStaged->hashPrevBlock)->nChainTx > 0;
-            }
-            if (!fProcessNext)
-                break;
-
-            LogPrint(BCLog::NET, "processing staged block %s\n", pblockStaged->GetHash().GetHex());
-            bool fNewBlock = false;
-            if (!ProcessNewBlock(Params(), pblockStaged, true, &fNewBlock))
-                error("Staging thread failed to process block\n");
-            mapStagedBlocks.erase(nHeightNext);
-
-            // If there is a new accumulator checkpoint, jump out so that we can try the next round  of batch zkproof batch verification
-            if (nHeightNext % 10 == 0)
-                break;
-            nHeightNext++;
         }
+        if (!fProcessNext) {
+            MilliSleep(100);
+            continue;
+        }
+
+        fProcessNext = mapBlockIndex.at(pblockStaged->hashPrevBlock)->nChainTx > 0;
+
+        if (!fProcessNext) {
+            MilliSleep(100);
+            continue;
+        }
+
+        LogPrint(BCLog::STAGING, "processing staged block %s\n", pblockStaged->GetHash().GetHex());
+        bool fNewBlock = false;
+        if (!ProcessNewBlock(Params(), pblockStaged, true, &fNewBlock))
+            error("Staging thread failed to process block\n");
 
         {
             LOCK(cs_staging);
+            mapStagedBlocks.erase(nHeightNext);
+
             //Clean up any stale staged blocks
             std::vector<int> vErase;
             for (const auto& p : mapStagedBlocks) {
@@ -3057,6 +3053,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         LogPrint(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->GetId());
 
         bool forceProcessing = false;
+        bool fProcessBlock = false;
+        bool fStageBlock = false;
+        int nHeightBlock = 0;
+        int nHeightNext = 0;
         const uint256 hash(pblock->GetHash());
         {
             LOCK(cs_main);
@@ -3066,46 +3066,48 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // mapBlockSource is only used for sending reject messages and DoS scores,
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
-        }
 
-        bool fProcessBlock = false;
-        int nHeightNext = 0;
-        {
-            LOCK(cs_main);
             if (mapBlockIndex.count(pblock->hashPrevBlock)) {
                 nHeightNext = chainActive.Height() + 1;
                 CBlockIndex* pindexPrev = mapBlockIndex.at(pblock->hashPrevBlock);
-                int nHeightBlock = pindexPrev->nHeight + 1;
+                nHeightBlock = pindexPrev->nHeight + 1;
                 bool isForReorg = nHeightBlock <= nHeightNext - 1 && !chainActive.Contains(pindexPrev);
 
                 //We need the full block data to process it
-                if (pblock->hashPrevBlock == Params().GenesisBlock().GetHash() || pindexPrev->nChainTx > 0 || (isForReorg && forceProcessing)) {
+                if (pblock->hashPrevBlock == Params().GenesisBlock().GetHash() || pindexPrev->nChainTx > 0 ||
+                    (isForReorg && forceProcessing)) {
                     fProcessBlock = true;
-                } else if (forceProcessing && nHeightBlock - nHeightNext < ASK_FOR_BLOCKS + 10 && nHeightNext <= nHeightBlock) {
-                    //Keep a few blocks cached so we don't fetch them over and over
-                    CDataStream ss(SER_DISK, PROTOCOL_VERSION);
-                    ss << *pblock;
-                    int nSizeBlock = ss.size();
-                    if (nStagedCacheSize < STAGING_CACHE_SIZE) {
-                        LOCK(cs_staging);
-                        nStagedCacheSize += nSizeBlock;
-                        mapStagedBlocks.emplace(nHeightBlock, *pblock);
-                        LogPrint(BCLog::NET, "staging block %s (%d) because only have prevheader and not prev block. Need:%d\n",
-                                 pblock->GetHash().ToString(), pindexPrev->nHeight+1, nHeightNext);
-                    } else {
-                        LogPrint(BCLog::NET, "staging area full, discarding block %s (%d)\n",
-                                pblock->GetHash().ToString(), pindexPrev->nHeight+1);
-                    }
+                } else if (forceProcessing && nHeightBlock - nHeightNext < ASK_FOR_BLOCKS + 10 &&
+                           nHeightNext <= nHeightBlock) {
+                    fStageBlock = true;
                 } else {
-                    LogPrint(BCLog::NET, "skipping block %s (%d)\n  force=%d\n  heightcalc=%d\n  nHeightNext=%d\n  pindexprevheight=%d\n",
-                             pblock->GetHash().ToString(), pindexPrev->nHeight+1, forceProcessing, pindexPrev->nHeight - nHeightNext, nHeightNext, pindexPrev->nHeight);
+                    LogPrint(BCLog::STAGING,
+                             "skipping block %s (%d)\n  force=%d\n  heightcalc=%d\n  nHeightNext=%d\n  pindexprevheight=%d\n",
+                             pblock->GetHash().ToString(), pindexPrev->nHeight + 1, forceProcessing,
+                             pindexPrev->nHeight - nHeightNext, nHeightNext, pindexPrev->nHeight);
                 }
             } else {
-                LogPrint(BCLog::NET, "skipping block %s because do not have prev\n", pblock->GetHash().ToString());
+                LogPrint(BCLog::STAGING, "skipping block %s because do not have prev\n",
+                         pblock->GetHash().ToString());
             }
         }
 
-        if (fProcessBlock) {
+        if (fStageBlock) {
+            //Keep a few blocks cached so we don't fetch them over and over
+            CDataStream ss(SER_DISK, PROTOCOL_VERSION);
+            ss << *pblock;
+            int nSizeBlock = ss.size();
+            if (nStagedCacheSize < STAGING_CACHE_SIZE) {
+                LOCK(cs_staging);
+                nStagedCacheSize += nSizeBlock;
+                mapStagedBlocks.emplace(nHeightBlock, *pblock);
+                LogPrint(BCLog::STAGING, "staging block %s (%d) because only have prevheader and not prev block. Need:%d\n",
+                         pblock->GetHash().ToString(), nHeightBlock, nHeightNext);
+            } else {
+                LogPrint(BCLog::STAGING, "staging area full, discarding block %s (%d)\n",
+                         pblock->GetHash().ToString(), nHeightBlock);
+            }
+        } else if (fProcessBlock) {
             bool fNewBlock = false;
             ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
             if (fNewBlock) {
@@ -4135,16 +4137,12 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
         //
         std::vector<CInv> vGetData;
         bool fRequest = true;
-        {
-            LOCK(cs_staging);
-//            if (mapStagedBlocks.size() > 50)
-//                fRequest = false;
-        }
-        int nBestHeight = 0;
-        {
-            LOCK(cs_main);
-            nBestHeight = chainActive.Height();
-        }
+//        {
+//            LOCK(cs_staging);
+////            if (mapStagedBlocks.size() > 50)
+////                fRequest = false;
+//        }
+        int nBestHeight = chainActive.Height();
 
         if (!pto->fClient && fRequest && ((fFetch && !pto->m_limited_node) /*|| !IsInitialBlockDownload()*/) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             std::vector<const CBlockIndex*> vToDownload;
@@ -4172,7 +4170,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                             fRequest = false;
                         }
                     } else {
-                        LOCK(cs_staging);
+                        //LOCK(cs_staging);
                         if (mapStagedBlocks.count(pindex->nHeight)) {
                             // If this block is already staged, dont request again
                             if (pindex->GetBlockHash() == inv.hash)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1537,7 +1537,8 @@ void ProcessStagingBatchVerify()
         if (vProofs.size() > 1) {
             if (nHighestBlockCheck > nHeightLastCheckpoint) {
                 LogPrint(BCLog::STAGING, "%s: Batch verifying %d zeroknowledge proofs\n", __func__, vProofs.size());
-                if (!libzerocoin::SerialNumberSoKProof::BatchVerify(vProofs)) {
+
+                if (!ThreadedBatchVerify(&vProofs)) {
                     fVerificationSuccess = false;
                 }
             }
@@ -1689,7 +1690,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
             headerBestNode = header;
         }
         LogPrint(BCLog::NET, "%s: Peer's best sent header=%s\n", __func__, headerBestNode.GetHash().GetHex());
-        
+
         // If we don't have the last header, then they'll have given us
         // something new (if these headers are valid).
         if (!LookupBlockIndex(hashLastBlock) || headerBestNode.hashPrevBlock == chainActive.Tip()->GetBlockHash()) {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -84,6 +84,8 @@ struct CNodeStateStats {
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 void ProcessStaging();
-void ThreadStaging();
+void ProcessStagingBatchVerify();
+void ThreadStagingBlockProcessing();
+void ThreadStagingBatchVerify();
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/test/zerocoin_zkp_tests.cpp
+++ b/src/test/zerocoin_zkp_tests.cpp
@@ -1,0 +1,575 @@
+#include "chainparams.h"
+#include "libzerocoin/ArithmeticCircuit.h"
+#include "libzerocoin/PolynomialCommitment.h"
+#include "libzerocoin/Bulletproofs.h"
+#include "libzerocoin/SerialNumberSoK_small.h"
+#include "libzerocoin/SerialNumberSignatureOfKnowledge.h"
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <time.h>
+#include <random.h>
+
+
+using namespace libzerocoin;
+
+#define COLOR_STR_NORMAL  "\033[0m"
+#define COLOR_BOLD        "\033[1m"
+#define COLOR_STR_GREEN   "\033[32m"
+#define COLOR_STR_RED     "\033[31m"
+#define COLOR_CYAN        "\033[0;36m"
+#define COLOR_MAGENTA     "\u001b[35m"
+
+std::string colorNormal(COLOR_STR_NORMAL);
+std::string colorBold(COLOR_BOLD);
+std::string colorGreen(COLOR_STR_GREEN);
+std::string colorRed(COLOR_STR_RED);
+std::string colorCyan(COLOR_CYAN);
+std::string colorMagenta(COLOR_MAGENTA);
+
+// Global test counters
+uint32_t    zNumTests        = 0;
+uint32_t    zSuccessfulTests = 0;
+
+std::string Pass(bool fReverseTest = false)
+{
+    return fReverseTest ? "[FAIL (good)]" : "[PASS]";
+}
+
+std::string Fail(bool fReverseTest = false)
+{
+    return fReverseTest ? "[PASS (when it shouldn't!)]" : "[FAIL]";
+}
+
+
+// Parameters ----------------------------------------------------------------------------------------
+
+bool Test_generators(IntegerGroupParams SoKGroup)
+{
+    zNumTests++;
+    std::cout << "- Testing generators...";
+    for(unsigned int i=0; i<512; i++) {
+        if ( SoKGroup.gis[i].pow_mod(SoKGroup.groupOrder,SoKGroup.modulus) != CBigNum(1)) {
+            std::cout << colorRed << Fail() << std::endl;
+            std::cout << "gis[" << i << "] ** q != 1" << colorNormal << std::endl;
+            return false;
+        }
+    }
+    std::cout << colorGreen << Pass() << colorNormal << std::endl;
+    zSuccessfulTests++;
+    return true;
+}
+
+
+bool parameters_tests()
+{
+    std::cout << colorBold << "*** parameters_tests ***" << std::endl;
+    std::cout << "------------------------" << colorNormal << std::endl;
+
+    bool finalResult = true;
+
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params();
+    (void)ZCParams;
+
+    finalResult = finalResult & Test_generators(ZCParams->serialNumberSoKCommitmentGroup);
+
+    std::cout << std::endl;
+
+    return finalResult;
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Arithmetic Circuit --------------------------------------------------------------------------------
+bool Test_multGates(ArithmeticCircuit ac, CBigNum q)
+{
+    zNumTests++;
+    // If multiplication gates hold this should be true
+    std::cout << "- Testing A times B equals C...";
+    for(unsigned int i=0; i<ZKP_M; i++) for(unsigned int j=0; j<ZKP_N; j++) {
+            if(ac.A[i][j].mul_mod(ac.B[i][j], q) != ac.C[i][j]) {
+                std::cout << colorRed << Fail() << std::endl;
+                std::cout << "Hadamard Test failed at i=" << i << ", j=" << j << colorNormal << std::endl;
+                return false;
+            }
+        }
+
+    std::cout << colorGreen << Pass()  << colorNormal << std::endl;
+    zSuccessfulTests++;
+    return true;
+}
+
+bool Test_cfinalLog(ArithmeticCircuit ac, CBigNum q, CBigNum a, CBigNum b, bool fReverseTest = false)
+{
+    zNumTests++;
+    // If circuit correctly evaluates (a^serial)*(b^randomness) this should be true
+    std::cout << "- Testing C_final equals Logarithm";
+    if (fReverseTest)
+        std::cout << colorMagenta << " with wrong assignment" << colorNormal;
+    std::cout << "...";
+    CBigNum logarithm =
+            a.pow_mod(ac.getSerialNumber(),q).mul_mod(
+                    b.pow_mod(ac.getRandomness(),q),q);
+    CBigNum Cfinal = ac.C[ZKP_M-1][0];
+    bool test = (logarithm == Cfinal);
+    if (test == fReverseTest) {
+        std::cout << colorRed << Fail(fReverseTest) << colorNormal << std::endl;
+        return false;
+    }
+
+    std::cout << colorGreen << Pass(fReverseTest) << colorNormal << std::endl;
+    zSuccessfulTests++;
+    return true;
+}
+
+bool Test_arithConstraints(ArithmeticCircuit ac, CBigNum q, bool fReverseTest = false)
+{
+    zNumTests++;
+    // Checking that the expressions in Equation (2) of the paper hold
+    std::cout << "- Testing the Arithmetic Constraints (eq. 2)";
+    if (fReverseTest)
+        std::cout << colorMagenta << " with wrong assignment" << colorNormal;
+    std::cout << "...";
+    bool test = true;
+    unsigned int last_index = 0;
+    for(unsigned int i=0; i<4*ZKP_SERIALSIZE-2; i++) {
+        if (ac.sumWiresDotWs(i) != ac.K[i] % q) {
+            test = false;
+            last_index = i;
+            break;
+        }
+    }
+
+    if (test == fReverseTest) {
+        std::cout << colorRed << Fail(fReverseTest) << std::endl;
+        std::cout << "Arithmetic Constraints Test failed at i=" << last_index << colorNormal << std::endl;
+        return false;
+    }
+
+    std::cout << colorGreen << Pass(fReverseTest)  << colorNormal << std::endl;
+    zSuccessfulTests++;
+    return true;
+}
+
+
+bool arithmetic_circuit_tests()
+{
+    std::cout << colorBold << "*** arithmetic_circuit_tests ***" << std::endl;
+    std::cout << "--------------------------------" << colorNormal << std::endl;
+
+    bool finalResult = true;
+
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params();
+    (void)ZCParams;
+
+    CBigNum a = ZCParams->coinCommitmentGroup.g;
+    CBigNum b = ZCParams->coinCommitmentGroup.h;
+    CBigNum q = ZCParams->serialNumberSoKCommitmentGroup.groupOrder;
+
+    // mint a coin
+    PrivateCoin coin(ZCParams, CoinDenomination::ZQ_TEN, true);
+    // get random Y
+    CBigNum Y = CBigNum::randBignum(q);
+    ArithmeticCircuit circuit(ZCParams);
+    circuit.setWireValues(coin);
+    circuit.setYPoly(Y);
+
+    finalResult = finalResult & Test_multGates(circuit, q);
+    finalResult = finalResult & Test_cfinalLog(circuit, q, a, b);
+    finalResult = finalResult & Test_arithConstraints(circuit, q);
+
+    // !TODO: rewrite this test case.
+    // Checking that the expressions in Equation (3) of the paper hold
+    // (circuit.sumWiresDotWPoly() == circuit.Kconst)
+
+    // New circuit with random assignment
+    ArithmeticCircuit newCircuit(circuit);
+    for(unsigned int i=0; i<ZKP_M; i++) {
+        random_vector_mod(newCircuit.A[i], q);
+        random_vector_mod(newCircuit.B[i], q);
+        for(unsigned int j=0; j<ZKP_N; j++)
+            newCircuit.C[i][j] = newCircuit.A[i][j].mul_mod(newCircuit.B[i][j],q);
+    }
+
+    // If circuit correctly evaluates (a^serial)*(b^randomness) we have a problem
+    finalResult = finalResult & Test_cfinalLog(newCircuit, q, a, b, true);
+
+    // Checking that the expressions in Equation (2) of the paper does not hold
+    finalResult = finalResult & Test_arithConstraints(newCircuit, q, true);
+
+    // !TODO: rewrite this test case.
+    // Checking that the expressions in Equation (3) of the does not paper hold
+
+    std::cout << std::endl;
+
+    return finalResult;
+}
+
+
+// ---------------------------------------------------------------------------------------------------
+// Polynomial Commitment -----------------------------------------------------------------------------
+
+// Evaluate tpolynomial at x
+CBigNum eval_tpoly(CBN_vector tpoly, CBN_vector xPowersPos, CBN_vector xPowersNeg, CBigNum q)
+{
+    CBigNum sum = CBigNum(0);
+    for(unsigned int i=0; i<=ZKP_NDASH*ZKP_M1DASH; i++)
+        sum = ( sum + tpoly[i].mul_mod(xPowersNeg[ZKP_NDASH*ZKP_M1DASH-i],q) ) % q;
+    for(unsigned int i=ZKP_NDASH*ZKP_M1DASH+1; i<=ZKP_NDASH*(ZKP_M1DASH+ZKP_M2DASH); i++)
+        sum = ( sum + tpoly[i].mul_mod(xPowersPos[i-ZKP_NDASH*ZKP_M1DASH],q) ) % q;
+    return sum;
+}
+
+bool Test_polyVerify1(PolynomialCommitment pc, CBigNum &val, bool fReverseTest = false)
+{
+    zNumTests++;
+    // Poly-Verify: For honest prover, verifier should be satisfied
+    std::cout << "- Testing PolyVerify";
+    if (fReverseTest)
+        std::cout << colorMagenta << " for dishonest prover" << colorNormal;
+    std::cout << "...";
+    // val = t(x) if proofs checks out
+    bool test = (pc.Verify(val));
+    if (test == fReverseTest) {
+        std::cout << colorRed << Fail(fReverseTest) << colorNormal << std::endl;
+        return false;
+    }
+
+    std::cout << colorGreen << Pass(fReverseTest)  << colorNormal << std::endl;
+    zSuccessfulTests++;
+    return true;
+}
+
+bool Test_polyVerify2(CBigNum val, CBN_vector tpoly,
+                      CBN_vector xpos, CBN_vector xneg, CBigNum q)
+{
+    zNumTests++;
+    // Poly-Verify: For honest prover, verifier is able to compute t(x)
+    std::cout << "- Testing t(x) == dotProduct(tbar,xPowersPos)...";
+    CBigNum tx = eval_tpoly(tpoly, xpos, xneg, q);
+    if (val != tx) {
+        std::cout << colorRed << Fail() << colorNormal << std::endl;
+        return false;
+    }
+
+    std::cout << colorGreen << Pass()  << colorNormal << std::endl;
+    zSuccessfulTests++;
+    return true;
+}
+
+bool polynomial_commitment_tests()
+{
+    std::cout << colorBold << "*** polynomial_commitment_tests ***" << std::endl;
+    std::cout << "-----------------------------------" << colorNormal << std::endl;
+
+    bool finalResult = true;
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params();
+    (void)ZCParams;
+
+    CBigNum q = ZCParams->serialNumberSoKCommitmentGroup.groupOrder;
+    CBigNum p = ZCParams->serialNumberSoKCommitmentGroup.modulus;
+
+    // generate a random tpolynomial with 0 constant term
+    CBN_vector tpoly(ZKP_NDASH*(ZKP_M1DASH+ZKP_M2DASH)+1);
+    for(unsigned int i=0; i<tpoly.size(); i++)
+        tpoly[i] = CBigNum::randBignum(q);
+    tpoly[ZKP_M1DASH*ZKP_NDASH] = CBigNum(0);
+
+    // generate a random evaluation point x in R and compute powers
+    CBigNum x = CBigNum::randBignum(q);
+    CBN_vector xPowersPositive(ZKP_M2DASH*ZKP_NDASH+1);
+    CBN_vector xPowersNegative(ZKP_M1DASH*ZKP_NDASH+1);
+    xPowersPositive[0] = xPowersNegative[0] = CBigNum(1);
+    xPowersPositive[1] = x;
+    xPowersNegative[1] = x.pow_mod(-1,q);
+    for(unsigned int i=2; i<ZKP_M2DASH*ZKP_NDASH+1; i++)
+        xPowersPositive[i] = x.pow_mod(i,q);
+    for(unsigned int i=2; i<ZKP_M1DASH*ZKP_NDASH+1; i++)
+        xPowersNegative[i] = x.pow_mod(-(int)i,q);
+
+    // Poly-Commit and Poly-Evaluate
+    PolynomialCommitment polyCommitment(ZCParams);
+    polyCommitment.Commit(tpoly);
+    polyCommitment.Eval(xPowersPositive, xPowersNegative);
+
+    // Polynomial  evaluation
+    CBigNum val;
+
+    finalResult = finalResult & Test_polyVerify1(polyCommitment, val);
+    finalResult = finalResult & Test_polyVerify2(val, tpoly, xPowersPositive, xPowersNegative, q);
+
+    // Create copies of the polynomial commitment and mess things up
+    PolynomialCommitment newPolyComm1(polyCommitment);
+    PolynomialCommitment newPolyComm2(polyCommitment);
+    PolynomialCommitment newPolyComm3(polyCommitment);
+    random_vector_mod(newPolyComm1.tbar, q);
+    random_vector_mod(newPolyComm2.Tf, q);
+    random_vector_mod(newPolyComm3.Trho, q);
+
+    // Poly-Verify: For dishonest prover, verifier should fail the test
+    finalResult = finalResult & Test_polyVerify1(newPolyComm1, val, true);
+    finalResult = finalResult & Test_polyVerify1(newPolyComm2, val, true);
+    finalResult = finalResult & Test_polyVerify1(newPolyComm3, val, true);
+
+    std::cout << std::endl;
+
+    return finalResult;
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Inner Product Argument ----------------------------------------------------------------------------
+
+// !TODO: Adapt to bulletproofs class
+/*
+BOOST_AUTO_TEST_CASE(inner_product_argument_tests)
+{
+    std::cout << "*** inner_product_argument_tests ***" << std::endl;
+    std::cout << "------------------------------------" << std::endl;
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params(false);
+    (void)ZCParams;
+    CBigNum q = ZCParams->serialNumberSoKCommitmentGroup.groupOrder;
+    CBigNum p = ZCParams->serialNumberSoKCommitmentGroup.modulus;
+    // Get random y in Z_q and (N+PADS)-vectors
+    CBigNum y = CBigNum::randBignum(q);
+    CBN_vector a_sets(ZKP_N+ZKP_PADS);
+    CBN_vector b_sets(ZKP_N+ZKP_PADS);
+    random_vector_mod(a_sets, q);
+    random_vector_mod(b_sets, q);
+    // Inner-product PROVE
+    InnerProductArgument innerProduct(ZCParams);
+    innerProduct.Prove(y, a_sets, b_sets);
+    // compute ck_inner sets
+    pair<CBN_vector, CBN_vector> resultSets = innerProduct.ck_inner_gen(ZCParams, y);
+    CBN_vector ck_inner_g = resultSets.first;
+    CBN_vector ck_inner_h = resultSets.second;
+    // Compute commitment A to a_sets under ck_inner_g
+    CBigNum A = CBigNum(1);
+    for(unsigned int i=0; i<a_sets.size(); i++)
+        A = A.mul_mod(ck_inner_g[i].pow_mod(a_sets[i], p), p);
+    // Compute commitment B to b_sets under ck_inner_h
+    CBigNum B = CBigNum(1);
+    for(unsigned int i=0; i<b_sets.size(); i++)
+        B = B.mul_mod(ck_inner_h[i].pow_mod(b_sets[i], p), p);
+    // Inner product z = <a,b>
+    CBigNum z = dotProduct(a_sets, b_sets, q);
+    // random_z != z
+    CBigNum random_z = CBigNum::randBignum(q);
+    while( random_z == dotProduct(a_sets, b_sets, q) ) random_z = CBigNum::randBignum(q);
+    // innerProductVerify
+    std::cout << "- Testing innerProductVerify..." << std::endl;
+    bool res = innerProduct.Verify(ZCParams, y, A, B, z);
+    BOOST_CHECK_MESSAGE(res,"InnerProduct:: Verification failed\n");
+    // Inner product z != <a, b>  (z = 0, z = 1, z = random)
+    std::cout << "- Testing innerProductVerify for dishonest prover..." << std::endl;
+    BOOST_CHECK_MESSAGE( !innerProduct.Verify(ZCParams, y, A, B, CBigNum(0)),
+            "InnerProduct:: Verification returned TRUE[1] for dishonest prover\n");
+    BOOST_CHECK_MESSAGE( !innerProduct.Verify(ZCParams, y, A, B, CBigNum(1)),
+            "InnerProduct:: Verification returned TRUE[2] for dishonest prover\n");
+    BOOST_CHECK_MESSAGE( !innerProduct.Verify(ZCParams, y, A, B, random_z),
+            "InnerProduct:: Verification returned TRUE[3] for dishonest prover\n");
+    std::cout << std::endl;
+}
+*/
+
+// ---------------------------------------------------------------------------------------------------
+// Signature Of Knowledge ----------------------------------------------------------------------------
+
+void printTime(clock_t start_time, int nProofs)
+{
+    clock_t total_time = clock() - start_time;
+    double passed = total_time*1000.0/CLOCKS_PER_SEC;
+    std::string strPerProof = std::to_string(passed/nProofs) + " msec per proof";
+    std::cout << colorCyan << "\t(" << passed << " msec " << (nProofs ? strPerProof.c_str() : "") << ")"  << colorNormal << std::endl;
+}
+
+bool Test_batchVerify(std::vector<SerialNumberSoKProof> proofs, bool fReverseTest = false)
+{
+    zNumTests++;
+    // verify the signature of the received SoKs
+    std::cout << "- Verifying the Signatures of Knowledge";
+    if (fReverseTest)
+        std::cout << colorMagenta << " for dishonest prover" << colorNormal;
+    std::cout << "...";
+
+    if (SerialNumberSoKProof::BatchVerify(proofs) == fReverseTest) {
+        std::cout << colorRed << Fail(fReverseTest) << colorNormal;
+        return false;
+    }
+
+    std::cout << colorGreen << Pass(fReverseTest) << colorNormal;
+    zSuccessfulTests++;
+    return true;
+}
+
+bool batch_signature_of_knowledge_tests(unsigned int start, unsigned int end, unsigned int step)
+{
+    if (end < start || step < 1) {
+        std::cout << "wrong range for batch_signature_of_knowledge_tests";
+        return false;
+    }
+
+    std::cout << colorBold <<  "*** batch_signature_of_knowledge_tests ***" << std::endl;
+    std::cout << "------------------------------------------" << colorNormal <<  std::endl;
+    std::cout << "starting size of the list: " << start << std::endl;
+    std::cout << "ending size of the list: " << end << std::endl;
+    std::cout << "step increment: " << step << std::endl;
+
+    bool finalResult = true;
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params();
+    (void)ZCParams;
+
+    for(unsigned int k=start; k<=end; k=k+step) {
+
+        // create k random message hashes
+        std::vector<uint256> msghashList;
+        for(unsigned int i=0; i<k; i++) {
+            CBigNum rbn = CBigNum::randBignum(256);
+            msghashList.push_back(rbn.getuint256());
+        }
+
+        // mint k coins
+        std::vector<PrivateCoin> coinList;
+        for(unsigned int i=0; i<k; i++) {
+            PrivateCoin newCoin(ZCParams, CoinDenomination::ZQ_TEN);
+            coinList.push_back(newCoin);
+        }
+
+        // commit to these coins
+        std::vector<Commitment> commitmentList;
+        for(unsigned int i=0; i<k; i++) {
+            const CBigNum newCoin_value = coinList[i].getPublicCoin().getValue();
+            Commitment commitment(&(ZCParams->serialNumberSoKCommitmentGroup), newCoin_value);
+            commitmentList.push_back(commitment);
+        }
+
+        // WRONG (random) assignments
+        // random messages
+        std::vector<uint256> msghashList2;
+        for(unsigned int i=0; i<k; i++) {
+            CBigNum rbn = CBigNum::randBignum(256);
+            msghashList2.push_back(rbn.getuint256());
+        }
+        // random coins
+        std::vector<PrivateCoin> coinList2;
+        for(unsigned int i=0; i<k; i++) {
+            PrivateCoin newCoin(ZCParams, CoinDenomination::ZQ_TEN);
+            coinList2.push_back(newCoin);
+        }
+        // commit to these coins
+        std::vector<Commitment> commitmentList2;
+        for(unsigned int i=0; i<k; i++) {
+            const CBigNum newCoin_value = coinList2[i].getPublicCoin().getValue();
+            Commitment commitment(&(ZCParams->serialNumberSoKCommitmentGroup), newCoin_value);
+            commitmentList2.push_back(commitment);
+        }
+
+
+        std::cout << "- Creating array of " << k << " Signatures of Knowledge...";
+
+        // create k signatures of knowledge
+        std::vector<SerialNumberSoK_small> sigList;
+
+        clock_t start_time = clock();
+
+        for(unsigned int i=0; i<k; i++) {
+            SerialNumberSoK_small sigOfKnowledge(ZCParams, coinList[i], commitmentList[i], msghashList[i]);
+            sigList.push_back(sigOfKnowledge);
+        }
+
+        printTime(start_time, 0);
+        start_time = clock();
+        std::cout << "- Packing and serializing the Signatures..." << std::endl;
+
+        // pack the signatures of knowledge (honest prover)
+        std::vector<SerialNumberSoKProof> proofs;
+        for(unsigned int i=0; i<k; i++) {
+            SerialNumberSoKProof proof(sigList[i], coinList[i].getSerialNumber(),
+                                       commitmentList[i].getCommitmentValue(), msghashList[i]);
+            proofs.push_back(proof);
+        }
+
+        // pack the signatures of knowledge (wrong msghash)
+        std::vector<SerialNumberSoKProof> proofs2;
+        for(unsigned int i=0; i<k; i++) {
+            SerialNumberSoKProof proof(sigList[i], coinList[i].getSerialNumber(),
+                                       commitmentList[i].getCommitmentValue(), msghashList2[i]);
+            proofs2.push_back(proof);
+        }
+
+        // pack the signatures of knowledge (wrong commitment)
+        std::vector<SerialNumberSoKProof> proofs3;
+        for(unsigned int i=0; i<k; i++) {
+            SerialNumberSoKProof proof(sigList[i], coinList[i].getSerialNumber(),
+                                       commitmentList2[i].getCommitmentValue(), msghashList[i]);
+            proofs3.push_back(proof);
+        }
+
+        // pack the signatures of knowledge (wrong coin and commitment)
+        std::vector<SerialNumberSoKProof> proofs4;
+        for(unsigned int i=0; i<k; i++) {
+            SerialNumberSoKProof proof(sigList[i], coinList2[i].getSerialNumber(),
+                                       commitmentList2[i].getCommitmentValue(), msghashList[i]);
+            proofs4.push_back(proof);
+        }
+
+        // serialize the proofs to a CDataStream object.
+        std::vector<CDataStream> serializedProofs(proofs.size(), CDataStream(SER_NETWORK, PROTOCOL_VERSION));
+        std::vector<CDataStream> serializedProofs2(proofs2.size(), CDataStream(SER_NETWORK, PROTOCOL_VERSION));
+        std::vector<CDataStream> serializedProofs3(proofs3.size(), CDataStream(SER_NETWORK, PROTOCOL_VERSION));
+        std::vector<CDataStream> serializedProofs4(proofs4.size(), CDataStream(SER_NETWORK, PROTOCOL_VERSION));
+        for(unsigned int i=0; i<serializedProofs.size(); i++) {
+            serializedProofs[i] << proofs[i];
+            serializedProofs2[i] << proofs2[i];
+            serializedProofs3[i] << proofs3[i];
+            serializedProofs4[i] << proofs4[i];
+        }
+
+        std::cout << "- Unserializing the Signatures of Knowledge..." << std::endl;
+
+        // unserialize the CDataStream object into a fresh SoK object
+        std::vector<SerialNumberSoKProof> newproofs(serializedProofs.size(), SerialNumberSoKProof(ZCParams));
+        std::vector<SerialNumberSoKProof> newproofs2(serializedProofs.size(), SerialNumberSoKProof(ZCParams));
+        std::vector<SerialNumberSoKProof> newproofs3(serializedProofs.size(), SerialNumberSoKProof(ZCParams));
+        std::vector<SerialNumberSoKProof> newproofs4(serializedProofs.size(), SerialNumberSoKProof(ZCParams));
+        for(unsigned int i=0; i<serializedProofs.size(); i++) {
+            serializedProofs[i] >> newproofs[i];
+            serializedProofs2[i] >> newproofs2[i];
+            serializedProofs3[i] >> newproofs3[i];
+            serializedProofs4[i] >> newproofs4[i];
+        }
+
+        start_time = clock();
+        finalResult = finalResult & Test_batchVerify(newproofs);
+        printTime(start_time, newproofs.size());
+        start_time = clock();
+        finalResult = finalResult & Test_batchVerify(newproofs2, true);
+        printTime(start_time, newproofs2.size());
+        start_time = clock();
+        finalResult = finalResult & Test_batchVerify(newproofs3, true);
+        printTime(start_time, newproofs3.size());
+        start_time = clock();
+        finalResult = finalResult & Test_batchVerify(newproofs4, true);
+        printTime(start_time, newproofs4.size());
+    }
+    std::cout << std::endl;
+    return finalResult;
+}
+
+
+BOOST_AUTO_TEST_SUITE(zerocoin_zkp_tests)
+
+BOOST_AUTO_TEST_CASE(bulletproofs_tests)
+{
+    std::cout << std::endl;
+    RandomInit();
+    ECC_Start();
+    BOOST_CHECK(parameters_tests());
+    BOOST_CHECK(arithmetic_circuit_tests());
+    BOOST_CHECK(polynomial_commitment_tests());
+    BOOST_CHECK(batch_signature_of_knowledge_tests(20, 20, 1));
+    std::cout << std::endl << zSuccessfulTests << " out of " << zNumTests << " tests passed." << std::endl << std::endl;
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2433,6 +2433,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!setBatchVerified.count(txid)) {
                         vTxidProofs.emplace_back(txid);
                         vProofs.emplace_back(proof);
+                    } else {
+                        LogPrint(BCLog::STAGING, "%s: skipping validating already verified proof for tx %s\n", __func__, txid.GetHex());
                     }
                 }
                 nTimeZerocoinSpendCheck += GetTimeMicros() - nTimeSpendCheck;
@@ -2575,7 +2577,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     }
 
     // Skip signature verification if it's already been done or if the block height is below a checkpoint height
-    bool fSkipSigVerify = block.fSignaturesVerified ? true : fSkipComputation;
+    bool fSkipSigVerify = fSkipComputation;
     int64_t nTimeSigVerify = GetTimeMicros();
     if (!fSkipSigVerify && !vProofs.empty()) {
         if (!libzerocoin::SerialNumberSoKProof::BatchVerify(vProofs)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2433,8 +2433,6 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!setBatchVerified.count(txid)) {
                         vTxidProofs.emplace_back(txid);
                         vProofs.emplace_back(proof);
-                    } else {
-                        LogPrint(BCLog::STAGING, "%s: skipping validating already verified proof for tx %s\n", __func__, txid.GetHex());
                     }
                 }
                 nTimeZerocoinSpendCheck += GetTimeMicros() - nTimeSpendCheck;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1103,7 +1103,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
         // Last we batch verify zerocoin spend proofs
         if (!vProofs.empty()) {
-            if (!libzerocoin::SerialNumberSoKProof::BatchVerify(vProofs)) {
+            if (!ThreadedBatchVerify(&vProofs)) {
                 return state.DoS(100, error("%s: Failed to verify zerocoinspend proofs for tx %s", __func__,
                                             tx.GetHash().GetHex()), REJECT_INVALID);
             }
@@ -2578,7 +2578,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     bool fSkipSigVerify = fSkipComputation;
     int64_t nTimeSigVerify = GetTimeMicros();
     if (!fSkipSigVerify && !vProofs.empty()) {
-        if (!libzerocoin::SerialNumberSoKProof::BatchVerify(vProofs)) {
+        if (!ThreadedBatchVerify(&vProofs)) {
             return state.DoS(100, error("%s: Failed to verify zerocoinspend proofs for block=%s height=%d", __func__,
                                         block.GetHash().GetHex(), pindex->nHeight), REJECT_INVALID);
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -83,6 +83,8 @@ static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
+/** Threads used when batch verifying zeroknowledge proofs **/
+static const int DEFAULT_BATCHVERIFY_THREADS = 2;
 /** Number of blocks that can be requested at any given time from a single peer. */
 static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */

--- a/src/veil/zerocoin/zchain.h
+++ b/src/veil/zerocoin/zchain.h
@@ -42,7 +42,7 @@ bool RemoveSerialFromDB(const CBigNum& bnSerial);
 std::string ReindexZerocoinDB();
 std::shared_ptr<libzerocoin::CoinSpend> TxInToZerocoinSpend(const CTxIn& txin);
 bool OutputToPublicCoin(const CTxOutBase* out, libzerocoin::PublicCoin& coin);
-bool ThreadedBatchVerify(const std::vector<libzerocoin::SerialNumberSoKProof>* vProofs);
+bool ThreadedBatchVerify(const std::vector<libzerocoin::SerialNumberSoKProof>* vProofs, int nThreads = -1);
 bool TxOutToPublicCoin(const CTxOut& txout, libzerocoin::PublicCoin& pubCoin);
 std::list<libzerocoin::CoinDenomination> ZerocoinSpendListFromBlock(const CBlock& block);
 

--- a/src/veil/zerocoin/zchain.h
+++ b/src/veil/zerocoin/zchain.h
@@ -42,6 +42,7 @@ bool RemoveSerialFromDB(const CBigNum& bnSerial);
 std::string ReindexZerocoinDB();
 std::shared_ptr<libzerocoin::CoinSpend> TxInToZerocoinSpend(const CTxIn& txin);
 bool OutputToPublicCoin(const CTxOutBase* out, libzerocoin::PublicCoin& coin);
+bool ThreadedBatchVerify(const std::vector<libzerocoin::SerialNumberSoKProof>* vProofs);
 bool TxOutToPublicCoin(const CTxOut& txout, libzerocoin::PublicCoin& pubCoin);
 std::list<libzerocoin::CoinDenomination> ZerocoinSpendListFromBlock(const CBlock& block);
 

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -463,7 +463,7 @@ std::set<CMintMeta> CzTracker::ListMints(bool fUnusedOnly, bool fMatureOnly, boo
         for (auto& dMint : listDeterministicDB) {
             Add(dMint);
         }
-        LogPrintf("%s: added %d dzpiv from DB\n", __func__, listDeterministicDB.size());
+        LogPrintf("%s: added %d deterministic zerocoins from DB\n", __func__, listDeterministicDB.size());
     }
 
     std::vector<CMintMeta> vOverWrite;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2453,7 +2453,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
     UniValue arr_vin(UniValue::VARR);
     for (auto txin : wtx.tx->vin) {
         UniValue obj_vin(UniValue::VOBJ);
-        bool fIsMyInput = pwallet->IsMine(txin);
+        bool fIsMyInput = pwallet->IsMine(txin, true, true);
 
         obj_vin.pushKV("from_me", fIsMyInput);
         if (txin.IsAnonInput()) {
@@ -2476,7 +2476,8 @@ static UniValue gettransaction(const JSONRPCRequest& request)
                 continue;
             }
 
-            obj_vin.pushKV("prevout", txin.prevout.ToString());
+            obj_vin.pushKV("prevout_hash", txin.prevout.hash.GetHex());
+            obj_vin.pushKV("prevout_n", (double)txin.prevout.n);
             auto nType = txPrev->vpout[txin.prevout.n]->GetType();
             if (nType == OUTPUT_STANDARD)
                 obj_vin.pushKV("type", "basecoin");


### PR DESCRIPTION
- Split block staging into two threads, one for adding blocks to the chain, the other for verifying proofs.
- Don't ask for block announcements more than three times.
- Don't process a block if it is already part of the main chain.
- Threaded batch verify. Default of 2 threads, able to be changed using `-threadbatchverify=`
- Add unit tests for batch verification of proofs.