### PR TITLE
Add coin control updates to veil send dialog

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -555,7 +555,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         if (nDepth < 1)
             continue;
 
-        for(unsigned int i = 1; i < txRecord.vout.size(); i++) {
+        for(unsigned int i = 0; i < txRecord.vout.size(); i++) {
             COutputRecord outputRecord = txRecord.vout[i];
 
             // unselect already spent, very unlikely scenario, this could happen

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -54,6 +54,7 @@ public:
     static QList<CAmount> payAmounts;
     static CCoinControl *coinControl();
     static bool fSubtractFeeFromAmount;
+    static int nCurrentCoinTypeSelected;
 
 private:
     Ui::CoinControlDialog *ui;
@@ -70,7 +71,7 @@ private:
     const PlatformStyle *platformStyle;
 
     void sortView(int, Qt::SortOrder);
-    void updateView(int nCoinType = 1); // 1 = OUTPUT_STANDARD
+    void updateView(int nCoinType = nCurrentCoinTypeSelected);
 
     enum
     {

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -70,7 +70,7 @@ private:
     const PlatformStyle *platformStyle;
 
     void sortView(int, Qt::SortOrder);
-    void updateView();
+    void updateView(int nCoinType = 1); // 1 = OUTPUT_STANDARD
 
     enum
     {
@@ -108,6 +108,7 @@ private Q_SLOTS:
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
     void updateLabelLocked();
+    void coinTypeChanged(int);
 };
 
 #endif // BITCOIN_QT_COINCONTROLDIALOG_H

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -358,7 +358,7 @@ font-size:13.5px;</string>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0">
+          <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0">
            <property name="spacing">
             <number>14</number>
            </property>
@@ -387,7 +387,7 @@ font-size:13.5px;</string>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Tree mode</string>
+              <string>&amp;Tree mode</string>
              </property>
             </widget>
            </item>
@@ -400,10 +400,20 @@ font-size:13.5px;</string>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>List mode</string>
+              <string>&amp;List mode</string>
              </property>
              <property name="checked">
               <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="coinTypeComboBox">
+             <property name="currentText">
+              <string/>
+             </property>
+             <property name="maxVisibleItems">
+              <number>3</number>
              </property>
             </widget>
            </item>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -47,9 +47,12 @@ border:none;</string>
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="bottomMargin">
+         <number>10</number>
+        </property>
         <item>
          <widget class="QLabel" name="title">
           <property name="styleSheet">
@@ -61,7 +64,7 @@ border:none;</string>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_3">
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -72,6 +75,276 @@ border:none;</string>
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout">
+          <property name="horizontalSpacing">
+           <number>10</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>10</number>
+          </property>
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelCoinControlQuantityText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>Quantity:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="labelCoinControlQuantity">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>0</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelCoinControlBytesText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>Bytes:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="labelCoinControlBytes">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>0</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="horizontalSpacing">
+           <number>10</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>10</number>
+          </property>
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelCoinControlAmountText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>Amount:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="labelCoinControlAmount">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>0.00 Veil</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelCoinControlLowOutputText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>Dust:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="labelCoinControlLowOutput">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>no</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout_3">
+          <property name="horizontalSpacing">
+           <number>10</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>10</number>
+          </property>
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelCoinControlFeeText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>Fee:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="labelCoinControlFee">
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>0.00 Veil</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout_4">
+          <property name="horizontalSpacing">
+           <number>10</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>10</number>
+          </property>
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelCoinControlAfterFeeText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>After Fee:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="labelCoinControlAfterFee">
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>0.00 Veil</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelCoinControlChangeText">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>Change:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="labelCoinControlChange">
+            <property name="styleSheet">
+             <string notr="true">color: black</string>
+            </property>
+            <property name="text">
+             <string>0.00 Veil</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -90,8 +363,8 @@ margin:0px;</string>
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>832</width>
-           <height>539</height>
+           <width>842</width>
+           <height>526</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">
@@ -132,7 +405,7 @@ margin:0px;</string>
        </widget>
       </item>
       <item>
-       <widget class="QFrame" name="">
+       <widget class="QFrame" name="frame">
         <property name="styleSheet">
          <string notr="true">QToolTip {
     color: #ffffff;

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -92,7 +92,7 @@
             <enum>Qt::StrongFocus</enum>
            </property>
            <property name="toolTip">
-            <string>The Veil address to send the payment to</string>
+            <string>The Veil stealth address to send the payment to</string>
            </property>
            <property name="styleSheet">
             <string notr="true">#payTo {   

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -120,6 +120,9 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     if (!settings.contains("fPayOnlyMinFee"))
         settings.setValue("fPayOnlyMinFee", false);
     minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+
+    //Hide all coincontrol labels
+    HideCoinControlLabels();
 }
 
 void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
@@ -195,6 +198,44 @@ SendCoinsDialog::~SendCoinsDialog()
     //settings.setValue("fPayOnlyMinFee", ui->checkBoxMinimumFee->isChecked());
 
     delete ui;
+}
+
+void SendCoinsDialog::HideCoinControlLabels()
+{
+    ui->horizontalSpacer_2->changeSize(1,1, QSizePolicy::Expanding, QSizePolicy::Fixed);
+    ui->labelCoinControlBytes->hide();
+    ui->labelCoinControlBytesText->hide();
+    ui->labelCoinControlQuantity->hide();
+    ui->labelCoinControlQuantityText->hide();
+    ui->labelCoinControlAmount->hide();
+    ui->labelCoinControlAmountText->hide();
+    ui->labelCoinControlLowOutput->hide();
+    ui->labelCoinControlLowOutputText->hide();
+    ui->labelCoinControlFee->hide();
+    ui->labelCoinControlFeeText->hide();
+    ui->labelCoinControlAfterFee->hide();
+    ui->labelCoinControlAfterFeeText->hide();
+    ui->labelCoinControlChange->hide();
+    ui->labelCoinControlChangeText->hide();
+}
+
+void SendCoinsDialog::ShowCoinCointrolLabels()
+{
+    ui->horizontalSpacer_2->changeSize(0,0, QSizePolicy::Fixed, QSizePolicy::Fixed);
+    ui->labelCoinControlBytes->show();
+    ui->labelCoinControlBytesText->show();
+    ui->labelCoinControlQuantity->show();
+    ui->labelCoinControlQuantityText->show();
+    ui->labelCoinControlAmount->show();
+    ui->labelCoinControlAmountText->show();
+    ui->labelCoinControlLowOutput->show();
+    ui->labelCoinControlLowOutputText->show();
+    ui->labelCoinControlFee->show();
+    ui->labelCoinControlFeeText->show();
+    ui->labelCoinControlAfterFee->show();
+    ui->labelCoinControlAfterFeeText->show();
+    ui->labelCoinControlChange->show();
+    ui->labelCoinControlChangeText->show();
 }
 
 void SendCoinsDialog::on_sendButton_clicked()
@@ -862,6 +903,7 @@ void SendCoinsDialog::coinControlChangeEdited(const QString& text)
 // Coin Control: update labels
 void SendCoinsDialog::coinControlUpdateLabels()
 {
+
     if (!model || !model->getOptionsModel())
         return;
 
@@ -885,15 +927,16 @@ void SendCoinsDialog::coinControlUpdateLabels()
 
     if (CoinControlDialog::coinControl()->HasSelected())
     {
+
         // actual coin control calculation
         CoinControlDialog::updateLabels(model, this);
 
-        // show coin control stats
-        //ui->labelCoinControlAutomaticallySelected->hide();
-        //ui->widgetCoinControl->show();
+        // Show coin control stats
+        ShowCoinCointrolLabels();
     }
     else
     {
+        HideCoinControlLabels();
         // hide coin control stats
         //ui->labelCoinControlAutomaticallySelected->show();
         //ui->widgetCoinControl->hide();

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -47,6 +47,9 @@ public:
     void pasteEntry(const SendCoinsRecipient &rv);
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
 
+    void HideCoinControlLabels();
+    void ShowCoinCointrolLabels();
+
 public Q_SLOTS:
     void clear();
     void reject();

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -58,7 +58,7 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
     ui->payTo_is->setFont(GUIUtil::fixedPitchFont());
 
     // Connect signals
-    //connect(ui->payAmount, SIGNAL(valueChanged()), this, SIGNAL(payAmountChanged()));
+    connect(ui->payAmount, SIGNAL(textChanged(QString)), this, SIGNAL(payAmountChanged()));
     //connect(ui->checkboxSubtractFeeFromAmount, SIGNAL(toggled(bool)), this, SIGNAL(subtractFeeFromAmountChanged()));
     connect(ui->btnRemove, SIGNAL(clicked()), this, SLOT(deleteClicked()));
     connect(ui->deleteButton_is, SIGNAL(clicked()), this, SLOT(deleteClicked()));


### PR DESCRIPTION
- Added labels to the send dialong if coin control has selected coins
- Added coin type selector to coin control for easier access to certain coins

New Labels
![image](https://user-images.githubusercontent.com/8285518/55436098-a8dc3e80-5558-11e9-83d1-2dc1b9064ca5.png)

New dropdown menu 
![image](https://user-images.githubusercontent.com/8285518/55436142-bee9ff00-5558-11e9-8de8-699f750f804d.png)

Dropdown menu items
![image](https://user-images.githubusercontent.com/8285518/55436255-0b353f00-5559-11e9-8d8e-bd75d750e891.png)


**GUI might look off because I am taking these screen shots on linux running kubutu**
**This needs to be tested on all platforms**

#430