### PR TITLE
[WIP] Add Zerocoin Precomputing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,6 +231,7 @@ BITCOIN_CORE_H = \
   wallet/feebumper.h \
   wallet/fees.h \
   wallet/init.h \
+  wallet/lrucache.h \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletbalances.h \
@@ -331,6 +332,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/feebumper.cpp \
   wallet/fees.cpp \
   wallet/init.cpp \
+  wallet/lrucache.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/rpczerocoin.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -213,6 +213,7 @@ BITCOIN_CORE_H = \
   veil/zerocoin/spendreceipt.h \
   veil/zerocoin/mintpool.h \
   veil/zerocoin/mintmeta.h \
+  veil/zerocoin/witness.h \
   veil/mnemonic/arrayslice.h \
   veil/mnemonic/dictionary.h \
   veil/mnemonic/generateseed.h \
@@ -342,6 +343,7 @@ libbitcoin_wallet_a_SOURCES = \
   veil/zerocoin/denomination_functions.cpp \
   veil/zerocoin/mintpool.cpp \
   veil/zerocoin/spendreceipt.cpp \
+  veil/zerocoin/witness.cpp \
   veil/zerocoin/zchain.cpp \
   veil/zerocoin/ztracker.cpp \
   veil/zerocoin/zwallet.cpp \

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -239,7 +239,7 @@ bool CheckZerocoinMint(const CTxOut& txout, CBigNum& bnValue, CValidationState& 
     if (!TxOutToPublicCoin(txout, pubCoin))
         return state.DoS(100, error("CheckZerocoinMint(): TxOutToPublicCoin() failed"));
 
-    if (!pubCoin.validate())
+    if (!fSkipZerocoinMintIsPrime && !pubCoin.validate())
         return state.DoS(100, error("CheckZerocoinMint() : PubCoin does not validate"));
 
     bnValue = pubCoin.getValue();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -53,6 +53,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <veil/ringct/anon.h>
+#include <veil/zerocoin/witness.h>
 #include <veil/zerocoin/zchain.h>
 
 #ifndef WIN32
@@ -286,6 +287,7 @@ void Shutdown()
         pcoinsdbview.reset();
         pblocktree.reset();
         pzerocoinDB.reset();
+        pprecomputeDB.reset();
     }
     g_wallet_init_interface.Stop();
 
@@ -1541,6 +1543,10 @@ bool AppInitMain()
                 pzerocoinDB.reset();
                 pzerocoinDB.reset(new CZerocoinDB(0, false, fReindex));
 
+                //zerocoinDB
+                pprecomputeDB.reset();
+                pprecomputeDB.reset(new CPrecomputeDB(0, false, false));
+
                 if (fReset) {
                     pblocktree->WriteReindexing(true);
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
@@ -1902,6 +1908,11 @@ bool AppInitMain()
 
             GenerateBitcoins(true, nThreads, coinbase_script);
         }
+    }
+
+    if (gArgs.GetBoolArg("-precompute", true)) {
+        // Run a thread to precompute any zPIV spends
+        threadGroup.create_thread(boost::bind(&ThreadPrecomputeSpends));
     }
 
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -55,6 +55,7 @@
 #include <veil/ringct/anon.h>
 #include <veil/zerocoin/witness.h>
 #include <veil/zerocoin/zchain.h>
+#include <wallet/wallet.h>
 
 #ifndef WIN32
 #include <signal.h>
@@ -249,6 +250,9 @@ void Shutdown()
     if (g_is_mempool_loaded && gArgs.GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool();
     }
+
+    // Try to dump the precomputes on shutdown
+    DumpPrecomputes();
 
     if (fFeeEstimatesInitialized)
     {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -121,6 +121,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::ZEROCOINDB, "zerocoindb"},
     {BCLog::BLOCKCREATION, "blockcreation"},
+    {BCLog::PRECOMPUTE, "precompute"},
     {BCLog::CHAINSCORE, "chainscore"},
     {BCLog::STAGING, "staging"},
     {BCLog::ALL, "1"},

--- a/src/logging.h
+++ b/src/logging.h
@@ -55,8 +55,9 @@ namespace BCLog {
         LEVELDB     = (1 << 20),
         ZEROCOINDB  = (1 << 21),
         BLOCKCREATION = (1 << 22),
-        CHAINSCORE = (1 << 23),
-        STAGING     = (1 << 24),
+        PRECOMPUTE = (1 << 23),
+        CHAINSCORE = (1 << 24),
+        STAGING     = (1 << 25),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -471,7 +471,7 @@ UniValue clearspendcache(const JSONRPCRequest& request)
     {
         int nTries = 0;
         while (nTries < 100) {
-            TRY_LOCK(zTracker->cs_spendcache, fLocked);
+            TRY_LOCK(zTracker->cs_modify_lock, fLocked);
             if (fLocked) {
                 if (zTracker->ClearSpendCache()) {
                     fClearSpendCache = true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -262,6 +262,8 @@ bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
 unsigned int nStakeMinAge = 60;
 static bool fVerifyingDB = false;
 
+bool fClearSpendCache = false;
+
 
 uint256 hashAssumeValid;
 arith_uint256 nMinimumChainWork;
@@ -326,6 +328,7 @@ std::unique_ptr<CCoinsViewDB> pcoinsdbview;
 std::unique_ptr<CCoinsViewCache> pcoinsTip;
 std::unique_ptr<CBlockTreeDB> pblocktree;
 std::unique_ptr<CZerocoinDB> pzerocoinDB;
+std::unique_ptr<CPrecomputeDB> pprecomputeDB;
 
 enum class FlushStateMode {
     NONE,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2145,7 +2145,9 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     bool fSkipComputation = false;
     int nHeightLastCheckpoint = Checkpoints::GetLastCheckpointHeight(chainparams.Checkpoints());
-    if (pindex->nHeight < nHeightLastCheckpoint)
+    if (pindex->nHeight < nHeightLastCheckpoint || fReindex)
+        fSkipComputation = true;
+    if (pindex->GetBlockTime() < GetAdjustedTime() - 24*60*60)
         fSkipComputation = true;
 
     // Check it again in case a previous version let a bad block in
@@ -3329,6 +3331,7 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
                     return false;
                 }
             } else {
+                LogPrintf("%s:%d\n", __func__, __LINE__);
                 PruneBlockIndexCandidates();
                 if (!pindexOldTip || chainActive.Tip()->nChainWork > pindexOldTip->nChainWork) {
                     // We're in a better position than we were. Return temporarily to release the lock.
@@ -3511,6 +3514,7 @@ bool CChainState::PreciousBlock(CValidationState& state, const CChainParams& par
         }
         if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && pindex->nChainTx) {
             setBlockIndexCandidates.insert(pindex);
+            LogPrintf("%s:%d\n", __func__, __LINE__);
             PruneBlockIndexCandidates();
         }
     }
@@ -4487,6 +4491,8 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
 
     int nHeightLastCheckpoint = Checkpoints::GetLastCheckpointHeight(chainparams.Checkpoints());
     bool fSkipComputation = pindex->nHeight < nHeightLastCheckpoint;
+    if (pindex->GetBlockTime() < GetAdjustedTime() - 24*60*60)
+        fSkipComputation = true;
     if (!CheckBlock(block, state, chainparams.GetConsensus(), fSkipComputation) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
@@ -4941,12 +4947,13 @@ bool LoadChainTip(const CChainParams& chainparams)
     }
     chainActive.SetTip(pindex);
 
-    g_chainstate.PruneBlockIndexCandidates();
+
 
     LogPrintf("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f\n",
         chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
         FormatISO8601DateTime(chainActive.Tip()->GetBlockTime()),
         GuessVerificationProgress(chainparams.TxData(), chainActive.Tip()));
+    g_chainstate.PruneBlockIndexCandidates();
     return true;
 }
 
@@ -5257,6 +5264,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
     if (chainActive.Tip() != nullptr) {
         // We can't prune block index candidates based on our tip if we have
         // no tip due to chainActive being empty!
+        LogPrintf("%s:%d\n", __func__, __LINE__);
         PruneBlockIndexCandidates();
 
         CheckBlockIndex(params.GetConsensus());

--- a/src/validation.h
+++ b/src/validation.h
@@ -43,7 +43,9 @@ class CScriptCheck;
 class CBlockPolicyEstimator;
 class CTxMemPool;
 class CValidationState;
+class CPrecomputeDB;
 struct ChainTxData;
+
 
 struct PrecomputedTransactionData;
 struct LockPoints;
@@ -217,6 +219,12 @@ static const unsigned int DEFAULT_CHECKLEVEL = 4;
 // one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
+
+/** Veil zerocoin precomputing variables */
+extern bool fClearSpendCache;
+static const int DEFAULT_PRECOMPUTE_LENGTH = 1000;
+static const int MIN_PRECOMPUTE_LENGTH = 500;
+static const int MAX_PRECOMPUTE_LENGTH = 2000;
 
 /**
  * Process an incoming block. This only returns after the best known valid
@@ -495,6 +503,9 @@ extern std::unique_ptr<CBlockTreeDB> pblocktree;
 
 /** Global variable that points to the active zerocoin database (protected by cs_main) */
 extern std::unique_ptr<CZerocoinDB> pzerocoinDB;
+
+/** Global variable that points to the active percompute database (protected by cs_main) */
+extern std::unique_ptr<CPrecomputeDB> pprecomputeDB;
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().

--- a/src/veil/proofofstake/stakeinput.h
+++ b/src/veil/proofofstake/stakeinput.h
@@ -69,6 +69,7 @@ public:
     int GetChecksumHeightFromMint();
     int GetChecksumHeightFromSpend();
     uint256 GetChecksum();
+    uint256 GetSerialHash();
 
     static int HeightToModifierHeight(int nHeight);
 };

--- a/src/veil/proofofstake/stakeinput.h
+++ b/src/veil/proofofstake/stakeinput.h
@@ -44,13 +44,13 @@ class ZerocoinStake : public CStakeInput
 private:
     uint256 nChecksum;
     bool fMint;
-    uint256 hashSerial;
+    uint256 hashStake;
 
 public:
-    explicit ZerocoinStake(libzerocoin::CoinDenomination denom, const uint256& hashSerial)
+    explicit ZerocoinStake(libzerocoin::CoinDenomination denom, const uint256& hashStake)
     {
         this->denom = denom;
-        this->hashSerial = hashSerial;
+        this->hashStake = hashStake;
         this->pindexFrom = nullptr;
         fMint = true;
     }
@@ -69,7 +69,7 @@ public:
     int GetChecksumHeightFromMint();
     int GetChecksumHeightFromSpend();
     uint256 GetChecksum();
-    uint256 GetSerialHash();
+    uint256 GetSerialStakeHash();
 
     static int HeightToModifierHeight(int nHeight);
 };

--- a/src/veil/zerocoin/accumulatormap.cpp
+++ b/src/veil/zerocoin/accumulatormap.cpp
@@ -75,6 +75,11 @@ bool AccumulatorMap::Accumulate(const PublicCoin& pubCoin, bool fSkipValidation)
     return mapAccumulators.at(denom)->accumulate(pubCoin);
 }
 
+libzerocoin::Accumulator AccumulatorMap::GetAccumulator(libzerocoin::CoinDenomination denom)
+{
+    return libzerocoin::Accumulator(params, denom, GetValue(denom));
+}
+
 //Get the value of a specific accumulator
 CBigNum AccumulatorMap::GetValue(CoinDenomination denom)
 {

--- a/src/veil/zerocoin/accumulatormap.h
+++ b/src/veil/zerocoin/accumulatormap.h
@@ -20,6 +20,7 @@ public:
     explicit AccumulatorMap(libzerocoin::ZerocoinParams* params);
     bool Load(const std::map<libzerocoin::CoinDenomination, uint256>& mapCheckpoints);
     bool Accumulate(const libzerocoin::PublicCoin& pubCoin, bool fSkipValidation = false);
+    libzerocoin::Accumulator GetAccumulator(libzerocoin::CoinDenomination denom);
     CBigNum GetValue(libzerocoin::CoinDenomination denom);
     std::map<libzerocoin::CoinDenomination, uint256> GetCheckpoints(bool fShowZeroIfEmpty = false);
     void Reset();

--- a/src/veil/zerocoin/accumulators.h
+++ b/src/veil/zerocoin/accumulators.h
@@ -14,9 +14,10 @@
 #include "arith_uint256.h"
 
 class CBlockIndex;
+class CoinWitnessData;
 
 std::map<libzerocoin::CoinDenomination, int> GetMintMaturityHeight();
-bool GenerateAccumulatorWitness(const libzerocoin::PublicCoin &coin, libzerocoin::Accumulator& accumulator, libzerocoin::AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, std::string& strError, CBlockIndex* pindexCheckpoint = nullptr);
+bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& mapAccumulators, int nSecurityLevel, std::string& strError, CBlockIndex* pindexCheckpoint = nullptr);
 bool GetAccumulatorValueFromDB(uint256 nCheckpoint, libzerocoin::CoinDenomination denom, CBigNum& bnAccValue);
 bool GetAccumulatorValueFromChecksum(const uint256& hashChecksum, bool fMemoryOnly, CBigNum& bnAccValue);
 void AddAccumulatorChecksum(const uint256 nChecksum, const CBigNum &bnValue, bool fMemoryOnly);
@@ -27,5 +28,6 @@ bool EraseAccumulatorValues(const uint256& nCheckpointErase, const uint256& nChe
 uint256 GetChecksum(const CBigNum &bnValue);
 int GetChecksumHeight(uint256 nChecksum, libzerocoin::CoinDenomination denomination);
 bool ValidateAccumulatorCheckpoint(const CBlock& block, CBlockIndex* pindex, AccumulatorMap& mapAccumulators);
+void AccumulateRange(CoinWitnessData* coinWitness, int nHeightEnd);
 
 #endif //PIVX_ACCUMULATORS_H

--- a/src/veil/zerocoin/witness.cpp
+++ b/src/veil/zerocoin/witness.cpp
@@ -1,0 +1,189 @@
+#include <chainparams.h>
+#include <tinyformat.h>
+#include "witness.h"
+#include <util.h>
+#include <wallet/walletutil.h>
+#include <wallet/walletdb.h>
+
+void CoinWitnessData::SetNull()
+{
+    coin = nullptr;
+    pAccumulator = nullptr;
+    pWitness = nullptr;
+    nMintsAdded = 0;
+    nHeightMintAdded = 0;
+    nHeightCheckpoint = 0;
+    nHeightAccStart = 0;
+    nHeightAccEnd = 0;
+}
+
+CoinWitnessData::CoinWitnessData()
+{
+    SetNull();
+}
+
+std::string CoinWitnessData::ToString()
+{
+    return strprintf("Mints Added: %d\n"
+            "Height Mint added: %d\n"
+            "Height Checkpoint: %d\n"
+            "Height Acc Start: %d\n"
+            "Height Acc End: %d\n"
+            "Amount: %s\n"
+            "Demon: %d\n", nMintsAdded, nHeightMintAdded, nHeightCheckpoint, nHeightAccStart, nHeightAccEnd, coin->getValue().GetHex(), coin->getDenomination());
+}
+
+CoinWitnessData::CoinWitnessData(CZerocoinMint& mint)
+{
+    SetNull();
+    denom = mint.GetDenomination();
+    libzerocoin::ZerocoinParams* paramsCoin = Params().Zerocoin_Params();
+    coin = std::unique_ptr<libzerocoin::PublicCoin>(new libzerocoin::PublicCoin(paramsCoin, mint.GetValue(), denom));
+    libzerocoin::Accumulator accumulator1(Params().Zerocoin_Params(), denom);
+    pWitness = std::unique_ptr<libzerocoin::AccumulatorWitness>(new libzerocoin::AccumulatorWitness(Params().Zerocoin_Params(), accumulator1, *coin));
+    nHeightAccStart = mint.GetHeight();
+}
+
+CoinWitnessData::CoinWitnessData(CoinWitnessCacheData& data)
+{
+    SetNull();
+    denom = data.denom;
+    libzerocoin::ZerocoinParams* paramsCoin = Params().Zerocoin_Params();
+    coin = std::unique_ptr<libzerocoin::PublicCoin>(new libzerocoin::PublicCoin(paramsCoin, data.coinAmount, data.coinDenom));
+    pAccumulator = std::unique_ptr<libzerocoin::Accumulator>(new libzerocoin::Accumulator(Params().Zerocoin_Params(), denom, data.accumulatorAmount));
+    pWitness = std::unique_ptr<libzerocoin::AccumulatorWitness>(new libzerocoin::AccumulatorWitness(Params().Zerocoin_Params(), *pAccumulator, *coin));
+    nMintsAdded = data.nMintsAdded;
+    nHeightMintAdded = data.nHeightMintAdded;
+    nHeightCheckpoint = data.nHeightCheckpoint;
+    nHeightAccStart = data.nHeightAccStart;
+    nHeightAccEnd = data.nHeightAccEnd;
+    txid = data.txid;
+}
+
+void CoinWitnessData::SetHeightMintAdded(int nHeight)
+{
+    nHeightMintAdded = nHeight;
+    nHeightCheckpoint = nHeight + (10 - (nHeight % 10));
+    nHeightAccStart = nHeight - (nHeight % 10);
+}
+
+
+
+void CoinWitnessCacheData::SetNull()
+{
+    nMintsAdded = 0;
+    nHeightMintAdded = 0;
+    nHeightCheckpoint = 0;
+    nHeightAccStart = 0;
+    nHeightAccEnd = 0;
+    coinAmount = CBigNum(0);
+    coinDenom = libzerocoin::CoinDenomination::ZQ_ERROR;
+    accumulatorAmount = CBigNum(0);
+    accumulatorDenom = libzerocoin::CoinDenomination::ZQ_ERROR;
+
+}
+
+CoinWitnessCacheData::CoinWitnessCacheData()
+{
+    SetNull();
+}
+
+CoinWitnessCacheData::CoinWitnessCacheData(CoinWitnessData* coinWitnessData)
+{
+    SetNull();
+    denom = coinWitnessData->denom;
+    txid = coinWitnessData->txid;
+    nMintsAdded = coinWitnessData->nMintsAdded;
+    nHeightMintAdded = coinWitnessData->nHeightMintAdded;
+    nHeightCheckpoint = coinWitnessData->nHeightCheckpoint;
+    nHeightAccStart = coinWitnessData->nHeightAccStart;
+    nHeightAccEnd = coinWitnessData->nHeightAccEnd;
+    coinAmount = coinWitnessData->coin->getValue();
+    coinDenom = coinWitnessData->coin->getDenomination();
+    accumulatorAmount = coinWitnessData->pAccumulator->getValue();
+    accumulatorDenom = coinWitnessData->pAccumulator->getDenomination();
+}
+
+CPrecomputeDB::CPrecomputeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetWalletDir() / "precomputes", nCacheSize, fMemory, fWipe)
+{
+}
+
+bool CPrecomputeDB::LoadPrecomputes(std::list<std::pair<uint256, CoinWitnessCacheData> >& itemList, std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator>& itemMap)
+{
+
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+
+    char type = 'P';
+    pcursor->Seek(std::make_pair(type, uint256()));
+
+    std::pair<unsigned char, uint256> key;
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+
+        if (pcursor->GetKey(key) && key.first == type) {
+
+            CoinWitnessCacheData data;
+            if (!pcursor->GetValue(data)) {
+                return error("%s: cannot parse CCoins record", __func__);
+            }
+
+            itemList.push_front(std::make_pair(key.second, data));
+            itemMap.insert(make_pair(key.second, itemList.begin()));
+
+            if (itemMap.size() == PRECOMPUTE_LRU_CACHE_SIZE)
+                break;
+
+            pcursor->Next();
+        } else {
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool CPrecomputeDB::LoadPrecomputes(std::set<uint256> setHashes)
+{
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+
+    char type = 'P';
+    pcursor->Seek(std::make_pair(type, uint256()));
+
+    std::pair<unsigned char, uint256> key;
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+
+        if (pcursor->GetKey(key) && key.first == type) {
+            setHashes.insert(key.second);
+            pcursor->Next();
+        } else {
+            break;
+        }
+
+    }
+
+    return true;
+}
+
+void CPrecomputeDB::EraseAllPrecomputes()
+{
+    std::set<uint256> setHashes;
+    LoadPrecomputes(setHashes);
+
+    for (auto hash : setHashes)
+        ErasePrecompute(hash);
+}
+
+bool CPrecomputeDB::WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data)
+{
+    return Write(std::make_pair('P', hash), data);
+}
+bool CPrecomputeDB::ReadPrecompute(const uint256& hash, CoinWitnessCacheData& data)
+{
+    return Read(std::make_pair('P', hash), data);
+}
+bool CPrecomputeDB::ErasePrecompute(const uint256& hash)
+{
+    return Erase(std::make_pair('P', hash));
+}
+

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -1,0 +1,96 @@
+#ifndef VEIL_WITNESS_H
+#define VEIL_WITNESS_H
+
+
+#include <libzerocoin/Accumulator.h>
+#include <libzerocoin/Coin.h>
+#include "primitives/zerocoin.h"
+#include "serialize.h"
+#include <dbwrapper.h>
+
+#define PRECOMPUTE_LRU_CACHE_SIZE 1000
+#define PRECOMPUTE_MAX_DIRTY_CACHE_SIZE 100
+#define PRECOMPUTE_FLUSH_TIME 300 // 5 minutes
+
+class CoinWitnessCacheData;
+
+class CoinWitnessData
+{
+public:
+    std::unique_ptr<libzerocoin::PublicCoin> coin;
+    std::unique_ptr<libzerocoin::Accumulator> pAccumulator;
+    std::unique_ptr<libzerocoin::AccumulatorWitness> pWitness;
+    libzerocoin::CoinDenomination denom;
+    int nHeightCheckpoint;
+    int nHeightMintAdded;
+    int nHeightAccStart;
+    int nHeightAccEnd;
+    int nMintsAdded;
+    uint256 txid;
+
+    CoinWitnessData();
+    CoinWitnessData(CZerocoinMint& mint);
+    CoinWitnessData(CoinWitnessCacheData& data);
+    void SetHeightMintAdded(int nHeight);
+    void SetNull();
+    std::string ToString();
+};
+
+class CoinWitnessCacheData
+{
+public:
+    libzerocoin::CoinDenomination denom;
+    int nHeightCheckpoint;
+    int nHeightMintAdded;
+    int nHeightAccStart;
+    int nHeightAccEnd;
+    int nMintsAdded;
+    uint256 txid;
+    CBigNum coinAmount;
+    libzerocoin::CoinDenomination coinDenom;
+    CBigNum accumulatorAmount;
+    libzerocoin::CoinDenomination accumulatorDenom;
+
+    CoinWitnessCacheData();
+    CoinWitnessCacheData(CoinWitnessData* coinWitnessData);
+    void SetNull();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(denom);
+        READWRITE(nHeightCheckpoint);
+        READWRITE(nHeightMintAdded);
+        READWRITE(nHeightAccStart);
+        READWRITE(nHeightAccEnd);
+        READWRITE(nMintsAdded);
+        READWRITE(txid);
+        READWRITE(coinAmount); // used to create the PublicCoin
+        READWRITE(coinDenom);
+        READWRITE(accumulatorAmount); // used to create the pAccumulator
+        READWRITE(accumulatorDenom);
+    };
+};
+
+/** Precompute database (precomputes/) */
+class CPrecomputeDB : public CDBWrapper
+{
+public:
+    explicit CPrecomputeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+
+private:
+    CPrecomputeDB(const CPrecomputeDB&);
+    void operator=(const CPrecomputeDB&);
+
+public:
+    /** Veil zerocoin precompute database functions */
+    bool LoadPrecomputes(std::list<std::pair<uint256, CoinWitnessCacheData> >& itemList, std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator>& itemMap);
+    bool LoadPrecomputes(std::set<uint256> setHashes);
+    void EraseAllPrecomputes();
+    bool WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data);
+    bool ReadPrecompute(const uint256& hash, CoinWitnessCacheData& data);
+    bool ErasePrecompute(const uint256& hash);
+};
+#endif //VEIL_WITNESS_H

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -8,9 +8,13 @@
 #include "serialize.h"
 #include <dbwrapper.h>
 
-#define PRECOMPUTE_LRU_CACHE_SIZE 1000
-#define PRECOMPUTE_MAX_DIRTY_CACHE_SIZE 100
-#define PRECOMPUTE_FLUSH_TIME 300 // 5 minutes
+// The number of items allows in the precompute LRU cache, if the LRU cache gets bigger than this, they are removed from the LRU cache and placed in the
+// dirty map, which holds the PRECOMPUTE_MAX_DIRTY_CACHE_SIZE amount
+#define PRECOMPUTE_LRU_CACHE_SIZE 2000
+// This number represents how many items from the precompute LRU cache is held in memory before a database write is executed
+#define PRECOMPUTE_MAX_DIRTY_CACHE_SIZE 1000
+// How often precomputes will flush to database
+#define PRECOMPUTE_FLUSH_TIME 900 // 15 minutes
 
 class CoinWitnessCacheData;
 

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -17,6 +17,7 @@
 #define PRECOMPUTE_FLUSH_TIME 900 // 15 minutes
 
 class CoinWitnessCacheData;
+class LRUCache;
 
 class CoinWitnessData
 {
@@ -28,13 +29,16 @@ public:
     int nHeightCheckpoint;
     int nHeightMintAdded;
     int nHeightAccStart;
-    int nHeightAccEnd;
+    int nHeightPrecomputed;
     int nMintsAdded;
     uint256 txid;
+    mutable CCriticalSection cs;
 
     CoinWitnessData();
     CoinWitnessData(CZerocoinMint& mint);
     CoinWitnessData(CoinWitnessCacheData& data);
+    CoinWitnessData(const CoinWitnessData& other);
+    CoinWitnessData& operator=(const CoinWitnessData& other);
     void SetHeightMintAdded(int nHeight);
     void SetNull();
     std::string ToString();
@@ -47,7 +51,7 @@ public:
     int nHeightCheckpoint;
     int nHeightMintAdded;
     int nHeightAccStart;
-    int nHeightAccEnd;
+    int nHeightPrecomputed;
     int nMintsAdded;
     uint256 txid;
     CBigNum coinAmount;
@@ -68,7 +72,7 @@ public:
         READWRITE(nHeightCheckpoint);
         READWRITE(nHeightMintAdded);
         READWRITE(nHeightAccStart);
-        READWRITE(nHeightAccEnd);
+        READWRITE(nHeightPrecomputed);
         READWRITE(nMintsAdded);
         READWRITE(txid);
         READWRITE(coinAmount); // used to create the PublicCoin
@@ -90,7 +94,7 @@ private:
 
 public:
     /** Veil zerocoin precompute database functions */
-    bool LoadPrecomputes(std::list<std::pair<uint256, CoinWitnessCacheData> >& itemList, std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator>& itemMap);
+    bool LoadPrecomputes(LRUCache* lru);
     bool LoadPrecomputes(std::set<uint256> setHashes);
     void EraseAllPrecomputes();
     bool WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data);

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -528,6 +528,30 @@ std::set<CMintMeta> CzTracker::ListMints(bool fUnusedOnly, bool fMatureOnly, boo
     return setMints;
 }
 
+
+CoinWitnessData* CzTracker::GetSpendCache(const uint256& hashStake)
+{
+    AssertLockHeld(cs_spendcache);
+    if (!mapStakeCache.count(hashStake)) {
+        std::unique_ptr<CoinWitnessData> uptr(new CoinWitnessData());
+        mapStakeCache.insert(std::make_pair(hashStake, std::move(uptr)));
+        return mapStakeCache.at(hashStake).get();
+    }
+
+    return mapStakeCache.at(hashStake).get();
+}
+
+bool CzTracker::ClearSpendCache()
+{
+    AssertLockHeld(cs_spendcache);
+    if (!mapStakeCache.empty()) {
+        mapStakeCache.clear();
+        return true;
+    }
+
+    return false;
+}
+
 void CzTracker::Clear()
 {
     mapSerialHashes.clear();

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -8,6 +8,7 @@
 #include "primitives/zerocoin.h"
 #include "wallet/walletdb.h"
 #include <list>
+#include "veil/zerocoin/witness.h"
 
 class CDeterministicMint;
 class CWallet;
@@ -24,6 +25,7 @@ private:
     std::map<SerialHash, CMintMeta> mapSerialHashes;
     std::map<SerialHash, uint256> mapPendingSpends; //serialhash, txid of spend
     std::map<PubCoinHash, SerialHash> mapHashPubCoin;
+    std::map<SerialHash, std::unique_ptr<CoinWitnessData> > mapStakeCache; //serialhash, witness value, height
     bool UpdateStatusInternal(const std::set<uint256>& setMempoolTx, const std::map<uint256, uint256>& mapMempoolSerials, CMintMeta& mint);
 public:
     CzTracker(CWallet* wallet);
@@ -53,6 +55,9 @@ public:
     bool UpdateZerocoinMint(const CZerocoinMint& mint);
     bool UpdateState(const CMintMeta& meta);
     void Clear();
+    mutable CCriticalSection cs_spendcache;
+    CoinWitnessData* GetSpendCache(const uint256& hashStake) EXCLUSIVE_LOCKS_REQUIRED(cs_spendcache);
+    bool ClearSpendCache() EXCLUSIVE_LOCKS_REQUIRED(cs_spendcache);
 
     static uint8_t GetMintMemFlags(const CMintMeta& mint, int nBestHeight, const std::map<libzerocoin::CoinDenomination, int>& mapMaturity);
 };

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -60,6 +60,9 @@ void WalletInit::AddWalletOptions() const
 
     gArgs.AddArg("-gen=<n>", strprintf("Enable CPU mining to true on the given number of threads (default: %u)", 0), false, OptionsCategory::WALLET);
     gArgs.AddArg("-genoverride", strprintf("Allows you to override the IsInitialBlockDownload check in BitcoinMiner for PoW mining (default: %u)", false), false, OptionsCategory::HIDDEN);
+
+    gArgs.AddArg("-precompute=<n>", strprintf(_("Enable precomputation of zerocoin spends and stakes (0-1, default %u)"), 1), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-precomputecachelength=<n>", strprintf(_("Set the number of included blocks to precompute per cycle. (minimum: %d) (maximum: %d) (default: %d)"), MIN_PRECOMPUTE_LENGTH, MAX_PRECOMPUTE_LENGTH, DEFAULT_PRECOMPUTE_LENGTH), false, OptionsCategory::WALLET);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/lrucache.cpp
+++ b/src/wallet/lrucache.cpp
@@ -1,0 +1,112 @@
+#include "lrucache.h"
+
+LRUCache::LRUCache()
+{
+    Clear();
+}
+
+void LRUCache::Clear()
+{
+    cache_list.clear();
+    mapCacheLocation.clear();
+    mapDirtyWitnessData.clear();
+}
+
+void LRUCache::AddNew(const uint256& hash, CoinWitnessCacheData& data)
+{
+    cache_list.push_front(std::make_pair(hash, data));
+    mapCacheLocation.insert(make_pair(hash, cache_list.begin()));
+    MoveLastToDirtyIfFull();
+    //Remove from dirty cache in case it is there
+    mapDirtyWitnessData.erase(hash);
+}
+
+int LRUCache::Size() const
+{
+    return mapCacheLocation.size();
+}
+
+int LRUCache::DirtySize() const
+{
+    return mapDirtyWitnessData.size();
+}
+
+bool LRUCache::Contains(const uint256& hash) const
+{
+    return mapCacheLocation.count(hash) > 0 || mapDirtyWitnessData.count(hash) > 0;
+}
+
+void LRUCache::MoveDirtyToLRU(const uint256& hash)
+{
+    auto data = CoinWitnessData(mapDirtyWitnessData.at(hash));
+    auto cachedata = CoinWitnessCacheData(&data);
+    AddNew(hash, cachedata);
+}
+
+void LRUCache::MoveLastToDirtyIfFull()
+{
+    if (mapCacheLocation.size() > PRECOMPUTE_LRU_CACHE_SIZE) {
+        auto last_it = cache_list.end(); last_it --;
+        mapCacheLocation.erase(last_it->first);
+        CoinWitnessCacheData removedData = cache_list.back().second;
+        mapDirtyWitnessData[cache_list.back().first] = removedData;
+        cache_list.pop_back();
+    }
+}
+
+CoinWitnessData LRUCache::GetWitnessData(const uint256& hash)
+{
+    if (mapDirtyWitnessData.count(hash)) {
+        MoveDirtyToLRU(hash);
+    }
+
+    auto it = mapCacheLocation.find(hash);
+    if (it != mapCacheLocation.end()) {
+        // Get the witness data from the cache
+        cache_list.splice(cache_list.begin(), cache_list, it->second);
+        return CoinWitnessData(it->second->second);
+    }
+
+    return CoinWitnessData();
+}
+
+void LRUCache::Remove(const uint256& hash)
+{
+    auto it = mapCacheLocation.find(hash);
+    if (it != mapCacheLocation.end()) {
+        cache_list.erase(it->second);
+        mapCacheLocation.erase(it);
+    }
+    mapDirtyWitnessData.erase(hash);
+}
+
+void LRUCache::AddToCache(const uint256& hash, CoinWitnessCacheData& serialData)
+{
+    // If the LRU cache already has a entry for it, update the entry and move it to the front of the list
+    auto it = mapCacheLocation.find(hash);
+    if (it != mapCacheLocation.end()) {
+        cache_list.splice(cache_list.begin(), cache_list, it->second);
+        cache_list.begin()->second = serialData;
+    } else {
+        AddNew(hash, serialData);
+    }
+
+    // We just added a new hash into our LRU cache, so remove it if we also have it in the dirty map
+    mapDirtyWitnessData.erase(hash);
+    MoveLastToDirtyIfFull();
+}
+
+void LRUCache::FlushToDisk(CPrecomputeDB* pprecomputeDB)
+{
+    // Save all cache data that was dirty back into the database
+    for (auto item : mapDirtyWitnessData) {
+        pprecomputeDB->WritePrecompute(item.first, item.second);
+    }
+
+    mapDirtyWitnessData.clear();
+
+    // Save the LRU cache data into the database
+    for (auto item : cache_list) {
+        pprecomputeDB->WritePrecompute(item.first, item.second);
+    }
+}

--- a/src/wallet/lrucache.h
+++ b/src/wallet/lrucache.h
@@ -1,0 +1,28 @@
+#ifndef VEIL_LRUCACHE_H
+#define VEIL_LRUCACHE_H
+
+#include <veil/zerocoin/witness.h>
+
+class LRUCache
+{
+private:
+    std::list<std::pair<uint256, CoinWitnessCacheData> > cache_list;
+    std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator> mapCacheLocation;
+    std::map<uint256, CoinWitnessCacheData> mapDirtyWitnessData;
+
+public:
+    void AddNew(const uint256& hash, CoinWitnessCacheData& data);
+    void AddToCache(const uint256& hash, CoinWitnessCacheData& serialData);
+    bool Contains(const uint256& hash) const;
+    void Clear();
+    void FlushToDisk(CPrecomputeDB* pprecomputeDB);
+    CoinWitnessData GetWitnessData(const uint256& hash);
+    LRUCache();
+    void MoveDirtyToLRU(const uint256& hash);
+    void MoveLastToDirtyIfFull();
+    void Remove(const uint256& hash);
+    int Size() const;
+    int DirtySize() const;
+};
+
+#endif //VEIL_LRUCACHE_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1348,6 +1348,9 @@ public:
     };
 };
 
+// Triggers the precomputes caches to write to database
+void DumpPrecomputes();
+
 /** A key allocated from the key pool. */
 class CReserveKey final : public CReserveScript
 {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -16,6 +16,7 @@
 #include <utiltime.h>
 #include <wallet/wallet.h>
 #include <wallet/deterministicmint.h>
+#include "veil/zerocoin/witness.h"
 
 #include <atomic>
 #include <string>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -43,6 +43,7 @@ class uint256;
 class CDeterministicMint;
 class CZerocoinMint;
 class CZerocoinSpend;
+class CoinWitnessCacheData;
 
 /** Backend-agnostic database type. */
 using WalletDatabase = BerkeleyDatabase;
@@ -280,6 +281,7 @@ public:
     bool ReadZCount(uint32_t &nCount);
     std::map<CKeyID, std::vector<std::pair<uint256, uint32_t> > > MapMintPool();
     bool WriteMintPoolPair(const CKeyID& hashMasterSeed, const uint256& hashPubcoin, const uint32_t& nCount);
+
 protected:
     BerkeleyBatch m_batch;
     WalletDatabase& m_database;


### PR DESCRIPTION
- Precomputing is enabled by **default**
- Precomputing is used to make spending zerocoin smoother and quicker
- Precomputing should decrease orphan rate of stakes by making spends take less time
- You can disable precomputing by passing **-precompute=0** as a startup flag or by putting it in the veil.conf
- Precomputing uses it own database which can be cleared manually by deleting the database file in the data directory. Or by using the rpc call **clearspendcache**
- You can view the precomputing percentages by using the rpc call **showspendcaching**
**Update: Use this branch at your own will. This branch is currently being tested, and is not fully supported by the Dev Team yet**