### PR TITLE
[QT] Enable return/enter on unlock screen password submission

### DIFF
--- a/src/qt/veil/forms/unlockpassworddialog.ui
+++ b/src/qt/veil/forms/unlockpassworddialog.ui
@@ -236,6 +236,9 @@ border-bottom:1px solid #bababa;</string>
              <property name="text">
               <string>UNLOCK</string>
              </property>
+             <property name="default">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>


### PR DESCRIPTION
- After typing your password to unlock the wallet. You had to use the mouse to click the unlock button. This change enables the use of the return/enter key to trigger the unlock button. 