### PR TITLE
Add Precomputing of Zerocoin Spends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ include_directories(src/zmq)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Core Gui)
 
 add_executable(veil
+        src/veil/zerocoin/witness.h
+        src/veil/zerocoin/witness.cpp
         src/bench/base58.cpp
         src/bench/bech32.cpp
         src/bench/bench.cpp
@@ -1012,6 +1014,6 @@ add_executable(veil
         src/versionbits.h
         src/walletinitinterface.h
         src/warnings.cpp
-        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp)
+        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/wallet/lrucache.h src/wallet/lrucache.cpp)
 
 qt5_use_modules(veil Core Widgets Gui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1014,6 +1014,6 @@ add_executable(veil
         src/versionbits.h
         src/walletinitinterface.h
         src/warnings.cpp
-        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/wallet/lrucache.h src/wallet/lrucache.cpp)
+        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/veil/zerocoin/lrucache.h src/veil/zerocoin/lrucache.cpp src/veil/zerocoin/precompute.h src/veil/zerocoin/precompute.cpp)
 
 qt5_use_modules(veil Core Widgets Gui)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,6 +231,7 @@ BITCOIN_CORE_H = \
   wallet/feebumper.h \
   wallet/fees.h \
   wallet/init.h \
+  wallet/lrucache.h \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletbalances.h \
@@ -331,6 +332,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/feebumper.cpp \
   wallet/fees.cpp \
   wallet/init.cpp \
+  wallet/lrucache.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/rpczerocoin.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -213,6 +213,7 @@ BITCOIN_CORE_H = \
   veil/zerocoin/spendreceipt.h \
   veil/zerocoin/mintpool.h \
   veil/zerocoin/mintmeta.h \
+  veil/zerocoin/witness.h \
   veil/mnemonic/arrayslice.h \
   veil/mnemonic/dictionary.h \
   veil/mnemonic/generateseed.h \
@@ -342,6 +343,7 @@ libbitcoin_wallet_a_SOURCES = \
   veil/zerocoin/denomination_functions.cpp \
   veil/zerocoin/mintpool.cpp \
   veil/zerocoin/spendreceipt.cpp \
+  veil/zerocoin/witness.cpp \
   veil/zerocoin/zchain.cpp \
   veil/zerocoin/ztracker.cpp \
   veil/zerocoin/zwallet.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -210,6 +210,8 @@ BITCOIN_CORE_H = \
   veil/zerocoin/accumulators.h \
   veil/zerocoin/accumulatormap.h \
   veil/zerocoin/denomination_functions.h \
+  veil/zerocoin/lrucache.h \
+  veil/zerocoin/precompute.h \
   veil/zerocoin/spendreceipt.h \
   veil/zerocoin/mintpool.h \
   veil/zerocoin/mintmeta.h \
@@ -231,7 +233,6 @@ BITCOIN_CORE_H = \
   wallet/feebumper.h \
   wallet/fees.h \
   wallet/init.h \
-  wallet/lrucache.h \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletbalances.h \
@@ -332,7 +333,6 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/feebumper.cpp \
   wallet/fees.cpp \
   wallet/init.cpp \
-  wallet/lrucache.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/rpczerocoin.cpp \
@@ -343,7 +343,9 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/deterministicmint.cpp \
   primitives/zerocoin.cpp \
   veil/zerocoin/denomination_functions.cpp \
+  veil/zerocoin/lrucache.cpp \
   veil/zerocoin/mintpool.cpp \
+  veil/zerocoin/precompute.cpp \
   veil/zerocoin/spendreceipt.cpp \
   veil/zerocoin/witness.cpp \
   veil/zerocoin/zchain.cpp \

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -239,7 +239,7 @@ bool CheckZerocoinMint(const CTxOut& txout, CBigNum& bnValue, CValidationState& 
     if (!TxOutToPublicCoin(txout, pubCoin))
         return state.DoS(100, error("CheckZerocoinMint(): TxOutToPublicCoin() failed"));
 
-    if (!pubCoin.validate())
+    if (!fSkipZerocoinMintIsPrime && !pubCoin.validate())
         return state.DoS(100, error("CheckZerocoinMint() : PubCoin does not validate"));
 
     bnValue = pubCoin.getValue();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -250,6 +250,8 @@ void Shutdown()
         DumpMempool();
     }
 
+    DumpPrecomputes();
+
     if (fFeeEstimatesInitialized)
     {
         ::feeEstimator.FlushUnconfirmed();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1922,11 +1922,14 @@ bool AppInitMain()
         }
     }
 
-    if (pprecompute) {
+    auto pt = GetMainWallet();
+    if (pprecompute && pt) {
         pprecompute->SetBlocksPerCycle(gArgs.GetArg("-precomputeblockpercycle", DEFAULT_PRECOMPUTE_BPC));
         if (gArgs.GetBoolArg("-precompute", false)) {
             // Start precomputing zerocoin proofs
-            pprecompute->StartPrecomputing();
+            std::string strStatus;
+            if (!pt->StartPrecomputing(strStatus))
+                error("Failed to start precomputing : %s", strStatus);
         }
     }
 

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -304,6 +304,11 @@ public:
     }
     void setStakingEnabled(bool fEnableStaking) override { m_wallet.SetStakingEnabled(fEnableStaking); }
     bool isStakingEnabled() override { return m_wallet.IsStakingEnabled(); }
+    bool StartPrecomputing(std::string& strStatus) override { return m_wallet.StartPrecomputing(strStatus); }
+    void StopPrecomputing() override { m_wallet.StopPrecomputing(); }
+    void setPrecomputingEnabled(bool fEnabledPrecomputing) override { m_wallet.SetPrecomputingEnabled(fEnabledPrecomputing); }
+    bool isPrecomputingEnabled() override { return m_wallet.IsPrecomputingEnabled(); }
+
     void abortRescan() override { m_wallet.AbortRescan(); }
     bool backupWallet(const std::string& filename) override { return m_wallet.BackupWallet(filename); }
     std::string getWalletName() override { return m_wallet.GetName(); }

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -296,6 +296,12 @@ public:
     virtual void setStakingEnabled(bool fEnableStaking) = 0;
     virtual bool isStakingEnabled() = 0;
 
+    // Enable or disable precomputing
+    virtual void setPrecomputingEnabled(bool fEnablePrecomputing) = 0;
+    virtual bool StartPrecomputing(std::string& strStatus) = 0;
+    virtual void StopPrecomputing() = 0;
+    virtual bool isPrecomputingEnabled() = 0;
+
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleUnload(UnloadFn fn) = 0;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -123,6 +123,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::BLOCKCREATION, "blockcreation"},
     {BCLog::CHAINSCORE, "chainscore"},
     {BCLog::STAGING, "staging"},
+    {BCLog::PRECOMPUTE, "precompute"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -57,6 +57,7 @@ namespace BCLog {
         BLOCKCREATION = (1 << 22),
         CHAINSCORE = (1 << 23),
         STAGING     = (1 << 24),
+        PRECOMPUTE = (1 << 25),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -200,4 +200,5 @@ void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScri
 void ThreadStakeMiner();
 void LinkPoWThreadGroup(void* pthreadgroup);
 
+
 #endif // BITCOIN_MINER_H

--- a/src/qt/veil/forms/veilstatusbar.ui
+++ b/src/qt/veil/forms/veilstatusbar.ui
@@ -109,7 +109,7 @@ border-left:0px;
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,4,1">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0">
         <property name="leftMargin">
          <number>9</number>
         </property>
@@ -123,12 +123,20 @@ border-left:0px;
          <number>3</number>
         </property>
         <item>
-         <widget class="QCheckBox" name="checkStaking">
-          <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
+         <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
+          <property name="spacing">
+           <number>2</number>
           </property>
-          <property name="styleSheet">
-           <string notr="true">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMinimumSize</enum>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="checkStaking">
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">
  #checkStaking::indicator {
      border: 0;
      background: none;
@@ -146,11 +154,43 @@ border-left:0px;
  background-image: url(&quot;:/icons/ic-switch-on-png&quot;) ;
  color:#105aef;
  }</string>
-          </property>
-          <property name="text">
-           <string>Staking</string>
-          </property>
-         </widget>
+            </property>
+            <property name="text">
+             <string>Staking</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="checkPrecompute">
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">
+ #checkPrecompute::indicator {
+     border: 0;
+     background: none;
+ }
+
+ #checkPrecompute {
+ background-image: url(&quot;:/icons/ic-switch-off-png&quot;) ;
+ background-repeat:no-repeat;
+ background-position:left center;
+ padding:8 4 8 30px;
+ color:#bababa;
+ }
+
+ #checkPrecompute:checked {
+ background-image: url(&quot;:/icons/ic-switch-on-png&quot;) ;
+ color:#105aef;
+ }</string>
+            </property>
+            <property name="text">
+             <string>Precompute</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QPushButton" name="btnSync">
@@ -169,7 +209,20 @@ background:transparent;
           </property>
          </widget>
         </item>
-        <item alignment="Qt::AlignRight">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>100</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
          <widget class="QPushButton" name="btnLock">
           <property name="focusPolicy">
            <enum>Qt::NoFocus</enum>
@@ -181,7 +234,7 @@ background:transparent;
            <string/>
           </property>
           <property name="icon">
-           <iconset resource="../../veil.qrc">
+           <iconset>
             <normaloff>:/icons/ic-locked-png</normaloff>
             <selectedoff>:/icons/ic-unlocked-png</selectedoff>:/icons/ic-locked-png</iconset>
           </property>

--- a/src/qt/veil/mainwindow.cpp
+++ b/src/qt/veil/mainwindow.cpp
@@ -38,6 +38,7 @@
 
     ui->title->setProperty("cssClass" , "title");
     ui->checkStaking->setProperty("cssClass" , "switch");
+    ui->checkPrecompute->setProperty("cssClass" , "switch");
     this->setStyleSheet(GUIUtil::loadStyleSheet());
 
     //ui->centralWidget->setContentsMargins(0,0,0,0);

--- a/src/qt/veil/veilstatusbar.h
+++ b/src/qt/veil/veilstatusbar.h
@@ -26,11 +26,13 @@ public:
     void setSyncStatusVisible(bool fVisible);
     void setWalletModel(WalletModel *model);
     void updateStakingCheckbox();
+    void updatePrecomputeCheckbox();
 
 private Q_SLOTS:
     void onBtnSyncClicked();
     void onBtnLockClicked();
     void onCheckStakingClicked(bool res);
+    void onCheckPrecomputeClicked(bool res);
 
 private:
     Ui::VeilStatusBar *ui;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -462,6 +462,26 @@ bool WalletModel::isStakingEnabled()
     return m_wallet->isStakingEnabled();
 }
 
+void WalletModel::setPrecomputingEnabled(bool fPrecomputingStaking)
+{
+    m_wallet->setPrecomputingEnabled(fPrecomputingStaking);
+}
+
+bool WalletModel::StartPrecomputing(std::string& strStatus)
+{
+    return m_wallet->StartPrecomputing(strStatus);
+}
+
+void WalletModel::StopPrecomputing()
+{
+    m_wallet->StopPrecomputing();
+}
+
+bool WalletModel::isPrecomputingEnabled()
+{
+    return m_wallet->isPrecomputingEnabled();
+}
+
 // Handlers for core signals
 static void NotifyUnload(WalletModel* walletModel)
 {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -211,6 +211,11 @@ public:
     void setStakingEnabled(bool fEnableStaking);
     bool isStakingEnabled();
 
+    bool StartPrecomputing(std::string& strStatus);
+    void StopPrecomputing();
+    void setPrecomputingEnabled(bool fEnablePrecomputing);
+    bool isPrecomputingEnabled();
+
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string &sAddress, const int64_t nId, const std::string &sRequest);
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -199,6 +199,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "spendzerocoinmints", 0, "mints_list"},
     { "abandontransaction", 1, "remove_mempool"},
     { "restoreaddresses", 0, "generate_count"},
+    { "showspendcaching", 0, "fVerbose"},
 };
 
 class CRPCConvertTable

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -200,6 +200,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "abandontransaction", 1, "remove_mempool"},
     { "restoreaddresses", 0, "generate_count"},
     { "showspendcaching", 0, "fVerbose"},
+    { "startprecomputing", 0, "nBlockPerCycle"},
+    { "setprecomputeblockpercycle", 0, "nBlockPerCycle"},
 };
 
 class CRPCConvertTable

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -32,6 +32,9 @@
 #endif
 
 #include <univalue.h>
+#include <veil/zerocoin/ztracker.h>
+#include <wallet/rpcwallet.h>
+#include <wallet/wallet.h>
 
 static UniValue validateaddress(const JSONRPCRequest& request)
 {
@@ -443,6 +446,48 @@ UniValue logging(const JSONRPCRequest& request)
     return result;
 }
 
+UniValue clearspendcache(const JSONRPCRequest& request)
+{
+    if(request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+                "clearspendcache\n"
+                "\nClear the pre-computed zerocoin spend cache, and database.\n"
+                "\nExamples\n" +
+                HelpExampleCli("clearspendcache", "") + HelpExampleRpc("clearspendcache", ""));
+
+
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    EnsureWalletIsUnlocked(pwallet);
+
+    CzTracker* zTracker = pwallet->GetZTrackerPointer();
+
+    {
+        int nTries = 0;
+        while (nTries < 100) {
+            TRY_LOCK(zTracker->cs_modify_lock, fLocked);
+            if (fLocked) {
+                if (zTracker->ClearSpendCache()) {
+                    fClearSpendCache = true;
+                    pprecomputeDB->EraseAllPrecomputes();
+                    return "Successfully Cleared the Precompute Spend Cache and Database";
+                }
+            } else {
+                fGlobalUnlockSpendCache = true;
+                nTries++;
+                MilliSleep(100);
+            }
+        }
+    }
+    throw JSONRPCError(RPC_WALLET_ERROR, "Error: Spend cache not cleared!");
+}
+
 static UniValue echo(const JSONRPCRequest& request)
 {
     if (request.fHelp)
@@ -477,6 +522,7 @@ static const CRPCCommand commands[] =
     { "util",               "createmultisig",         &createmultisig,         {"nrequired","keys"} },
     { "util",               "verifymessage",          &verifymessage,          {"address","signature","message"} },
     { "util",               "signmessagewithprivkey", &signmessagewithprivkey, {"privkey","message"} },
+    { "util",               "clearspendcache",        &clearspendcache,        {}},
 
     /* Not shown in help */
     { "hidden",             "setmocktime",            &setmocktime,            {"timestamp"}},

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -262,6 +262,8 @@ bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
 unsigned int nStakeMinAge = 60;
 static bool fVerifyingDB = false;
 
+bool fClearSpendCache = false;
+
 
 uint256 hashAssumeValid;
 arith_uint256 nMinimumChainWork;
@@ -326,6 +328,7 @@ std::unique_ptr<CCoinsViewDB> pcoinsdbview;
 std::unique_ptr<CCoinsViewCache> pcoinsTip;
 std::unique_ptr<CBlockTreeDB> pblocktree;
 std::unique_ptr<CZerocoinDB> pzerocoinDB;
+std::unique_ptr<CPrecomputeDB> pprecomputeDB;
 
 enum class FlushStateMode {
     NONE,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2145,7 +2145,9 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     bool fSkipComputation = false;
     int nHeightLastCheckpoint = Checkpoints::GetLastCheckpointHeight(chainparams.Checkpoints());
-    if (pindex->nHeight < nHeightLastCheckpoint)
+    if (pindex->nHeight < nHeightLastCheckpoint || fReindex)
+        fSkipComputation = true;
+    if (pindex->GetBlockTime() < GetAdjustedTime() - 24*60*60)
         fSkipComputation = true;
 
     // Check it again in case a previous version let a bad block in
@@ -3329,6 +3331,7 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
                     return false;
                 }
             } else {
+                LogPrintf("%s:%d\n", __func__, __LINE__);
                 PruneBlockIndexCandidates();
                 if (!pindexOldTip || chainActive.Tip()->nChainWork > pindexOldTip->nChainWork) {
                     // We're in a better position than we were. Return temporarily to release the lock.
@@ -3511,6 +3514,7 @@ bool CChainState::PreciousBlock(CValidationState& state, const CChainParams& par
         }
         if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && pindex->nChainTx) {
             setBlockIndexCandidates.insert(pindex);
+            LogPrintf("%s:%d\n", __func__, __LINE__);
             PruneBlockIndexCandidates();
         }
     }
@@ -4487,6 +4491,8 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
 
     int nHeightLastCheckpoint = Checkpoints::GetLastCheckpointHeight(chainparams.Checkpoints());
     bool fSkipComputation = pindex->nHeight < nHeightLastCheckpoint;
+    if (pindex->GetBlockTime() < GetAdjustedTime() - 24*60*60)
+        fSkipComputation = true;
     if (!CheckBlock(block, state, chainparams.GetConsensus(), fSkipComputation) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
@@ -4941,12 +4947,13 @@ bool LoadChainTip(const CChainParams& chainparams)
     }
     chainActive.SetTip(pindex);
 
-    g_chainstate.PruneBlockIndexCandidates();
+
 
     LogPrintf("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f\n",
         chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
         FormatISO8601DateTime(chainActive.Tip()->GetBlockTime()),
         GuessVerificationProgress(chainparams.TxData(), chainActive.Tip()));
+    g_chainstate.PruneBlockIndexCandidates();
     return true;
 }
 
@@ -5257,6 +5264,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
     if (chainActive.Tip() != nullptr) {
         // We can't prune block index candidates based on our tip if we have
         // no tip due to chainActive being empty!
+        LogPrintf("%s:%d\n", __func__, __LINE__);
         PruneBlockIndexCandidates();
 
         CheckBlockIndex(params.GetConsensus());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -63,6 +63,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 #include "veil/zerocoin/accumulators.h"
+#include "veil/zerocoin/precompute.h"
 
 #if defined(NDEBUG)
 # error "Veil cannot be compiled without assertions."
@@ -263,8 +264,8 @@ bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
 unsigned int nStakeMinAge = 60;
 static bool fVerifyingDB = false;
 
+// Used in the precomputing thread
 bool fClearSpendCache = false;
-
 
 uint256 hashAssumeValid;
 arith_uint256 nMinimumChainWork;
@@ -330,6 +331,7 @@ std::unique_ptr<CCoinsViewCache> pcoinsTip;
 std::unique_ptr<CBlockTreeDB> pblocktree;
 std::unique_ptr<CZerocoinDB> pzerocoinDB;
 std::unique_ptr<CPrecomputeDB> pprecomputeDB;
+std::unique_ptr<Precompute> pprecompute;
 
 enum class FlushStateMode {
     NONE,

--- a/src/validation.h
+++ b/src/validation.h
@@ -43,7 +43,9 @@ class CScriptCheck;
 class CBlockPolicyEstimator;
 class CTxMemPool;
 class CValidationState;
+class CPrecomputeDB;
 struct ChainTxData;
+
 
 struct PrecomputedTransactionData;
 struct LockPoints;
@@ -217,6 +219,12 @@ static const unsigned int DEFAULT_CHECKLEVEL = 4;
 // one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
+
+/** Veil zerocoin precomputing variables */
+extern bool fClearSpendCache;
+static const int DEFAULT_PRECOMPUTE_LENGTH = 1000;
+static const int MIN_PRECOMPUTE_LENGTH = 500;
+static const int MAX_PRECOMPUTE_LENGTH = 2000;
 
 /**
  * Process an incoming block. This only returns after the best known valid
@@ -495,6 +503,9 @@ extern std::unique_ptr<CBlockTreeDB> pblocktree;
 
 /** Global variable that points to the active zerocoin database (protected by cs_main) */
 extern std::unique_ptr<CZerocoinDB> pzerocoinDB;
+
+/** Global variable that points to the active percompute database (protected by cs_main) */
+extern std::unique_ptr<CPrecomputeDB> pprecomputeDB;
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().

--- a/src/validation.h
+++ b/src/validation.h
@@ -44,6 +44,7 @@ class CBlockPolicyEstimator;
 class CTxMemPool;
 class CValidationState;
 class CPrecomputeDB;
+class Precompute;
 struct ChainTxData;
 
 
@@ -223,9 +224,6 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
 /** Veil zerocoin precomputing variables */
 extern bool fClearSpendCache;
-static const int DEFAULT_PRECOMPUTE_LENGTH = 1000;
-static const int MIN_PRECOMPUTE_LENGTH = 500;
-static const int MAX_PRECOMPUTE_LENGTH = 2000;
 
 /**
  * Process an incoming block. This only returns after the best known valid
@@ -507,6 +505,8 @@ extern std::unique_ptr<CZerocoinDB> pzerocoinDB;
 
 /** Global variable that points to the active percompute database (protected by cs_main) */
 extern std::unique_ptr<CPrecomputeDB> pprecomputeDB;
+
+extern std::unique_ptr<Precompute> pprecompute;
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().

--- a/src/veil/proofofstake/stakeinput.h
+++ b/src/veil/proofofstake/stakeinput.h
@@ -69,6 +69,7 @@ public:
     int GetChecksumHeightFromMint();
     int GetChecksumHeightFromSpend();
     uint256 GetChecksum();
+    uint256 GetSerialHash();
 
     static int HeightToModifierHeight(int nHeight);
 };

--- a/src/veil/proofofstake/stakeinput.h
+++ b/src/veil/proofofstake/stakeinput.h
@@ -44,13 +44,13 @@ class ZerocoinStake : public CStakeInput
 private:
     uint256 nChecksum;
     bool fMint;
-    uint256 hashSerial;
+    uint256 hashStake;
 
 public:
-    explicit ZerocoinStake(libzerocoin::CoinDenomination denom, const uint256& hashSerial)
+    explicit ZerocoinStake(libzerocoin::CoinDenomination denom, const uint256& hashStake)
     {
         this->denom = denom;
-        this->hashSerial = hashSerial;
+        this->hashStake = hashStake;
         this->pindexFrom = nullptr;
         fMint = true;
     }
@@ -69,7 +69,7 @@ public:
     int GetChecksumHeightFromMint();
     int GetChecksumHeightFromSpend();
     uint256 GetChecksum();
-    uint256 GetSerialHash();
+    uint256 GetSerialStakeHash();
 
     static int HeightToModifierHeight(int nHeight);
 };

--- a/src/veil/proofofstake/stakeinput.h
+++ b/src/veil/proofofstake/stakeinput.h
@@ -47,10 +47,10 @@ private:
     uint256 hashSerial;
 
 public:
-    explicit ZerocoinStake(libzerocoin::CoinDenomination denom, const uint256& hashStake)
+    explicit ZerocoinStake(libzerocoin::CoinDenomination denom, const uint256& hashSerial)
     {
         this->denom = denom;
-        this->hashSerial = hashStake;
+        this->hashSerial = hashSerial;
         this->pindexFrom = nullptr;
         fMint = true;
     }

--- a/src/veil/zerocoin/accumulatormap.cpp
+++ b/src/veil/zerocoin/accumulatormap.cpp
@@ -75,6 +75,11 @@ bool AccumulatorMap::Accumulate(const PublicCoin& pubCoin, bool fSkipValidation)
     return mapAccumulators.at(denom)->accumulate(pubCoin);
 }
 
+libzerocoin::Accumulator AccumulatorMap::GetAccumulator(libzerocoin::CoinDenomination denom)
+{
+    return libzerocoin::Accumulator(params, denom, GetValue(denom));
+}
+
 //Get the value of a specific accumulator
 CBigNum AccumulatorMap::GetValue(CoinDenomination denom)
 {

--- a/src/veil/zerocoin/accumulatormap.h
+++ b/src/veil/zerocoin/accumulatormap.h
@@ -20,6 +20,7 @@ public:
     explicit AccumulatorMap(libzerocoin::ZerocoinParams* params);
     bool Load(const std::map<libzerocoin::CoinDenomination, uint256>& mapCheckpoints);
     bool Accumulate(const libzerocoin::PublicCoin& pubCoin, bool fSkipValidation = false);
+    libzerocoin::Accumulator GetAccumulator(libzerocoin::CoinDenomination denom);
     CBigNum GetValue(libzerocoin::CoinDenomination denom);
     std::map<libzerocoin::CoinDenomination, uint256> GetCheckpoints(bool fShowZeroIfEmpty = false);
     void Reset();

--- a/src/veil/zerocoin/accumulators.cpp
+++ b/src/veil/zerocoin/accumulators.cpp
@@ -346,7 +346,7 @@ void AccumulateRange(CoinWitnessData* coinWitness, int nHeightEnd)
 {
     int nHeightStart = std::max(coinWitness->nHeightAccStart, coinWitness->nHeightPrecomputed + 1);
     CBlockIndex* pindex = chainActive[nHeightStart];
-    LogPrintf("%s:%d Accumulate %d until height %d\n", __func__, __LINE__, nHeightStart, nHeightEnd);
+//    LogPrintf("%s:%d Accumulate %d until height %d\n", __func__, __LINE__, nHeightStart, nHeightEnd);
     libzerocoin::PublicCoin pubCoinSelected = *coinWitness->coin;
     while (pindex && pindex->nHeight <= nHeightEnd) {
         coinWitness->nMintsAdded += AddBlockMintsToAccumulator(pubCoinSelected, coinWitness->nHeightMintAdded, pindex, coinWitness->pAccumulator.get(), true);
@@ -366,11 +366,9 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
 
         //If there is a Acc End height filled in, then this has already been partially accumulated.
         if (!coinwitness->nHeightPrecomputed) {
-            LogPrintf("Starting precompute for mint %s accumulated height=%d\n", coinwitness->coin->getValue().GetHex().substr(0, 6), coinwitness->nHeightMintAdded);
+//            LogPrintf("Starting precompute for mint %s accumulated height=%d\n", coinwitness->coin->getValue().GetHex().substr(0, 6), coinwitness->nHeightMintAdded);
             coinwitness->pAccumulator = std::unique_ptr<Accumulator>(new Accumulator(Params().Zerocoin_Params(), coinwitness->denom));
             coinwitness->pWitness = std::unique_ptr<AccumulatorWitness>(new AccumulatorWitness(Params().Zerocoin_Params(), *coinwitness->pAccumulator, coin));
-        } else {
-            LogPrintf("%s: Using precomputed coinspend witness. \n", __func__);
         }
 
         uint256 txid;
@@ -391,7 +389,7 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
         //Get the accumulator that is right before the cluster of blocks containing our mint was added to the accumulator
         bnAccValue = 0;
         if (!coinwitness->nHeightPrecomputed && GetAccumulatorValue(coinwitness->nHeightCheckpoint, coin.getDenomination(), bnAccValue)) {
-            LogPrintf("%s: using new accumulator from checkpoint block %d\n", __func__, coinwitness->nHeightCheckpoint);
+//            LogPrintf("%s: using new accumulator from checkpoint block %d\n", __func__, coinwitness->nHeightCheckpoint);
             libzerocoin::Accumulator witnessAccumulator(Params().Zerocoin_Params(), coinwitness->denom, bnAccValue);
             coinwitness->pAccumulator->setValue(witnessAccumulator.getValue());
         }
@@ -405,7 +403,7 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
         if (pindexCheckpoint) {
             nHeightStop = pindexCheckpoint->nHeight - 10;
             nHeightStop -= nHeightStop % 10;
-            LogPrintf("%s: using checkpoint height %d\n", __func__, pindexCheckpoint->nHeight);
+//            LogPrintf("%s: using checkpoint height %d\n", __func__, pindexCheckpoint->nHeight);
         }
 
         if (nHeightStop <= coinwitness->nHeightPrecomputed)
@@ -426,7 +424,7 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
 
     // calculate how many mints of this denomination existed in the accumulator we initialized
     coinwitness->nMintsAdded += ComputeAccumulatedCoins(coinwitness->nHeightAccStart, coin.getDenomination());
-    LogPrintf("%s : %d mints added to witness\n", __func__, coinwitness->nMintsAdded);
+//    LogPrintf("%s : %d mints added to witness\n", __func__, coinwitness->nMintsAdded);
 
     return true;
 }

--- a/src/veil/zerocoin/accumulators.cpp
+++ b/src/veil/zerocoin/accumulators.cpp
@@ -405,12 +405,15 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
             nHeightStop -= nHeightStop % 10;
 //            LogPrintf("%s: using checkpoint height %d\n", __func__, pindexCheckpoint->nHeight);
         }
-
-        if (nHeightStop <= coinwitness->nHeightPrecomputed)
-            return error("%s: trying to accumulate bad block range, start=%d end=%d", __func__, coinwitness->nHeightPrecomputed, nHeightStop);
     }
 
-    AccumulateRange(coinwitness, nHeightStop - 1);
+    // If we are already at the tip, no reason to Accumulate Range
+    if (nHeightStop <= coinwitness->nHeightPrecomputed) {
+        LogPrintf("%s: trying to accumulate bad block range, start=%d end=%d\n", __func__, coinwitness->nHeightPrecomputed, nHeightStop);
+    } else {
+        AccumulateRange(coinwitness, nHeightStop - 1);
+    }
+
     mapAccumulators.Load(chainActive[nHeightStop + 10]->mapAccumulatorHashes);
     coinwitness->pWitness->resetValue(*coinwitness->pAccumulator, coin);
     if(!coinwitness->pWitness->VerifyWitness(mapAccumulators.GetAccumulator(coinwitness->denom), coin))

--- a/src/veil/zerocoin/accumulators.h
+++ b/src/veil/zerocoin/accumulators.h
@@ -14,9 +14,10 @@
 #include "arith_uint256.h"
 
 class CBlockIndex;
+class CoinWitnessData;
 
 std::map<libzerocoin::CoinDenomination, int> GetMintMaturityHeight();
-bool GenerateAccumulatorWitness(const libzerocoin::PublicCoin &coin, libzerocoin::Accumulator& accumulator, libzerocoin::AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, std::string& strError, CBlockIndex* pindexCheckpoint = nullptr);
+bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& mapAccumulators, int nSecurityLevel, std::string& strError, CBlockIndex* pindexCheckpoint = nullptr);
 bool GetAccumulatorValueFromDB(uint256 nCheckpoint, libzerocoin::CoinDenomination denom, CBigNum& bnAccValue);
 bool GetAccumulatorValueFromChecksum(const uint256& hashChecksum, bool fMemoryOnly, CBigNum& bnAccValue);
 void AddAccumulatorChecksum(const uint256 nChecksum, const CBigNum &bnValue, bool fMemoryOnly);
@@ -27,5 +28,6 @@ bool EraseAccumulatorValues(const uint256& nCheckpointErase, const uint256& nChe
 uint256 GetChecksum(const CBigNum &bnValue);
 int GetChecksumHeight(uint256 nChecksum, libzerocoin::CoinDenomination denomination);
 bool ValidateAccumulatorCheckpoint(const CBlock& block, CBlockIndex* pindex, AccumulatorMap& mapAccumulators);
+void AccumulateRange(CoinWitnessData* coinWitness, int nHeightEnd);
 
 #endif //PIVX_ACCUMULATORS_H

--- a/src/veil/zerocoin/lrucache.cpp
+++ b/src/veil/zerocoin/lrucache.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Veil Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "lrucache.h"
 
 LRUCache::LRUCache()

--- a/src/veil/zerocoin/lrucache.h
+++ b/src/veil/zerocoin/lrucache.h
@@ -1,3 +1,8 @@
+// Copyright (c) 2019 The Veil Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
 #ifndef VEIL_LRUCACHE_H
 #define VEIL_LRUCACHE_H
 

--- a/src/veil/zerocoin/precompute.cpp
+++ b/src/veil/zerocoin/precompute.cpp
@@ -29,21 +29,23 @@ void Precompute::SetThreadGroupPointer(void* threadGroup)
     pthreadGroupPrecompute = (boost::thread_group*)threadGroup;
 }
 
-std::string Precompute::StartPrecomputing()
+bool Precompute::StartPrecomputing(std::string& strStatus)
 {
     if (!pthreadGroupPrecompute) {
         error("%s: pthreadGroupPrecompute is null! Cannot precompute.", __func__);
-        return "pthreadGroupPrecompute is null! Cannot precompute.";
+        strStatus = "Unable to start the precompute thread group";
+        return false;
     }
 
     // Close any active precomputing threads before starting new threads
     if (pthreadGroupPrecompute->size() > 0) {
-        StopPrecomputing();
+        this->StopPrecomputing();
     }
 
     pthreadGroupPrecompute->create_thread(boost::bind(&ThreadPrecomputeSpends));
 
-    return "precomputing started";
+    strStatus = "precomputing started";
+    return true;
 }
 
 void Precompute::StopPrecomputing()

--- a/src/veil/zerocoin/precompute.cpp
+++ b/src/veil/zerocoin/precompute.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2019 The Veil Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/wallet.h>
+#include "precompute.h"
+
+Precompute precomputer = Precompute();
+
+Precompute::Precompute()
+{
+    SetNull();
+}
+
+void Precompute::SetNull()
+{
+    nBlocksPerCycle = DEFAULT_PRECOMPUTE_BPC;
+    pthreadGroupPrecompute = nullptr;
+    lru.Clear();
+}
+
+boost::thread_group* Precompute::GetThreadGroupPointer()
+{
+    return pthreadGroupPrecompute;
+}
+
+void Precompute::SetThreadGroupPointer(void* threadGroup)
+{
+    pthreadGroupPrecompute = (boost::thread_group*)threadGroup;
+}
+
+std::string Precompute::StartPrecomputing()
+{
+    if (!pthreadGroupPrecompute) {
+        error("%s: pthreadGroupPrecompute is null! Cannot precompute.", __func__);
+        return "pthreadGroupPrecompute is null! Cannot precompute.";
+    }
+
+    // Close any active precomputing threads before starting new threads
+    if (pthreadGroupPrecompute->size() > 0) {
+        StopPrecomputing();
+    }
+
+    pthreadGroupPrecompute->create_thread(boost::bind(&ThreadPrecomputeSpends));
+
+    return "Start precomputing";
+}
+
+void Precompute::StopPrecomputing()
+{
+    DumpPrecomputes();
+
+    if (!pthreadGroupPrecompute) {
+        error("%s: pthreadGroupPrecompute is null! Cannot stop precomputing.", __func__);
+        return;
+    }
+
+    if (pthreadGroupPrecompute->size() > 0) {
+        pthreadGroupPrecompute->interrupt_all();
+        pthreadGroupPrecompute->join_all();
+    }
+}
+
+
+void Precompute::SetBlocksPerCycle(const int& nNewBlockPerCycle)
+{
+    nBlocksPerCycle = nNewBlockPerCycle;
+
+    // Force the cache length to be divisible by 10
+    if (nBlocksPerCycle % 10)
+        nBlocksPerCycle -= nBlocksPerCycle % 10;
+
+    // Enforce the mimimum number of blocks per cycle
+    if (nBlocksPerCycle < MIN_PRECOMPUTE_BPC)
+        nBlocksPerCycle = MIN_PRECOMPUTE_BPC;
+
+    // Enforce the maximum number of blocks per cycle
+    if (nBlocksPerCycle > MAX_PRECOMPUTE_BPC)
+        nBlocksPerCycle = MAX_PRECOMPUTE_BPC;
+}
+
+int Precompute::GetBlocksPerCycle()
+{
+    return nBlocksPerCycle;
+}
+
+void ThreadPrecomputeSpends()
+{
+    boost::this_thread::interruption_point();
+    LogPrintf("ThreadPrecomputeSpends started\n");
+    auto pwallet = GetMainWallet();
+
+    if (!pwallet) {
+        LogPrintf("%s: pwallet is null cannot precompute\n", __func__);
+        return;
+    }
+
+    try {
+        pwallet->PrecomputeSpends();
+        boost::this_thread::interruption_point();
+    }  catch (std::exception& e) {
+        LogPrintf("ThreadPrecomputeSpends() exception\n");
+    } catch (boost::thread_interrupted) {
+        LogPrintf("ThreadPrecomputeSpends() interrupted\n");
+    }
+
+    LogPrintf("ThreadPrecomputeSpends exiting,\n");
+}
+
+void LinkPrecomputeThreadGroup(void* pthreadgroup)
+{
+    pprecompute->SetThreadGroupPointer(pthreadgroup);
+}
+
+void DumpPrecomputes() {
+
+    if (!pprecomputeDB) {
+        LogPrintf("Dump Precomputes: Database pointer not found\n");
+        return;
+    }
+
+    if (!pprecompute) {
+        LogPrintf("Dump Precomputes: Precompute pointer not found\n");
+        return;
+    }
+
+    int64_t start = GetTimeMicros();
+    pprecompute->lru.FlushToDisk(pprecomputeDB.get());
+    int64_t end = GetTimeMicros();
+    LogPrintf("Dump Precomputes: %gs to dump\n", (end-start)*0.000001);
+}
+

--- a/src/veil/zerocoin/precompute.cpp
+++ b/src/veil/zerocoin/precompute.cpp
@@ -43,7 +43,7 @@ std::string Precompute::StartPrecomputing()
 
     pthreadGroupPrecompute->create_thread(boost::bind(&ThreadPrecomputeSpends));
 
-    return "Start precomputing";
+    return "precomputing started";
 }
 
 void Precompute::StopPrecomputing()

--- a/src/veil/zerocoin/precompute.h
+++ b/src/veil/zerocoin/precompute.h
@@ -16,7 +16,6 @@ class Precompute
 {
 private:
     int nBlocksPerCycle;
-    PRECOMPUTE_STATUS status;
     boost::thread_group* pthreadGroupPrecompute;
 
 public:

--- a/src/veil/zerocoin/precompute.h
+++ b/src/veil/zerocoin/precompute.h
@@ -16,6 +16,7 @@ class Precompute
 {
 private:
     int nBlocksPerCycle;
+    PRECOMPUTE_STATUS status;
     boost::thread_group* pthreadGroupPrecompute;
 
 public:
@@ -27,7 +28,8 @@ public:
     boost::thread_group* GetThreadGroupPointer();
     void SetThreadGroupPointer(void* threadGroup);
     void SetThreadPointer();
-    std::string StartPrecomputing();
+    bool StartPrecomputing(std::string& strStatus);
+
     void StopPrecomputing();
     void SetBlocksPerCycle(const int& nNewBlockPerCycle);
     int GetBlocksPerCycle();

--- a/src/veil/zerocoin/precompute.h
+++ b/src/veil/zerocoin/precompute.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 The Veil Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef VEIL_PRECOMPUTE_H
+#define VEIL_PRECOMPUTE_H
+
+#include "lrucache.h"
+#include "boost/thread.hpp"
+
+static const int DEFAULT_PRECOMPUTE_BPC = 100; // BPC = Blocks Per Cycle
+static const int MIN_PRECOMPUTE_BPC = 100;
+static const int MAX_PRECOMPUTE_BPC = 2000;
+
+class Precompute
+{
+private:
+    int nBlocksPerCycle;
+    boost::thread_group* pthreadGroupPrecompute;
+
+public:
+
+    LRUCache lru;
+
+    Precompute();
+    void SetNull();
+    boost::thread_group* GetThreadGroupPointer();
+    void SetThreadGroupPointer(void* threadGroup);
+    void SetThreadPointer();
+    std::string StartPrecomputing();
+    void StopPrecomputing();
+    void SetBlocksPerCycle(const int& nNewBlockPerCycle);
+    int GetBlocksPerCycle();
+};
+
+void ThreadPrecomputeSpends();
+void LinkPrecomputeThreadGroup(void* pthreadgroup);
+void DumpPrecomputes();
+
+
+#endif //VEIL_PRECOMPUTE_H

--- a/src/veil/zerocoin/witness.cpp
+++ b/src/veil/zerocoin/witness.cpp
@@ -1,0 +1,189 @@
+#include <chainparams.h>
+#include <tinyformat.h>
+#include "witness.h"
+#include <util.h>
+#include <wallet/walletutil.h>
+#include <wallet/walletdb.h>
+
+void CoinWitnessData::SetNull()
+{
+    coin = nullptr;
+    pAccumulator = nullptr;
+    pWitness = nullptr;
+    nMintsAdded = 0;
+    nHeightMintAdded = 0;
+    nHeightCheckpoint = 0;
+    nHeightAccStart = 0;
+    nHeightAccEnd = 0;
+}
+
+CoinWitnessData::CoinWitnessData()
+{
+    SetNull();
+}
+
+std::string CoinWitnessData::ToString()
+{
+    return strprintf("Mints Added: %d\n"
+            "Height Mint added: %d\n"
+            "Height Checkpoint: %d\n"
+            "Height Acc Start: %d\n"
+            "Height Acc End: %d\n"
+            "Amount: %s\n"
+            "Demon: %d\n", nMintsAdded, nHeightMintAdded, nHeightCheckpoint, nHeightAccStart, nHeightAccEnd, coin->getValue().GetHex(), coin->getDenomination());
+}
+
+CoinWitnessData::CoinWitnessData(CZerocoinMint& mint)
+{
+    SetNull();
+    denom = mint.GetDenomination();
+    libzerocoin::ZerocoinParams* paramsCoin = Params().Zerocoin_Params();
+    coin = std::unique_ptr<libzerocoin::PublicCoin>(new libzerocoin::PublicCoin(paramsCoin, mint.GetValue(), denom));
+    libzerocoin::Accumulator accumulator1(Params().Zerocoin_Params(), denom);
+    pWitness = std::unique_ptr<libzerocoin::AccumulatorWitness>(new libzerocoin::AccumulatorWitness(Params().Zerocoin_Params(), accumulator1, *coin));
+    nHeightAccStart = mint.GetHeight();
+}
+
+CoinWitnessData::CoinWitnessData(CoinWitnessCacheData& data)
+{
+    SetNull();
+    denom = data.denom;
+    libzerocoin::ZerocoinParams* paramsCoin = Params().Zerocoin_Params();
+    coin = std::unique_ptr<libzerocoin::PublicCoin>(new libzerocoin::PublicCoin(paramsCoin, data.coinAmount, data.coinDenom));
+    pAccumulator = std::unique_ptr<libzerocoin::Accumulator>(new libzerocoin::Accumulator(Params().Zerocoin_Params(), denom, data.accumulatorAmount));
+    pWitness = std::unique_ptr<libzerocoin::AccumulatorWitness>(new libzerocoin::AccumulatorWitness(Params().Zerocoin_Params(), *pAccumulator, *coin));
+    nMintsAdded = data.nMintsAdded;
+    nHeightMintAdded = data.nHeightMintAdded;
+    nHeightCheckpoint = data.nHeightCheckpoint;
+    nHeightAccStart = data.nHeightAccStart;
+    nHeightAccEnd = data.nHeightAccEnd;
+    txid = data.txid;
+}
+
+void CoinWitnessData::SetHeightMintAdded(int nHeight)
+{
+    nHeightMintAdded = nHeight;
+    nHeightCheckpoint = nHeight + (10 - (nHeight % 10));
+    nHeightAccStart = nHeight - (nHeight % 10);
+}
+
+
+
+void CoinWitnessCacheData::SetNull()
+{
+    nMintsAdded = 0;
+    nHeightMintAdded = 0;
+    nHeightCheckpoint = 0;
+    nHeightAccStart = 0;
+    nHeightAccEnd = 0;
+    coinAmount = CBigNum(0);
+    coinDenom = libzerocoin::CoinDenomination::ZQ_ERROR;
+    accumulatorAmount = CBigNum(0);
+    accumulatorDenom = libzerocoin::CoinDenomination::ZQ_ERROR;
+
+}
+
+CoinWitnessCacheData::CoinWitnessCacheData()
+{
+    SetNull();
+}
+
+CoinWitnessCacheData::CoinWitnessCacheData(CoinWitnessData* coinWitnessData)
+{
+    SetNull();
+    denom = coinWitnessData->denom;
+    txid = coinWitnessData->txid;
+    nMintsAdded = coinWitnessData->nMintsAdded;
+    nHeightMintAdded = coinWitnessData->nHeightMintAdded;
+    nHeightCheckpoint = coinWitnessData->nHeightCheckpoint;
+    nHeightAccStart = coinWitnessData->nHeightAccStart;
+    nHeightAccEnd = coinWitnessData->nHeightAccEnd;
+    coinAmount = coinWitnessData->coin->getValue();
+    coinDenom = coinWitnessData->coin->getDenomination();
+    accumulatorAmount = coinWitnessData->pAccumulator->getValue();
+    accumulatorDenom = coinWitnessData->pAccumulator->getDenomination();
+}
+
+CPrecomputeDB::CPrecomputeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetWalletDir() / "precomputes", nCacheSize, fMemory, fWipe)
+{
+}
+
+bool CPrecomputeDB::LoadPrecomputes(std::list<std::pair<uint256, CoinWitnessCacheData> >& itemList, std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator>& itemMap)
+{
+
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+
+    char type = 'P';
+    pcursor->Seek(std::make_pair(type, uint256()));
+
+    std::pair<unsigned char, uint256> key;
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+
+        if (pcursor->GetKey(key) && key.first == type) {
+
+            CoinWitnessCacheData data;
+            if (!pcursor->GetValue(data)) {
+                return error("%s: cannot parse CCoins record", __func__);
+            }
+
+            itemList.push_front(std::make_pair(key.second, data));
+            itemMap.insert(make_pair(key.second, itemList.begin()));
+
+            if (itemMap.size() == PRECOMPUTE_LRU_CACHE_SIZE)
+                break;
+
+            pcursor->Next();
+        } else {
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool CPrecomputeDB::LoadPrecomputes(std::set<uint256> setHashes)
+{
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+
+    char type = 'P';
+    pcursor->Seek(std::make_pair(type, uint256()));
+
+    std::pair<unsigned char, uint256> key;
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+
+        if (pcursor->GetKey(key) && key.first == type) {
+            setHashes.insert(key.second);
+            pcursor->Next();
+        } else {
+            break;
+        }
+
+    }
+
+    return true;
+}
+
+void CPrecomputeDB::EraseAllPrecomputes()
+{
+    std::set<uint256> setHashes;
+    LoadPrecomputes(setHashes);
+
+    for (auto hash : setHashes)
+        ErasePrecompute(hash);
+}
+
+bool CPrecomputeDB::WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data)
+{
+    return Write(std::make_pair('P', hash), data);
+}
+bool CPrecomputeDB::ReadPrecompute(const uint256& hash, CoinWitnessCacheData& data)
+{
+    return Read(std::make_pair('P', hash), data);
+}
+bool CPrecomputeDB::ErasePrecompute(const uint256& hash)
+{
+    return Erase(std::make_pair('P', hash));
+}
+

--- a/src/veil/zerocoin/witness.cpp
+++ b/src/veil/zerocoin/witness.cpp
@@ -5,6 +5,7 @@
 #include <veil/zerocoin/lrucache.h>
 #include <wallet/walletutil.h>
 #include <wallet/walletdb.h>
+#include <boost/thread.hpp>
 
 void CoinWitnessData::SetNull()
 {

--- a/src/veil/zerocoin/witness.cpp
+++ b/src/veil/zerocoin/witness.cpp
@@ -2,7 +2,7 @@
 #include <tinyformat.h>
 #include "witness.h"
 #include <util.h>
-#include <wallet/lrucache.h>
+#include <veil/zerocoin/lrucache.h>
 #include <wallet/walletutil.h>
 #include <wallet/walletdb.h>
 

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -1,0 +1,96 @@
+#ifndef VEIL_WITNESS_H
+#define VEIL_WITNESS_H
+
+
+#include <libzerocoin/Accumulator.h>
+#include <libzerocoin/Coin.h>
+#include "primitives/zerocoin.h"
+#include "serialize.h"
+#include <dbwrapper.h>
+
+#define PRECOMPUTE_LRU_CACHE_SIZE 1000
+#define PRECOMPUTE_MAX_DIRTY_CACHE_SIZE 100
+#define PRECOMPUTE_FLUSH_TIME 300 // 5 minutes
+
+class CoinWitnessCacheData;
+
+class CoinWitnessData
+{
+public:
+    std::unique_ptr<libzerocoin::PublicCoin> coin;
+    std::unique_ptr<libzerocoin::Accumulator> pAccumulator;
+    std::unique_ptr<libzerocoin::AccumulatorWitness> pWitness;
+    libzerocoin::CoinDenomination denom;
+    int nHeightCheckpoint;
+    int nHeightMintAdded;
+    int nHeightAccStart;
+    int nHeightAccEnd;
+    int nMintsAdded;
+    uint256 txid;
+
+    CoinWitnessData();
+    CoinWitnessData(CZerocoinMint& mint);
+    CoinWitnessData(CoinWitnessCacheData& data);
+    void SetHeightMintAdded(int nHeight);
+    void SetNull();
+    std::string ToString();
+};
+
+class CoinWitnessCacheData
+{
+public:
+    libzerocoin::CoinDenomination denom;
+    int nHeightCheckpoint;
+    int nHeightMintAdded;
+    int nHeightAccStart;
+    int nHeightAccEnd;
+    int nMintsAdded;
+    uint256 txid;
+    CBigNum coinAmount;
+    libzerocoin::CoinDenomination coinDenom;
+    CBigNum accumulatorAmount;
+    libzerocoin::CoinDenomination accumulatorDenom;
+
+    CoinWitnessCacheData();
+    CoinWitnessCacheData(CoinWitnessData* coinWitnessData);
+    void SetNull();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(denom);
+        READWRITE(nHeightCheckpoint);
+        READWRITE(nHeightMintAdded);
+        READWRITE(nHeightAccStart);
+        READWRITE(nHeightAccEnd);
+        READWRITE(nMintsAdded);
+        READWRITE(txid);
+        READWRITE(coinAmount); // used to create the PublicCoin
+        READWRITE(coinDenom);
+        READWRITE(accumulatorAmount); // used to create the pAccumulator
+        READWRITE(accumulatorDenom);
+    };
+};
+
+/** Precompute database (precomputes/) */
+class CPrecomputeDB : public CDBWrapper
+{
+public:
+    explicit CPrecomputeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+
+private:
+    CPrecomputeDB(const CPrecomputeDB&);
+    void operator=(const CPrecomputeDB&);
+
+public:
+    /** Veil zerocoin precompute database functions */
+    bool LoadPrecomputes(std::list<std::pair<uint256, CoinWitnessCacheData> >& itemList, std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator>& itemMap);
+    bool LoadPrecomputes(std::set<uint256> setHashes);
+    void EraseAllPrecomputes();
+    bool WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data);
+    bool ReadPrecompute(const uint256& hash, CoinWitnessCacheData& data);
+    bool ErasePrecompute(const uint256& hash);
+};
+#endif //VEIL_WITNESS_H

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -13,6 +13,7 @@
 #define PRECOMPUTE_FLUSH_TIME 300 // 5 minutes
 
 class CoinWitnessCacheData;
+class LRUCache;
 
 class CoinWitnessData
 {
@@ -24,13 +25,16 @@ public:
     int nHeightCheckpoint;
     int nHeightMintAdded;
     int nHeightAccStart;
-    int nHeightAccEnd;
+    int nHeightPrecomputed;
     int nMintsAdded;
     uint256 txid;
+    mutable CCriticalSection cs;
 
     CoinWitnessData();
     CoinWitnessData(CZerocoinMint& mint);
     CoinWitnessData(CoinWitnessCacheData& data);
+    CoinWitnessData(const CoinWitnessData& other);
+    CoinWitnessData& operator=(const CoinWitnessData& other);
     void SetHeightMintAdded(int nHeight);
     void SetNull();
     std::string ToString();
@@ -43,7 +47,7 @@ public:
     int nHeightCheckpoint;
     int nHeightMintAdded;
     int nHeightAccStart;
-    int nHeightAccEnd;
+    int nHeightPrecomputed;
     int nMintsAdded;
     uint256 txid;
     CBigNum coinAmount;
@@ -64,7 +68,7 @@ public:
         READWRITE(nHeightCheckpoint);
         READWRITE(nHeightMintAdded);
         READWRITE(nHeightAccStart);
-        READWRITE(nHeightAccEnd);
+        READWRITE(nHeightPrecomputed);
         READWRITE(nMintsAdded);
         READWRITE(txid);
         READWRITE(coinAmount); // used to create the PublicCoin
@@ -86,7 +90,7 @@ private:
 
 public:
     /** Veil zerocoin precompute database functions */
-    bool LoadPrecomputes(std::list<std::pair<uint256, CoinWitnessCacheData> >& itemList, std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator>& itemMap);
+    bool LoadPrecomputes(LRUCache* lru);
     bool LoadPrecomputes(std::set<uint256> setHashes);
     void EraseAllPrecomputes();
     bool WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data);

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -8,9 +8,9 @@
 #include "serialize.h"
 #include <dbwrapper.h>
 
-#define PRECOMPUTE_LRU_CACHE_SIZE 1000
-#define PRECOMPUTE_MAX_DIRTY_CACHE_SIZE 100
-#define PRECOMPUTE_FLUSH_TIME 300 // 5 minutes
+#define PRECOMPUTE_LRU_CACHE_SIZE 2000
+#define PRECOMPUTE_MAX_DIRTY_CACHE_SIZE 1000
+#define PRECOMPUTE_FLUSH_TIME 3600 // 1 Hour
 
 class CoinWitnessCacheData;
 class LRUCache;

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -92,7 +92,7 @@ public:
     /** Veil zerocoin precompute database functions */
     bool LoadPrecomputes(LRUCache* lru);
     bool LoadPrecomputes(std::set<uint256> setHashes);
-    void EraseAllPrecomputes();
+    bool EraseAllPrecomputes();
     bool WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data);
     bool ReadPrecompute(const uint256& hash, CoinWitnessCacheData& data);
     bool ErasePrecompute(const uint256& hash);

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -528,6 +528,30 @@ std::set<CMintMeta> CzTracker::ListMints(bool fUnusedOnly, bool fMatureOnly, boo
     return setMints;
 }
 
+
+CoinWitnessData* CzTracker::GetSpendCache(const uint256& hashStake)
+{
+    AssertLockHeld(cs_spendcache);
+    if (!mapStakeCache.count(hashStake)) {
+        std::unique_ptr<CoinWitnessData> uptr(new CoinWitnessData());
+        mapStakeCache.insert(std::make_pair(hashStake, std::move(uptr)));
+        return mapStakeCache.at(hashStake).get();
+    }
+
+    return mapStakeCache.at(hashStake).get();
+}
+
+bool CzTracker::ClearSpendCache()
+{
+    AssertLockHeld(cs_spendcache);
+    if (!mapStakeCache.empty()) {
+        mapStakeCache.clear();
+        return true;
+    }
+
+    return false;
+}
+
 void CzTracker::Clear()
 {
     mapSerialHashes.clear();

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -567,16 +567,30 @@ bool CzTracker::GetCoinWitness(const uint256& hashSerial, CoinWitnessData& data)
 
     auto pwitness = mapSpendCache.at(hashSerial).get();
 
-    auto denom = pwitness->denom;
-    data.denom = denom;
-    data.coin = std::unique_ptr<libzerocoin::PublicCoin>(new libzerocoin::PublicCoin(Params().Zerocoin_Params(), pwitness->coin->getValue(), denom));
-    data.pAccumulator = std::unique_ptr<libzerocoin::Accumulator>(new libzerocoin::Accumulator(Params().Zerocoin_Params(), denom, pwitness->pAccumulator->getValue()));
-    data.pWitness = std::unique_ptr<libzerocoin::AccumulatorWitness>(new libzerocoin::AccumulatorWitness(Params().Zerocoin_Params(), *data.pAccumulator.get(), *data.coin));
-    data.nHeightCheckpoint = pwitness->nHeightCheckpoint;
-    data.nHeightMintAdded = pwitness->nHeightMintAdded;
-    data.nHeightAccStart = pwitness->nHeightAccStart;
-    data.nHeightPrecomputed = pwitness->nHeightPrecomputed;
-    data.txid = pwitness->txid;
+    if (!pwitness->coin) {
+        return error("%s: Coin pointer was null: returning false", __func__);
+    }
+
+    if (!pwitness->pAccumulator) {
+        return error("%s: Accumulator pointer was null: returning false", __func__);
+    }
+
+    try {
+        data = *pwitness;
+    } catch(...) {
+        return error("%s: Failed to copy pwitness data", __func__);
+    }
+
+//    auto denom = pwitness->denom;
+//    data.denom = denom;
+//    data.coin = std::unique_ptr<libzerocoin::PublicCoin>(new libzerocoin::PublicCoin(Params().Zerocoin_Params(), pwitness->coin->getValue(), denom));
+//    data.pAccumulator = std::unique_ptr<libzerocoin::Accumulator>(new libzerocoin::Accumulator(Params().Zerocoin_Params(), denom, pwitness->pAccumulator->getValue()));
+//    data.pWitness = std::unique_ptr<libzerocoin::AccumulatorWitness>(new libzerocoin::AccumulatorWitness(Params().Zerocoin_Params(), *data.pAccumulator.get(), *data.coin));
+//    data.nHeightCheckpoint = pwitness->nHeightCheckpoint;
+//    data.nHeightMintAdded = pwitness->nHeightMintAdded;
+//    data.nHeightAccStart = pwitness->nHeightAccStart;
+//    data.nHeightPrecomputed = pwitness->nHeightPrecomputed;
+//    data.txid = pwitness->txid;
 
     return true;
 }

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -8,6 +8,7 @@
 #include "primitives/zerocoin.h"
 #include "wallet/walletdb.h"
 #include <list>
+#include "veil/zerocoin/witness.h"
 
 class CDeterministicMint;
 class CWallet;
@@ -24,6 +25,7 @@ private:
     std::map<SerialHash, CMintMeta> mapSerialHashes;
     std::map<SerialHash, uint256> mapPendingSpends; //serialhash, txid of spend
     std::map<PubCoinHash, SerialHash> mapHashPubCoin;
+    std::map<SerialHash, std::unique_ptr<CoinWitnessData> > mapStakeCache; //serialhash, witness value, height
     bool UpdateStatusInternal(const std::set<uint256>& setMempoolTx, const std::map<uint256, uint256>& mapMempoolSerials, CMintMeta& mint);
 public:
     CzTracker(CWallet* wallet);
@@ -53,6 +55,9 @@ public:
     bool UpdateZerocoinMint(const CZerocoinMint& mint);
     bool UpdateState(const CMintMeta& meta);
     void Clear();
+    mutable CCriticalSection cs_spendcache;
+    CoinWitnessData* GetSpendCache(const uint256& hashStake) EXCLUSIVE_LOCKS_REQUIRED(cs_spendcache);
+    bool ClearSpendCache() EXCLUSIVE_LOCKS_REQUIRED(cs_spendcache);
 
     static uint8_t GetMintMemFlags(const CMintMeta& mint, int nBestHeight, const std::map<libzerocoin::CoinDenomination, int>& mapMaturity);
 };

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -18,6 +18,7 @@
 #include <wallet/walletutil.h>
 #include <veil/ringct/anonwallet.h>
 #include <veil/zerocoin/zwallet.h>
+#include <veil/zerocoin/precompute.h>
 
 void WalletInit::AddWalletOptions() const
 {
@@ -60,6 +61,10 @@ void WalletInit::AddWalletOptions() const
 
     gArgs.AddArg("-gen=<n>", strprintf("Enable CPU mining to true on the given number of threads (default: %u)", 0), false, OptionsCategory::WALLET);
     gArgs.AddArg("-genoverride", strprintf("Allows you to override the IsInitialBlockDownload check in BitcoinMiner for PoW mining (default: %u)", false), false, OptionsCategory::HIDDEN);
+
+    gArgs.AddArg("-precompute=<n>", strprintf("Enable the wallet to start solving zerocoin spend proofs inorder to make staking and spending zerocoin faster (default: %u)", false), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-precomputeblockpercycle=<n>", strprintf("Set the number of included blocks to precompute per cycle. (minimum: %d) (maximum: %d) (default: %d)", MIN_PRECOMPUTE_BPC, DEFAULT_PRECOMPUTE_BPC, MIN_PRECOMPUTE_BPC), false, OptionsCategory::WALLET);
+
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/lrucache.cpp
+++ b/src/wallet/lrucache.cpp
@@ -1,0 +1,107 @@
+#include "lrucache.h"
+
+LRUCache::LRUCache()
+{
+    Clear();
+}
+
+void LRUCache::Clear()
+{
+    cache_list.clear();
+    mapCacheLocation.clear();
+    mapDirtyWitnessData.clear();
+}
+
+void LRUCache::AddNew(const uint256& hash, CoinWitnessCacheData& data)
+{
+    cache_list.push_front(std::make_pair(hash, data));
+    mapCacheLocation.insert(make_pair(hash, cache_list.begin()));
+    MoveLastToDirtyIfFull();
+    //Remove from dirty cache in case it is there
+    mapDirtyWitnessData.erase(hash);
+}
+
+int LRUCache::Size() const
+{
+    return mapCacheLocation.size();
+}
+
+bool LRUCache::Contains(const uint256& hash) const
+{
+    return mapCacheLocation.count(hash) > 0 || mapDirtyWitnessData.count(hash) > 0;
+}
+
+void LRUCache::MoveDirtyToLRU(const uint256& hash)
+{
+    auto data = CoinWitnessData(mapDirtyWitnessData.at(hash));
+    auto cachedata = CoinWitnessCacheData(&data);
+    AddNew(hash, cachedata);
+}
+
+void LRUCache::MoveLastToDirtyIfFull()
+{
+    if (mapCacheLocation.size() > PRECOMPUTE_LRU_CACHE_SIZE) {
+        auto last_it = cache_list.end(); last_it --;
+        mapCacheLocation.erase(last_it->first);
+        CoinWitnessCacheData removedData = cache_list.back().second;
+        mapDirtyWitnessData[cache_list.back().first] = removedData;
+        cache_list.pop_back();
+    }
+}
+
+CoinWitnessData LRUCache::GetWitnessData(const uint256& hash)
+{
+    if (mapDirtyWitnessData.count(hash)) {
+        MoveDirtyToLRU(hash);
+    }
+
+    auto it = mapCacheLocation.find(hash);
+    if (it != mapCacheLocation.end()) {
+        // Get the witness data from the cache
+        cache_list.splice(cache_list.begin(), cache_list, it->second);
+        return CoinWitnessData(it->second->second);
+    }
+
+    return CoinWitnessData();
+}
+
+void LRUCache::Remove(const uint256& hash)
+{
+    auto it = mapCacheLocation.find(hash);
+    if (it != mapCacheLocation.end()) {
+        cache_list.erase(it->second);
+        mapCacheLocation.erase(it);
+    }
+    mapDirtyWitnessData.erase(hash);
+}
+
+void LRUCache::AddToCache(const uint256& hash, CoinWitnessCacheData& serialData)
+{
+    // If the LRU cache already has a entry for it, update the entry and move it to the front of the list
+    auto it = mapCacheLocation.find(hash);
+    if (it != mapCacheLocation.end()) {
+        cache_list.splice(cache_list.begin(), cache_list, it->second);
+        cache_list.begin()->second = serialData;
+    } else {
+        AddNew(hash, serialData);
+    }
+
+    // We just added a new hash into our LRU cache, so remove it if we also have it in the dirty map
+    mapDirtyWitnessData.erase(hash);
+    MoveLastToDirtyIfFull();
+}
+
+void LRUCache::FlushToDisk(CPrecomputeDB* pprecomputeDB)
+{
+    // Save all cache data that was dirty back into the database
+    for (auto item : mapDirtyWitnessData) {
+        pprecomputeDB->WritePrecompute(item.first, item.second);
+        MoveDirtyToLRU(item.first);
+    }
+    mapDirtyWitnessData.clear();
+
+    // Save the LRU cache data into the database
+    for (auto item : cache_list) {
+        pprecomputeDB->WritePrecompute(item.first, item.second);
+    }
+}

--- a/src/wallet/lrucache.cpp
+++ b/src/wallet/lrucache.cpp
@@ -26,6 +26,11 @@ int LRUCache::Size() const
     return mapCacheLocation.size();
 }
 
+int LRUCache::DirtyCacheSize() const
+{
+    return mapDirtyWitnessData.size();
+}
+
 bool LRUCache::Contains(const uint256& hash) const
 {
     return mapCacheLocation.count(hash) > 0 || mapDirtyWitnessData.count(hash) > 0;

--- a/src/wallet/lrucache.cpp
+++ b/src/wallet/lrucache.cpp
@@ -96,7 +96,6 @@ void LRUCache::FlushToDisk(CPrecomputeDB* pprecomputeDB)
     // Save all cache data that was dirty back into the database
     for (auto item : mapDirtyWitnessData) {
         pprecomputeDB->WritePrecompute(item.first, item.second);
-        MoveDirtyToLRU(item.first);
     }
     mapDirtyWitnessData.clear();
 

--- a/src/wallet/lrucache.h
+++ b/src/wallet/lrucache.h
@@ -1,0 +1,27 @@
+#ifndef VEIL_LRUCACHE_H
+#define VEIL_LRUCACHE_H
+
+#include <veil/zerocoin/witness.h>
+
+class LRUCache
+{
+private:
+    std::list<std::pair<uint256, CoinWitnessCacheData> > cache_list;
+    std::map<uint256, std::list<std::pair<uint256, CoinWitnessCacheData> >::iterator> mapCacheLocation;
+    std::map<uint256, CoinWitnessCacheData> mapDirtyWitnessData;
+
+public:
+    void AddNew(const uint256& hash, CoinWitnessCacheData& data);
+    void AddToCache(const uint256& hash, CoinWitnessCacheData& serialData);
+    bool Contains(const uint256& hash) const;
+    void Clear();
+    void FlushToDisk(CPrecomputeDB* pprecomputeDB);
+    CoinWitnessData GetWitnessData(const uint256& hash);
+    LRUCache();
+    void MoveDirtyToLRU(const uint256& hash);
+    void MoveLastToDirtyIfFull();
+    void Remove(const uint256& hash);
+    int Size() const;
+};
+
+#endif //VEIL_LRUCACHE_H

--- a/src/wallet/lrucache.h
+++ b/src/wallet/lrucache.h
@@ -22,6 +22,7 @@ public:
     void MoveLastToDirtyIfFull();
     void Remove(const uint256& hash);
     int Size() const;
+    int DirtyCacheSize() const;
 };
 
 #endif //VEIL_LRUCACHE_H

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -1589,8 +1589,11 @@ UniValue startprecomputing(const JSONRPCRequest& request)
         int nBPC = params[0].get_int();
         pprecompute->SetBlocksPerCycle(nBPC);
     }
+    std::string response;
 
-    std::string response = pprecompute->StartPrecomputing();
+    if (!pwallet->StartPrecomputing(response)) {
+        return "Failed to start precomputing: " + response;
+    }
 
     return response;
 }
@@ -1617,9 +1620,9 @@ UniValue stopprecomputing(const JSONRPCRequest& request)
     if (!pprecompute)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Precompute pointer not initialized");
 
-    pprecompute->StopPrecomputing();
+    pwallet->StopPrecomputing();
 
-    return "Precompute Stopping";
+    return "precomputing stopping";
 }
 
 UniValue setprecomputeblockpercycle(const JSONRPCRequest& request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6451,6 +6451,27 @@ bool CWallet::GetZerocoinKey(const CBigNum& bnSerial, CKey& key)
     return mint.GetKeyPair(key);
 }
 
+bool CWallet::StartPrecomputing(std::string& strStatus)
+{
+    if (!pprecompute) {
+        strStatus = "Failed to access the precompute pointer";
+        return false;
+    }
+
+    SetPrecomputingEnabled(true);
+    return pprecompute->StartPrecomputing(strStatus);
+}
+
+void CWallet::StopPrecomputing()
+{
+    if (!pprecompute) {
+        return;
+    }
+
+    SetPrecomputingEnabled(false);
+    pprecompute->StopPrecomputing();
+}
+
 void CWallet::PrecomputeSpends()
 {
     LogPrintf("Veil Precomputing Started\n");
@@ -6488,7 +6509,7 @@ void CWallet::PrecomputeSpends()
         if (ShutdownRequested())
             break;
 
-        if (IsInitialBlockDownload() || !HeadersAndBlocksSynced()) {
+        if (IsInitialBlockDownload() || !HeadersAndBlocksSynced() || !IsPrecomputingEnabled()) {
             MilliSleep(5000);
             continue;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <wallet/wallet.h>
+#include <wallet/lrucache.h>
 #include <veil/ringct/anonwallet.h>
 #include <veil/budget.h>
 
@@ -5471,30 +5472,39 @@ CScript GetLargestContributor(std::set<CInputCoin>& setCoins)
 bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, const uint256& hashTxOut, CTxIn& newTxIn,
                          CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
 {
+    auto hashSerial = GetSerialHash(zerocoinSelected.GetSerialNumber());
+    CMintMeta meta = zTracker->Get(hashSerial);
+    CoinWitnessData coinwitness;
+    {
+        int nLockAttempts = 0;
+        while (nLockAttempts < 1000) {
+            TRY_LOCK(zTracker->cs_readlock, lockSpendcache);
+            if (!lockSpendcache) {
+                fGlobalUnlockSpendCache = true;
+                MilliSleep(10);
+                ++nLockAttempts;
+                continue;
+            }
 
-    AssertLockHeld(zTracker->cs_spendcache);
-    CMintMeta meta = zTracker->Get(GetSerialHash(zerocoinSelected.GetSerialNumber()));
-    CoinWitnessData *coinwitness = zTracker->GetSpendCache(meta.hashStake);
-
-    if (!coinwitness->nHeightAccEnd) {
-        *coinwitness = CoinWitnessData(zerocoinSelected);
-        coinwitness->SetHeightMintAdded(zerocoinSelected.GetHeight());
+            if (!zTracker->GetCoinWitness(hashSerial, coinwitness)) {
+                //No spend cache for this yet
+                coinwitness = CoinWitnessData(zerocoinSelected);
+                coinwitness.SetHeightMintAdded(zerocoinSelected.GetHeight());
+            }
+            break;
+        }
+        if (nLockAttempts >= 1000)
+            return error("%s: \n*******************\n    ****** \n ************ \n failed to lock spend cache!", __func__);
     }
+
+    LOCK(coinwitness.cs);
 
     // Default error status if not changed below
     receipt.SetStatus(_("Transaction Mint Started"), ZTXMINT_GENERAL);
-    //LogPrintf("%s: *** using v1 coin params=%b, using v1 acc params=%b\n", __func__, isV1Coin, chainActive.Height() < Params().Zerocoin_Block_V2_Start());
 
     // 2. Get pubcoin from the private coin
     libzerocoin::CoinDenomination denomination = zerocoinSelected.GetDenomination();
-//    libzerocoin::PublicCoin pubCoinSelected(Params().Zerocoin_Params(), zerocoinSelected.GetValue(), denomination);
-//    //LogPrintf("%s : selected mint %s\n pubcoinhash=%s\n", __func__, zerocoinSelected.ToString(), GetPubCoinHash(zerocoinSelected.GetValue()).GetHex());
-//    if (!pubCoinSelected.validate()) {
-//        receipt.SetStatus(_("The selected mint coin is an invalid coin"), ZINVALID_COIN);
-//        return false;
-//    }
-
-    libzerocoin::PublicCoin pubCoinSelected = *coinwitness->coin;
+    libzerocoin::PublicCoin pubCoinSelected = *coinwitness.coin;
     if (!pubCoinSelected.validate()) {
         receipt.SetStatus(_("The selected mint coin is an invalid coin"), ZINVALID_COIN);
         return false;
@@ -5503,14 +5513,14 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
     // 3. Compute Accumulator and Witness
     string strFailReason = "";
     AccumulatorMap mapAccumulators(Params().Zerocoin_Params());
-    if (!GenerateAccumulatorWitness(coinwitness, mapAccumulators, nSecurityLevel, strFailReason, pindexCheckpoint)) {
+    if (!GenerateAccumulatorWitness(&coinwitness, mapAccumulators, nSecurityLevel, strFailReason, pindexCheckpoint)) {
         receipt.SetStatus(_("Try to spend with a higher security level to include more coins"), ZFAILED_ACCUMULATOR_INITIALIZATION);
         return error("%s : %s", __func__, receipt.GetStatusMessage());
     }
 
     // Construct the CoinSpend object. This acts like a signature on the transaction.
-    libzerocoin::PrivateCoin privateCoin(Params().Zerocoin_Params(), coinwitness->denom, false);
-    privateCoin.setPublicCoin(*coinwitness->coin);
+    libzerocoin::PrivateCoin privateCoin(Params().Zerocoin_Params(), coinwitness.denom, false);
+    privateCoin.setPublicCoin(*coinwitness.coin);
     privateCoin.setRandomness(zerocoinSelected.GetRandomness());
     privateCoin.setSerialNumber(zerocoinSelected.GetSerialNumber());
 
@@ -5522,15 +5532,14 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
         return error("%s: failed to set zerocoin privkey mint version=%d", __func__, nVersion);
     privateCoin.setPrivKey(key.GetPrivKey());
 
-
-    libzerocoin::Accumulator accumulator = mapAccumulators.GetAccumulator(coinwitness->denom);
+    libzerocoin::Accumulator accumulator = mapAccumulators.GetAccumulator(coinwitness.denom);
     auto nChecksum = GetChecksum(accumulator.getValue());
     CBigNum bnValue;
     if (!GetAccumulatorValueFromChecksum(nChecksum, false, bnValue) || bnValue == 0)
         return error("%s: could not find checksum used for spend\n", __func__);
 
     try {
-        libzerocoin::CoinSpend spend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, *coinwitness->pWitness, hashTxOut, spendType);
+        libzerocoin::CoinSpend spend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, *coinwitness.pWitness, hashTxOut, spendType);
 
         std::string strError;
         if (!spend.Verify(accumulator, strError, true)) {
@@ -5543,7 +5552,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
         serializedCoinSpend << spend;
         std::vector<unsigned char> data(serializedCoinSpend.begin(), serializedCoinSpend.end());
 
-        //Add the coin spend into a PIVX transaction
+        //Add the coin spend into a transaction
         newTxIn.scriptSig = CScript() << OP_ZEROCOINSPEND << data.size();
         newTxIn.scriptSig.insert(newTxIn.scriptSig.end(), data.begin(), data.end());
         newTxIn.prevout.SetNull();
@@ -5577,7 +5586,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
         auto nAccumulatorChecksum = GetChecksum(accumulator.getValue());
         CZerocoinSpend zcSpend(spend.getCoinSerialNumber(), uint256(), zerocoinSelected.GetValue(),
                 zerocoinSelected.GetDenomination(), nAccumulatorChecksum);
-        zcSpend.SetMintCount(coinwitness->nMintsAdded);
+        zcSpend.SetMintCount(coinwitness.nMintsAdded);
         receipt.AddSpend(zcSpend);
     } catch (const std::exception&) {
         receipt.SetStatus(_("CoinSpend: Accumulator witness does not verify"), ZINVALID_WITNESS);
@@ -6351,24 +6360,12 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
             //hash with only the output info in it to be used in Signature of Knowledge
             uint256 hashTxOut = wtxNew.tx->GetOutputsHash();
 
-            int nLockAttempts = 0;
-            while (nLockAttempts < 100) {
-                TRY_LOCK(zTracker->cs_spendcache, lockSpendcache);
-                if (!lockSpendcache) {
-                    fGlobalUnlockSpendCache = true;
-                    MilliSleep(100);
-                    ++nLockAttempts;
-                    continue;
-                }
-
-                //add all of the mints to the transaction as inputs
-                for (CZerocoinMint& mint : vSelectedMints) {
-                    CTxIn newTxIn;
-                    if (!MintToTxIn(mint, nSecurityLevel, hashTxOut, newTxIn, receipt, libzerocoin::SpendType::SPEND))
-                        return false;
-                    mtx.vin.push_back(newTxIn);
-                }
-                break;
+            //add all of the mints to the transaction as inputs
+            for (CZerocoinMint& mint : vSelectedMints) {
+                CTxIn newTxIn;
+                if (!MintToTxIn(mint, nSecurityLevel, hashTxOut, newTxIn, receipt, libzerocoin::SpendType::SPEND))
+                    return false;
+                mtx.vin.push_back(newTxIn);
             }
 
             // Limit size
@@ -6476,12 +6473,7 @@ void CWallet::PrecomputeSpends()
         return;
     }
 
-    // Create LRU Cache
-    std::list<std::pair<uint256, CoinWitnessCacheData> > item_list;
-    std::map<uint256, list<std::pair<uint256, CoinWitnessCacheData> >::iterator> item_map;
-
-    // Dirty cache that needs to be written to disk
-    std::map<uint256, CoinWitnessCacheData> mapDirtyWitnessData;
+    LRUCache lru;
 
     // Initialize Variables
     bool fLoadedPrecomputesFromDB = false;
@@ -6489,198 +6481,167 @@ void CWallet::PrecomputeSpends()
     int64_t nLastCacheCleanUpTime = GetTime();
     int64_t nLastCacheWriteDB = nLastCacheCleanUpTime;
     int nRequiredStakeDepthBuffer = Params().Zerocoin_RequiredStakeDepth() + 10;
-    int nAdjustableCacheLength = gArgs.GetArg("-precomputecachelength", DEFAULT_PRECOMPUTE_LENGTH);
+    //int nAdjustableCacheLength = gArgs.GetArg("-precomputecachelength", DEFAULT_PRECOMPUTE_LENGTH);
+    int nAdjustableCacheLength = 100;
 
     // Force the cache length to be divisible by 10
     if (nAdjustableCacheLength % 10)
         nAdjustableCacheLength -= nAdjustableCacheLength % 10;
 
-    if (nAdjustableCacheLength < MIN_PRECOMPUTE_LENGTH)
-        nAdjustableCacheLength = MIN_PRECOMPUTE_LENGTH;
-
-    if (nAdjustableCacheLength > MAX_PRECOMPUTE_LENGTH)
-        nAdjustableCacheLength = MAX_PRECOMPUTE_LENGTH;
+//    if (nAdjustableCacheLength < MIN_PRECOMPUTE_LENGTH)
+//        nAdjustableCacheLength = MIN_PRECOMPUTE_LENGTH;
+//
+//    if (nAdjustableCacheLength > MAX_PRECOMPUTE_LENGTH)
+//        nAdjustableCacheLength = MAX_PRECOMPUTE_LENGTH;
 
     while (true) {
         // Check to see if we need to clear the cache
         if (fClearSpendCache) {
             fClearSpendCache = false;
-            item_map.clear();
-            item_list.clear();
-            mapDirtyWitnessData.clear();
+            lru.Clear();
             nLastCacheCleanUpTime = GetTime();
             nLastCacheWriteDB = nLastCacheCleanUpTime;
-        }
-
-        // Get the list of zPIV inputs
-        std::list <std::unique_ptr<ZerocoinStake>> listInputs;
-        if (!SelectStakeCoins(listInputs, 0)) {
-            MilliSleep(5000);
-            continue;
-        }
-
-        if (listInputs.empty()) {
-            MilliSleep(5000);
-            continue;
         }
 
         if (ShutdownRequested())
             break;
 
-        while (IsLocked())
+        if (IsInitialBlockDownload() || !HeadersAndBlocksSynced()) {
             MilliSleep(5000);
+            continue;
+        }
+
+        // Get full list of spendable zerocoin mints
+        std::set<CMintMeta> setMints = zTracker->ListMints(/*fUnusedOnly*/true, /*fMatureOnly*/true, /*fUpdate*/true);
+        if (setMints.empty() || IsLocked()) {
+            MilliSleep(5000);
+            continue;
+        }
 
         // If we haven't loaded from database yet, load the precomputes from the database
         if (!fLoadedPrecomputesFromDB) {
             // Load the precomputes into the LRU cache
-            if (!pprecomputeDB->LoadPrecomputes(item_list, item_map))
+            if (!pprecomputeDB->LoadPrecomputes(&lru))
                 LogPrint(BCLog::PRECOMPUTE, "%s: Failed to load precompute database\n", __func__);
             fLoadedPrecomputesFromDB = true;
             LogPrint(BCLog::PRECOMPUTE, "%s: Loaded precomputes from database. Size of lru cache: %d\n", __func__,
-                     item_map.size());
+                     lru.Size());
+
+            // Link LRU cache to zTracker
+            LOCK(zTracker->cs_readlock);
+            for (const auto& meta : setMints) {
+                CoinWitnessData *witnessData;
+                if (zTracker->HasSpendCache(meta.hashSerial)) {
+                    witnessData = zTracker->GetSpendCache(meta.hashSerial);
+                } else {
+                    LOCK(zTracker->cs_modify_lock);
+                    witnessData = zTracker->CreateSpendCache(meta.hashSerial);
+                }
+
+                if (lru.Contains(meta.hashSerial)) {
+                    *witnessData = lru.GetWitnessData(meta.hashSerial);
+                }
+            }
         }
 
         // Do some precomputing of zerocoin spend knowledge proofs
         std::set <uint256> setInputHashes;
-        for (std::unique_ptr <ZerocoinStake>& stakeInput : listInputs) {
+        for (const CMintMeta& meta : setMints) {
             if (ShutdownRequested() || IsLocked())
                 break;
 
             CoinWitnessCacheData tempDataHolder;
-
             {
-                TRY_LOCK(zTracker->cs_spendcache, fLocked);
-                if (!fLocked)
-                    continue;
+                CoinWitnessData* witnessData;
+                {
+                    TRY_LOCK(zTracker->cs_readlock, fLocked);
+                    if (!fLocked)
+                        continue;
 
-                if (fGlobalUnlockSpendCache) {
-                    break;
+                    if (fGlobalUnlockSpendCache) {
+                        break;
+                    }
+
+                    // When we see a clear spend cache bool set to true, break out of the loop
+                    // All cache data will be cleared at the beginning of the while loop above
+                    if (fClearSpendCache) {
+                        break;
+                    }
+
+                    setInputHashes.insert(meta.hashSerial);
+                    if (zTracker->HasSpendCache(meta.hashSerial)) {
+                        witnessData = zTracker->GetSpendCache(meta.hashSerial);
+                    } else {
+                        LOCK(zTracker->cs_modify_lock);
+                        witnessData = zTracker->CreateSpendCache(meta.hashSerial);
+                    }
                 }
-
-                // When we see a clear spend cache bool set to true, break out of the loop
-                // All cache data will be cleared at the beginning of the while loop above
-                if (fClearSpendCache) {
-                    break;
-                }
-
-                uint256 serialHash = stakeInput->GetSerialHash();
-                setInputHashes.insert(serialHash);
-                CoinWitnessData* witnessData = zTracker->GetSpendCache(serialHash);
 
                 // Initialize nHeightStop so it can be set below
                 int nHeightStop = 0;
 
-                if (witnessData->nHeightAccStart) { // Witness is already valid
-                    nHeightStop = std::min(chainActive.Height() - nRequiredStakeDepthBuffer,
-                                           (witnessData->nHeightAccEnd ? witnessData->nHeightAccEnd
-                                                                       : witnessData->nHeightAccStart) +
-                                           nAdjustableCacheLength);
-                } else if (item_map.count(serialHash)) { // Check Database cache
-                    // Get the witness data from the cache
-                    auto it = item_map.find(serialHash);
-                    item_list.splice(item_list.begin(), item_list, it->second);
+                // Precomputes takes a lower priority than the use (spend/stake) of a precompute, just move on in the rare
+                // case that this is locked somewhere else
+                TRY_LOCK(witnessData->cs, fLockWitness);
+                if (!fLockWitness)
+                    continue;
 
-                    *witnessData = CoinWitnessData(it->second->second);
-
-                    // Set the stop height from the variables received from the database cache
-                    nHeightStop = std::min(chainActive.Height() - nRequiredStakeDepthBuffer,
-                                           (witnessData->nHeightAccEnd ? witnessData->nHeightAccEnd
-                                                                       : witnessData->nHeightAccStart) +
-                                           nAdjustableCacheLength);
-
-                    LogPrint(BCLog::PRECOMPUTE, "%s: Got Witness Data from lru cache: %s\n", __func__,
-                             witnessData->ToString());
-                } else if (mapDirtyWitnessData.count(serialHash) || pprecomputeDB->ReadPrecompute(serialHash, tempDataHolder)) {
-                    if (mapDirtyWitnessData.count(serialHash)) {
-                        // Get the witness data from the dirty cache if it exists
-                        *witnessData = CoinWitnessData(mapDirtyWitnessData.at(serialHash));
-                        LogPrint(BCLog::PRECOMPUTE, "%s: Got Witness Data from mapDirtyWitnessData: %s\n", __func__,
-                                 witnessData->ToString());
-                    } else {
-                        // Get the witness data from the database
+                /** If Witness is not already valid and loaded, then load/create it **/
+                if (!witnessData->nHeightAccStart) {
+                    if (lru.Contains(meta.hashSerial)) {
+                        /** Load witness from cache **/
+                        *witnessData = lru.GetWitnessData(meta.hashSerial);
+                        LogPrint(BCLog::PRECOMPUTE, "%s: Got Witness Data from lru cache: %s\n", __func__, witnessData->ToString());
+                    } else if (pprecomputeDB->ReadPrecompute(meta.hashSerial, tempDataHolder)) {
+                        /** Precompute was found on disk but not loaded to LRU **/
                         *witnessData = CoinWitnessData(tempDataHolder);
-                        LogPrint(BCLog::PRECOMPUTE, "%s: Got Witness Data from precompute database: %s\n", __func__,
-                                 witnessData->ToString());
+                        lru.AddNew(meta.hashSerial, tempDataHolder);
+                        LogPrint(BCLog::PRECOMPUTE, "%s: Got Witness Data from precompute database: %s\n", __func__, witnessData->ToString());
+                    } else {
+                        /** No cache, so initialize new **/
+                        CZerocoinMint mint;
+                        if (!GetMint(meta.hashSerial, mint))
+                            continue;
+                        *witnessData = CoinWitnessData(mint);
+                        nHeightStop = std::min(chainActive.Height() - nRequiredStakeDepthBuffer,
+                                               mint.GetHeight() + nAdjustableCacheLength);
                     }
-
-                    // Set the stop height from the variables received from the database cache
-                    nHeightStop = std::min(chainActive.Height() - nRequiredStakeDepthBuffer,
-                                           (witnessData->nHeightAccEnd ? witnessData->nHeightAccEnd
-                                                                       : witnessData->nHeightAccStart) +
-                                           nAdjustableCacheLength);
-
-                    // Add the serialHash found into the cache
-                    item_list.push_front(make_pair(serialHash, tempDataHolder));
-                    item_map.insert(make_pair(serialHash, item_list.begin()));
-
-                    // We just added a new hash into our LRU cache, so remove it if we also have it in the dirty map
-                    mapDirtyWitnessData.erase(serialHash);
-
-                    if (item_map.size() > PRECOMPUTE_LRU_CACHE_SIZE) {
-                        auto last_it = item_list.end(); last_it --;
-                        item_map.erase(last_it->first);
-                        CoinWitnessCacheData removedData = item_list.back().second;
-                        mapDirtyWitnessData[serialHash] = removedData;
-                        item_list.pop_back();
-                    }
-                } else { // This has no cache, so initialize it
-                    CZerocoinMint mint;
-                    if (!GetMintFromStakeHash(serialHash, mint))
-                        continue;
-                    *witnessData = CoinWitnessData(mint);
-                    nHeightStop = std::min(chainActive.Height() - nRequiredStakeDepthBuffer,
-                                           mint.GetHeight() + nAdjustableCacheLength);
                 }
 
-                if (nHeightStop - (witnessData->nHeightAccEnd ? witnessData->nHeightAccEnd : witnessData->nHeightAccStart) < 20)
+                if (!nHeightStop) {
+                    // Set the stop height from the variables received from the database cache
+                    int nStakeHeight = chainActive.Height() - nRequiredStakeDepthBuffer;
+                    int nAdjustableHeight = (witnessData->nHeightPrecomputed ? witnessData->nHeightPrecomputed : witnessData->nHeightAccStart) + nAdjustableCacheLength;
+                    nHeightStop = std::min(nStakeHeight, nAdjustableHeight);
+                }
+
+                LogPrint(BCLog::PRECOMPUTE, "%s: StopHeight: %d already precomputedheight: %d\n", __func__, nHeightStop, witnessData->nHeightPrecomputed);
+
+                // Leave a buffer of 20 blocks between what to precompute
+                if (nHeightStop - (witnessData->nHeightPrecomputed ? witnessData->nHeightPrecomputed : witnessData->nHeightAccStart) < 20)
                     continue;
 
                 CBlockIndex* pindexStop = chainActive[nHeightStop];
                 AccumulatorMap mapAccumulators(Params().Zerocoin_Params());
-                LogPrint(BCLog::PRECOMPUTE,"%s: caching mint %s of denom %d start=%d stop=%d end=%s\n", __func__,
+                LogPrint(BCLog::PRECOMPUTE,"%s: caching mint %s of denom %d start=%d stop=%d precomputed_to=%s\n", __func__,
                          witnessData->coin->getValue().GetHex().substr(0, 6),
                          ZerocoinDenominationToInt(witnessData->denom),
-                         witnessData->nHeightAccStart, nHeightStop, witnessData->nHeightAccEnd);
+                         witnessData->nHeightAccStart, nHeightStop, witnessData->nHeightPrecomputed);
 
+                /** Add to current precomputed witness **/
                 std::string strError;
                 if (!GenerateAccumulatorWitness(witnessData, mapAccumulators, 100, strError, pindexStop)) {
                     LogPrintf("%s: Generate witness failed!\n", __func__);
-
                     // If we fail this check, we need to make sure we remove this from the LRU cache
-                    auto it = item_map.find(serialHash);
-                    if (it != item_map.end())
-                    {
-                        item_list.erase(it->second);
-                        item_map.erase(it);
-                    }
-                    mapDirtyWitnessData.erase(serialHash);
-                    pprecomputeDB->ErasePrecompute(serialHash);
+                    lru.Remove(meta.hashSerial);
+                    pprecomputeDB->ErasePrecompute(meta.hashSerial);
                     continue;
                 }
 
-
+                /** Update LRU with new data **/
                 CoinWitnessCacheData serialData(witnessData);
-
-                // If the LRU cache already has a entry for it, update the entry and move it to the front of the list
-                auto it = item_map.find(serialHash);
-                if (it != item_map.end()) {
-                    item_list.splice(item_list.begin(), item_list, it->second);
-                    item_list.begin()->second = serialData;
-                } else {
-                    item_list.push_front(make_pair(serialHash, serialData));
-                    item_map.insert(make_pair(serialHash, item_list.begin()));
-                }
-
-                // We just added a new hash into our LRU cache, so remove it if we also have it in the dirty map
-                mapDirtyWitnessData.erase(serialHash);
-
-                // Clean up the LRU cache to the max size
-                while (item_map.size() > PRECOMPUTE_LRU_CACHE_SIZE) {
-                    auto last_it = item_list.end(); last_it --;
-                    item_map.erase(last_it->first);
-                    mapDirtyWitnessData[serialHash] = item_list.back().second;
-                    item_list.pop_back();
-                }
+                lru.AddToCache(meta.hashSerial, serialData);
+                lru.FlushToDisk(pprecomputeDB.get());
             }
             // Sleep for 150ms to allow any potential spend attempt
             MilliSleep(150);
@@ -6697,7 +6658,7 @@ void CWallet::PrecomputeSpends()
             // We only want to clear the cache if we have calculated new witness data
             if (setInputHashes.size()) {
                 // Get a list of hashes currently in the database
-                set <uint256> databaseHashes;
+                std::set<uint256> databaseHashes;
                 if (!pprecomputeDB->LoadPrecomputes(databaseHashes)) {
                     LogPrintf("%s: failed to load precompute hashes\n", __func__);
                 }
@@ -6709,13 +6670,7 @@ void CWallet::PrecomputeSpends()
 
                 // Erase all old hashes from the database
                 for (auto hash : databaseHashes) {
-                    auto it = item_map.find(hash);
-                    if (it != item_map.end())
-                    {
-                        item_list.erase(it->second);
-                        item_map.erase(it);
-                    }
-                    mapDirtyWitnessData.erase(hash);
+                    lru.Remove(hash);
                     pprecomputeDB->ErasePrecompute(hash);
                 }
 
@@ -6724,19 +6679,9 @@ void CWallet::PrecomputeSpends()
         }
 
         // On first load, and every 5 minutes write the cache to database
-        if (mapDirtyWitnessData.size() > PRECOMPUTE_MAX_DIRTY_CACHE_SIZE || nLastCacheWriteDB < GetTime() - 30 /**PRECOMPUTE_FLUSH_TIME*/ || ShutdownRequested()) {
-            // Save all cache data that was dirty back into the database
-            for (auto item : mapDirtyWitnessData) {
-                pprecomputeDB->WritePrecompute(item.first, item.second);
-            }
-            mapDirtyWitnessData.clear();
-
-            // Save the LRU cache data into the database
-            for (auto item : item_list) {
-                pprecomputeDB->WritePrecompute(item.first, item.second);
-            }
-
-            LogPrint(BCLog::PRECOMPUTE, "%s: Writing precomputes to database. Precomputes size: %d\n", __func__, item_map.size());
+        if (lru.Size() > PRECOMPUTE_MAX_DIRTY_CACHE_SIZE || nLastCacheWriteDB < GetTime() - 30 /**PRECOMPUTE_FLUSH_TIME*/ || ShutdownRequested()) {
+            lru.FlushToDisk(pprecomputeDB.get());
+            LogPrint(BCLog::PRECOMPUTE, "%s: Writing precomputes to database. Precomputes size: %d\n", __func__, lru.Size());
             nLastCacheWriteDB = GetTime();
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6506,6 +6506,7 @@ void CWallet::PrecomputeSpends()
             lru.Clear();
             nLastCacheCleanUpTime = GetTime();
             nLastCacheWriteDB = nLastCacheCleanUpTime;
+            MilliSleep(5000);
         }
 
         if (ShutdownRequested())

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1348,7 +1348,7 @@ public:
     };
 };
 
-void DumpPrecomputes();
+
 
 /** A key allocated from the key pool. */
 class CReserveKey final : public CReserveScript
@@ -1415,8 +1415,6 @@ public:
         }
     }
 };
-
-void ThreadPrecomputeSpends();
 
 // Calculate the size of the transaction assuming all signatures are max size
 // Use DummySignatureCreator, which inserts 71 byte signatures everywhere.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -678,6 +678,8 @@ protected:
     std::unique_ptr<CzTracker> zTracker;
     bool fUnlockForStakingOnly = false;
     bool fStakingEnabled = true;
+    bool fPrecomputingEnabled = false;
+
 
     WalletBatch *encrypted_batch = nullptr;
 
@@ -966,6 +968,11 @@ public:
     bool IsUnlockedForStakingOnly() const { return fUnlockForStakingOnly; }
     void SetStakingEnabled(bool fStakingEnabled) { this->fStakingEnabled = fStakingEnabled; }
     bool IsStakingEnabled() const { return fStakingEnabled; }
+
+    bool StartPrecomputing(std::string& strStatus);
+    void StopPrecomputing();
+    void SetPrecomputingEnabled(bool fPrecomputingEnabled) { this->fPrecomputingEnabled = fPrecomputingEnabled; }
+    bool IsPrecomputingEnabled() const { return fPrecomputingEnabled; }
 
     /*
      * Rescan abort properties

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1348,6 +1348,8 @@ public:
     };
 };
 
+void DumpPrecomputes();
+
 /** A key allocated from the key pool. */
 class CReserveKey final : public CReserveScript
 {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -16,6 +16,7 @@
 #include <utiltime.h>
 #include <wallet/wallet.h>
 #include <wallet/deterministicmint.h>
+#include "veil/zerocoin/witness.h"
 
 #include <atomic>
 #include <string>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -43,6 +43,7 @@ class uint256;
 class CDeterministicMint;
 class CZerocoinMint;
 class CZerocoinSpend;
+class CoinWitnessCacheData;
 
 /** Backend-agnostic database type. */
 using WalletDatabase = BerkeleyDatabase;
@@ -280,6 +281,7 @@ public:
     bool ReadZCount(uint32_t &nCount);
     std::map<CKeyID, std::vector<std::pair<uint256, uint32_t> > > MapMintPool();
     bool WriteMintPoolPair(const CKeyID& hashMasterSeed, const uint256& hashPubcoin, const uint32_t& nCount);
+
 protected:
     BerkeleyBatch m_batch;
     WalletDatabase& m_database;


### PR DESCRIPTION
- Precomputing is **disabled by default**
- Precomputing is used to make spending zerocoin smoother and quicker
- Precomputing should decrease orphan rate of stakes by making spends take less time
- You can start or stop it by running the rpc call **startprecomputing** or **stoprecomputing**
- View precomputing progess with rpc call **showspendcache**
- Set the precompute blocks per cycle with rpc call **setprecomputeblockspercycle**
- Get the current blocks per cycle with rpc call **getprecomputeblockpercycle**
- Clear your cache and precompute database with **clearspendcache**
- Enable precompute always by starting with or adding the flag **precompute=1** into your veil.conf
- Set the precomputeblockpercycle with by starting with or adding the flag **precomputeblockpercycle=number** into your veil.conf
- Precomputing uses it own database which can be cleared manually by deleting the database file in the data directory. Or by using the rpc call **clearspendcache**

**Update: Use this branch at your own will. This branch is currently being tested, and is not fully supported by the Dev Team yet**

Solves Issues: #447 #448 #449 #450 

**Update: Added QT checkbox to turn off an on precomputing 51b5e37495f57d12c2a11447c29c71b7423c1c99
![Screenshot_20190321_100410](https://user-images.githubusercontent.com/8285518/54766775-85f97400-4bc1-11e9-8b5b-8636224b5ec8.png)
![Screenshot_20190321_100502](https://user-images.githubusercontent.com/8285518/54766779-872aa100-4bc1-11e9-8bf8-91741b56f8bd.png)
![Screenshot_20190321_100518](https://user-images.githubusercontent.com/8285518/54766782-885bce00-4bc1-11e9-84b3-3e3c1fc7d44e.png)


