### PR TITLE
[RPC] introduce new 'getzerocoinsupply' method

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -59,6 +59,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 1, "minconf" },
     { "getbalance", 2, "include_watchonly" },
     { "getblockhash", 0, "height" },
+    { "getzerocoinsupply", 0, "height" },
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },
     { "waitforblock", 1, "timeout" },

--- a/src/veil-cli.cpp
+++ b/src/veil-cli.cpp
@@ -262,6 +262,8 @@ public:
             result.pushKV("balance", batch[ID_WALLETINFO]["result"]["balance"]);
         }
         result.pushKV("blocks", batch[ID_BLOCKCHAININFO]["result"]["blocks"]);
+        result.pushKV("moneysupply", batch[ID_BLOCKCHAININFO]["result"]["moneysupply"]);
+        result.pushKV("zerocoinsupply", batch[ID_BLOCKCHAININFO]["result"]["zerocoinsupply"]);
         result.pushKV("timeoffset", batch[ID_NETWORKINFO]["result"]["timeoffset"]);
         result.pushKV("connections", batch[ID_NETWORKINFO]["result"]["connections"]);
         result.pushKV("proxy", batch[ID_NETWORKINFO]["result"]["networks"][0]["proxy"]);


### PR DESCRIPTION
This introduces a new RPC method, `getzerocoinsupply`,  to get the zerocoin supply per denomination at given height and the percent relative to the total supply.

It can be used either as a standalone call or as part of `getblockchaininfo`/`-getinfo`.
Examples:
```
:~$ veil-cli getzerocoinsupply 2130
[
  {
    "denom": "10",
    "amount": 4224000000000,
    "percent": 39.67670183985004
  },
  {
    "denom": "100",
    "amount": 450000000000,
    "percent": 4.226921360779478
  },
  {
    "denom": "1000",
    "amount": 200000000000,
    "percent": 1.87863171590199
  },
  {
    "denom": "10000",
    "amount": 0,
    "percent": 0
  },
  {
    "denom": "total",
    "amount": 4874000000000,
    "percent": 45.78225491653151
  }
]
```

```
:~$ veil-cli -getinfo
  "version": 99,
  "protocolversion": 70022,
  "walletversion": 169900,
  "balance": 0.00000000,
  "blocks": 71077,
  "moneysupply": 571260724134473,
  "zerocoinsupply": [
    {
      "denom": "10",
      "amount": 80686000000000,
      "percent": 14.12419873994466
    },
    {
      "denom": "100",
      "amount": 48540000000000,
      "percent": 8.496995846081278
    },
    {
      "denom": "1000",
      "amount": 236300000000000,
      "percent": 41.36465015304915
    },
    {
      "denom": "10000",
      "amount": 75000000000000,
      "percent": 13.1288563752801
    },
    {
      "denom": "total",
      "amount": 440526000000000,
      "percent": 77.1147011143552
    }
  ],
  "timeoffset": 0,
  "connections": 7,
  "proxy": "",
  "difficulty": null,
  "testnet": false,
  "keypoololdest": 1550744333,
  "keypoolsize": 1000,
  "paytxfee": 0.00000000,
  "relayfee": 0.00001000,
  "warnings": "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications"
}
``` 