### PR TITLE
[Wallet] Select oldest zerocoinmints first when spending zerocoins

### DIFF
--- a/src/veil/zerocoin/denomination_functions.cpp
+++ b/src/veil/zerocoin/denomination_functions.cpp
@@ -441,3 +441,11 @@ std::vector<CMintMeta> SelectMintsFromList(const CAmount nValueTarget, CAmount& 
     //}
     return vSelectedMints;
 }
+
+// -------------------------------------------------------------------------------------------------------
+// CMintMeta comparison by mint nHeight - Oldest mints first
+// -------------------------------------------------------------------------------------------------------
+bool oldest_first (const CMintMeta& first, const CMintMeta&  second)
+{
+    return first.nHeight < second.nHeight;
+}

--- a/src/veil/zerocoin/denomination_functions.h
+++ b/src/veil/zerocoin/denomination_functions.h
@@ -30,5 +30,6 @@ int calculateChange(
         std::map<libzerocoin::CoinDenomination, CAmount>& mapOfDenomsUsed);
 
 void listSpends(const std::vector<CMintMeta>& vSelectedMints);
+bool oldest_first (const CMintMeta& first, const CMintMeta&  second);
 
 #endif //VEIL_DENOMINATION_FUNCTIONS_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6152,6 +6152,9 @@ bool CWallet::CollectMintsForSpend(CAmount nValue, std::vector<CZerocoinMint>& v
         }
     }
 
+    // order the list of mints - oldest first
+    listMints.sort(oldest_first);
+
     int nCoinsReturned, nNeededSpends;
     CAmount nValueSelected;
     auto vMintsToFetch = SelectMintsFromList(nValueToSelect, nValueSelected, Params().Zerocoin_MaxSpendsPerTransaction(),


### PR DESCRIPTION
Order mints by descending confirmations before zcspend input collection.

Closes https://github.com/Veil-Project/veil/issues/402