### PR TITLE
[Consensus] fix superblock consensus bugs

### DIFF
--- a/src/veil/budget.cpp
+++ b/src/veil/budget.cpp
@@ -7,7 +7,7 @@ namespace veil {
 
 bool CheckBudgetTransaction(const int nHeight, const CTransaction& tx, CValidationState& state)
 {
-    if (nHeight % BudgetParams::nBlocksPerPeriod)
+    if (!BudgetParams::IsSuperBlock(nHeight))
         return true;
 
     CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment;

--- a/src/veil/budget.h
+++ b/src/veil/budget.h
@@ -20,9 +20,9 @@ private:
     std::string budgetAddress;
     std::string founderAddress;
     std::string labAddress;
-    static bool IsSuperBlock(int nBlockHeight);
 
 public:
+    static bool IsSuperBlock(int nBlockHeight);
     static BudgetParams* Get();
 
     static void GetBlockRewards(int nBlockHeight,


### PR DESCRIPTION
This fixes two problems with contextual checks on superblock.
- bad-coinbase-vpout would be triggered for valid PoS superblocks  (mainnet and testnet) after the  first one.
- CheckBudgetTransaction does not reflect the changes introduced with https://github.com/Veil-Project/veil/pull/299 (only testnet)