### PR TITLE
[Wallet] Refactor zerocoin mints collection before spending

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6248,8 +6248,8 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
                 return false;
             }
 
-            if (nChange > 0 && !address) {
-                receipt.SetStatus("Need address because change is not exact", nStatus);
+            if (!address) {
+                receipt.SetStatus("No address provided", nStatus);
                 return false;
             }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -808,6 +808,7 @@ public:
 
     // Zerocoin
     bool MintableCoins();
+    bool CollectMintsForSpend(CAmount nValue, std::vector<CZerocoinMint>& vMints, CZerocoinSpendReceipt& receipt, int nStatus, bool fMinimizeChange, libzerocoin::CoinDenomination denomFilter);
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, std::vector<CDeterministicMint>& vDMints,
             CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, std::vector<CTempRecipient>& vecSend, OutputTypes inputtype, const CCoinControl* coinControl = NULL,
             const bool isZCSpendChange = false);


### PR DESCRIPTION
The wallet was scanned for zerocoin spend inputs both in `SpendZerocoin` and in `CreateZerocoinSpendTransaction` (called by the former) resulting in extra selected mints when the vector `vMintsSelected` was already filled with user-provided mint list (e.g. when accessing via the rpc method `spendzerocoinmints`).

The vector of mints is now filled only in a new method `CWallet::CollectMintsForSpend` and assumed always already populated inside `CreateZerocoinSpendTransaction`.
This should fix issue https://github.com/Veil-Project/veil/issues/380
____________
In order to resolve a segfault when no destination address is provided to `CreateZerocoinSpendTransaction`, the method now returns error in that case (06ec8cf).