### PR TITLE
[RPC] getzerocoinsupply - add checks for null supply

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -228,7 +228,12 @@ static UniValue getzerocoinsupply(const JSONRPCRequest& request)
         pblockindex = chainActive.Tip();
     }
 
-    int64_t totalSupply = pblockindex->nMoneySupply;
+    int64_t totalSupply = 0;
+    if(pblockindex)
+        totalSupply = pblockindex->nMoneySupply;
+
+   if(!totalSupply)
+       return NullUniValue;
 
     UniValue resArr(UniValue::VARR);
     for (auto denom : libzerocoin::zerocoinDenomList) {


### PR DESCRIPTION
simple check preventing `getzerocoinsupply`, `getblockchaininfo`, `-getinfo` from returning "error: couldn't parse reply from server" when pindex is null or money supply is zero (e.g. when trying to sync from scratch with no peers connected yet)