### PR TITLE
Do not load corrupted duplicate block indexes.

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -266,6 +266,14 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             CDiskBlockIndex diskindex;
             if (pcursor->GetValue(diskindex)) {
+                // For some reason Veil has a tendency to duplicate an index, and store the second under a different key
+                // ignore any duplicates and mark them to be erased
+                uint256 hashBlock = diskindex.GetBlockHash();
+                if (hashBlock != key.second) {
+                    pcursor->Next();
+                    continue;
+                }
+
                 // Construct block index object
                 CBlockIndex* pindexNew = insertBlockIndex(diskindex.GetBlockHash());
                 pindexNew->pprev          = insertBlockIndex(diskindex.hashPrev);


### PR DESCRIPTION
fixes #422
It is also possible that #405 is related, but not positive.

For some reason multiple indexes are being saved to disk for the same block. The second index will overwrite the first index on first load. The second index has `nTx` set to `0`, as well as all relevant block file locations. The second index causes all subsequent indexes to have `nChainTx` set to `0`, causing them not to be able to be considered block candidates. Also notable is that the second index has the wrong database key which is supposed to be the block hash but is not.

This change simply ignores the second block index on first load. It is still yet to be determined what causes the duplicate index.