### PR TITLE
[Wallet] Use a temp keystore for signing stealth inputs.

### DIFF
--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -265,6 +265,7 @@ public:
     bool RegenerateKey(const CKeyID& idKey, CKey& key) const;
     bool RegenerateExtKey(const CKeyID& idKey, CExtKey& extkey) const;
     bool RegenerateAccountExtKey(const CKeyID& idAccount, CExtKey& keyAccount) const;
+    bool MakeSigningKeystore(CBasicKeyStore& keystore, const CScript& scriptPubKey);
 
     bool NewStealthKey(CStealthAddress& stealthAddress, uint32_t nPrefixBits, const char *pPrefix);
 


### PR DESCRIPTION
This fixes issues with not being able to spend CT and RingCT inputs under certain circumstances.