### PR TITLE
[UI] Fixed Copyright notices in LicenseInfo()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -561,11 +561,10 @@ std::string LicenseInfo()
     const std::string URL_SOURCE_CODE = "<https://github.com/veil-project/veil>";
     const std::string URL_WEBSITE = "<https://veil-project.com>";
 
-    return  CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR) + " ") + "\n" +
-            "Copyright (C) 2009-2019 The Bitcoin Core developers" + "\n"
-            "Copyright (C) 2015-2019 PIVX Developers" + "\n" +
+    return  std::string("Copyright (C) 2009-2019 The Bitcoin Core developers") + "\n"
+            "Copyright (C) 2015-2019 The PIVX Developers" + "\n" +
             "Copyright (C) 2017-2019 The Particl Developers" + "\n" +
-            "Copyright (C) 2018-2019 Veil Developers" + "\n" +
+            CopyrightHolders(strprintf(_("Copyright (C) %i-%i "), 2018, COPYRIGHT_YEAR)) + "\n" +
            "\n" +
            strprintf(_("Please contribute if you find %s useful. "
                        "Visit %s for further information about the software."),


### PR DESCRIPTION
Veil Copyright notice was appearing as duplicated, one notice before Bitcoin, and one notice after Particl. Veil Copyright year has also been fixed (2009 --> 2018).

Visual example of the (**current**) wallet's Information menu:
![veil-broken-copyright](https://user-images.githubusercontent.com/42538664/53705970-df228300-3e1f-11e9-8ee1-26db47f8d5d7.png)

---

Visual example of this PR's **edited** Information menu:
![image](https://user-images.githubusercontent.com/42538664/53706180-e7c78900-3e20-11e9-9376-8af4244c0a18.png)