### PR TITLE
Add zerocoin to coincontrol

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -327,6 +327,11 @@ public:
         return m_wallet.MintZerocoin(nValue, wtx , vDMints, inputtype,coinControl);
     }
 
+    bool getMint(const uint256& serialHash, CZerocoinMint& mint) override
+    {
+        return m_wallet.GetMint(serialHash, mint);
+    }
+
     std::unique_ptr<PendingWalletTx> prepareZerocoinSpend(CAmount nValue, int nSecurityLevel,
             CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange,
             bool fMinimizeChange, std::vector<CommitData>& vCommitData, libzerocoin::CoinDenomination denomFilter,
@@ -712,6 +717,10 @@ public:
             return 0;
         }
         return m_wallet.GetAnonWallet()->GetAvailableAnonBalance(&coin_control);
+    }
+    CAmount getAvailableZerocoinBalance(const CCoinControl& coin_control) override
+    {
+        return m_wallet.GetAvailableZerocoinBalance(&coin_control);
     }
     CWallet* getWalletPointer() override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -110,6 +110,8 @@ public:
     virtual std::string mintZerocoin(CAmount nValue, std::vector<CDeterministicMint>& vDMints, OutputTypes inputtype,
             const CCoinControl* coinControl) = 0;
 
+    virtual bool getMint(const uint256& serialHash, CZerocoinMint& mint) = 0;
+
     virtual std::unique_ptr<PendingWalletTx> prepareZerocoinSpend(CAmount nValue, int nSecurityLevel,
             CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange,
             bool fMinimizeChange, std::vector<std::tuple<CWalletTx, std::vector<CDeterministicMint>,
@@ -238,6 +240,7 @@ public:
     virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
     virtual CAmount getAvailableCTBalance(const CCoinControl& coin_control) { return 0; }
     virtual CAmount getAvailableRingCTBalance(const CCoinControl& coin_control) { return 0; }
+    virtual CAmount getAvailableZerocoinBalance(const CCoinControl& coin_control) = 0;
 
     //! Create a WalletTx without all the data filled in yet.
     virtual CWallet* getWalletPointer() { return nullptr; }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -24,6 +24,7 @@ enum OutputTypes
     OUTPUT_CT               = 2,
     OUTPUT_RINGCT           = 3,
     OUTPUT_DATA             = 4,
+    OUTPUT_ZC               = 5,
 };
 
 enum TransactionTypes

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -24,7 +24,6 @@ enum OutputTypes
     OUTPUT_CT               = 2,
     OUTPUT_RINGCT           = 3,
     OUTPUT_DATA             = 4,
-    OUTPUT_ZC               = 5,
 };
 
 enum TransactionTypes

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -55,6 +55,7 @@ public:
     static CCoinControl *coinControl();
     static bool fSubtractFeeFromAmount;
     static int nCurrentCoinTypeSelected;
+    static bool fSpendingZerocoin;
 
 private:
     Ui::CoinControlDialog *ui;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -67,6 +67,7 @@ private:
     QAction *copyTransactionHashAction;
     QAction *lockAction;
     QAction *unlockAction;
+    QAction *copyStakeHash;
 
     const PlatformStyle *platformStyle;
 

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -78,6 +78,9 @@
               <bold>true</bold>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
+            </property>
             <property name="text">
              <string>Quantity:</string>
             </property>
@@ -90,6 +93,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::ActionsContextMenu</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string notr="true">0</string>
@@ -107,6 +113,9 @@
               <bold>true</bold>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
+            </property>
             <property name="text">
              <string>Bytes:</string>
             </property>
@@ -119,6 +128,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::ActionsContextMenu</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string notr="true">0</string>
@@ -152,6 +164,9 @@
               <bold>true</bold>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
+            </property>
             <property name="text">
              <string>Amount:</string>
             </property>
@@ -164,6 +179,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::ActionsContextMenu</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string notr="true">0.00 Veil</string>
@@ -232,6 +250,9 @@
               <bold>true</bold>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
+            </property>
             <property name="text">
              <string>Fee:</string>
             </property>
@@ -244,6 +265,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::ActionsContextMenu</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string notr="true">0.00 Veil</string>
@@ -277,6 +301,9 @@
               <bold>true</bold>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
+            </property>
             <property name="text">
              <string>After Fee:</string>
             </property>
@@ -289,6 +316,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::ActionsContextMenu</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string notr="true">0.00 Veil</string>
@@ -309,6 +339,9 @@
               <bold>true</bold>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
+            </property>
             <property name="text">
              <string>Change:</string>
             </property>
@@ -324,6 +357,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::ActionsContextMenu</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string notr="true">0.00 Veil</string>
@@ -409,11 +445,8 @@ font-size:13.5px;</string>
            </item>
            <item>
             <widget class="QComboBox" name="coinTypeComboBox">
-             <property name="currentText">
-              <string/>
-             </property>
-             <property name="maxVisibleItems">
-              <number>3</number>
+             <property name="styleSheet">
+              <string notr="true"/>
              </property>
             </widget>
            </item>
@@ -450,7 +483,9 @@ font-size:13.5px;</string>
         <property name="styleSheet">
          <string notr="true">background-color:white;
 color:#707070;
-font-size:13.5px;</string>
+font-size:13.5px;
+alternate-background-color:#7fb3d2;
+</string>
         </property>
         <property name="sortingEnabled">
          <bool>false</bool>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -99,7 +99,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>Quantity:</string>
@@ -112,7 +112,7 @@ border:none;</string>
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>0</string>
@@ -131,7 +131,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>Bytes:</string>
@@ -144,7 +144,7 @@ border:none;</string>
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>0</string>
@@ -179,7 +179,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>Amount:</string>
@@ -192,7 +192,7 @@ border:none;</string>
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>0.00 Veil</string>
@@ -208,7 +208,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>Dust:</string>
@@ -221,7 +221,7 @@ border:none;</string>
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>no</string>
@@ -259,7 +259,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>Fee:</string>
@@ -269,7 +269,7 @@ border:none;</string>
           <item row="0" column="1">
            <widget class="QLabel" name="labelCoinControlFee">
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>0.00 Veil</string>
@@ -301,7 +301,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>After Fee:</string>
@@ -311,7 +311,7 @@ border:none;</string>
           <item row="0" column="1">
            <widget class="QLabel" name="labelCoinControlAfterFee">
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>0.00 Veil</string>
@@ -327,7 +327,7 @@ border:none;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>Change:</string>
@@ -337,7 +337,7 @@ border:none;</string>
           <item row="1" column="1">
            <widget class="QLabel" name="labelCoinControlChange">
             <property name="styleSheet">
-             <string notr="true">color: black</string>
+             <string notr="true">color:#707070;</string>
             </property>
             <property name="text">
              <string>0.00 Veil</string>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -293,6 +293,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     WalletModelSpendType spendType;
     CZerocoinSpendReceipt receipt;
     std::vector<CommitData> vCommitData;
+
     prepareStatus = model->prepareTransaction(currentTransaction, ctrl, spendType, receipt, vCommitData);
     // process prepareStatus and on error generate message shown to user
     processSendCoinsReturn(prepareStatus,

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -212,11 +212,11 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         }
     }
 
-    if (inputType == OUTPUT_STANDARD) {
+    if (inputType == OUTPUT_STANDARD && !coinControl.fZerocoinSelected) {
         spendType = WalletModelSpendType::BASECOINSPEND;
         outputType = OUTPUT_CT;
         nBalance = m_wallet->getAvailableBalance(coinControl);
-    } else if (inputType == OUTPUT_ZC) {
+    } else if (inputType == OUTPUT_STANDARD && coinControl.fZerocoinSelected) {
         spendType = WalletModelSpendType::ZCSPEND;
         // Get serialhash from coincontrol
         std::vector<uint256> vSerialHashes;

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -21,6 +21,7 @@ void CCoinControl::SetNull()
     //m_fee_mode = FeeEstimateMode::UNSET;
 
     nCoinType = OUTPUT_STANDARD;
+    fZerocoinSelected = false;
     fHaveAnonOutputs = false;
     m_extrafee = 0;
 

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -23,5 +23,7 @@ void CCoinControl::SetNull()
     nCoinType = OUTPUT_STANDARD;
     fHaveAnonOutputs = false;
     m_extrafee = 0;
+
+    setZerocoinSelected.clear();
 }
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -47,6 +47,7 @@ public:
     FeeEstimateMode m_fee_mode;
 
     int nCoinType;
+    mutable bool fZerocoinSelected = false;
     mutable bool fHaveAnonOutputs = false;
     mutable bool fNeedHardwareKey = false;
     CAmount m_extrafee;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -834,7 +834,9 @@ public:
             std::vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange,
             std::vector<CommitData>& vCommitData, libzerocoin::CoinDenomination denomFilter = libzerocoin::CoinDenomination::ZQ_ERROR, CTxDestination* addressTo = NULL);
     bool CommitZerocoinSpend(CZerocoinSpendReceipt& receipt, std::vector<CommitData>& vCommitData);
-    bool AvailableZerocoins(std::set<CMintMeta>& setMints);
+    CAmount GetAvailableZerocoinBalance(const CCoinControl* coinControl) const;
+    bool AvailableZerocoins(std::set<CMintMeta>& setMints, const CCoinControl *coinControl = nullptr) const;
+    bool GetZerocoinPrecomputePercentage(const uint256 &nSerialHash, double &nPercent);
 //    std::string ResetMintZerocoin();
 //    std::string ResetSpentZerocoin();
     void ReconsiderZerocoins(std::list<CZerocoinMint>& listMintsRestored, std::list<CDeterministicMint>& listDMintsRestored);


### PR DESCRIPTION
- Add ability to select zerocoin denomination from coin control when spending
- Coin control will show zerocoin precomputation percentage if it is enabled and running 

**Precomputation isn't running**
![image](https://user-images.githubusercontent.com/8285518/55689078-be2ce080-593d-11e9-8d95-97c4fdb04dac.png)

**Precomputation is running**
![image](https://user-images.githubusercontent.com/8285518/55689094-d7359180-593d-11e9-9ef3-0db64d88b471.png)

Closes #431 
