### PR TITLE
[Wallet][RPC] Add recoveraddresses rpc to regenerate keys and zerocoins after a seed import.

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -163,6 +163,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
     { "addwitnessaddress", 1, "p2sh" },
+    { "recoveraddresses", 0, "count" },
+    { "recoveraddresses", 1, "unused_buffer"},
+    { "recoveraddresses", 2, "scan_from_block"},
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -387,10 +387,106 @@ bool AnonWallet::GetAddressMeta(const CStealthAddress& address, CKeyID& idAccoun
     if (mapKeyPaths.count(sxAddr.GetID())) {
         auto accountpair = mapKeyPaths.at(sxAddr.GetID());
         idAccount = accountpair.first;
+        std::string strPathToKey = BIP32PathToString(accountpair.second);
+
+        //The path of the account is what provides context
+        if (!mapKeyPaths.count(idAccount))
+            return false;
+        accountpair = mapKeyPaths.at(idAccount);
         strPath = BIP32PathToString(accountpair.second);
+        strPath += strPathToKey;
     }
 
     return true;
+}
+
+CStealthAddress GenerateStealthAddressFromIndex(const CExtKey& keyStealthAddress, int nIndex)
+{
+    //Generate the extkey for spend and scan
+    BIP32Path vPathNew;
+    vPathNew.emplace_back(nIndex, true);
+    CExtKey extKeyScan = DeriveKeyFromPath(keyStealthAddress, vPathNew);
+    vPathNew.clear();
+    vPathNew.emplace_back(nIndex+1, true);
+    CExtKey extKeySpend = DeriveKeyFromPath(keyStealthAddress, vPathNew);
+    CKey keyScan = extKeyScan.key;
+    CKey keySpend = extKeySpend.key;
+    CPubKey pkSpend = keySpend.GetPubKey();
+
+    // Make a stealth address
+    CStealthAddress stealthAddress;
+    stealthAddress.SetNull();
+    stealthAddress.scan_pubkey = keyScan.GetPubKey().Raw();
+    stealthAddress.spend_pubkey = pkSpend.Raw();
+    stealthAddress.scan_secret.Set(keyScan.begin(), true);
+    stealthAddress.spend_secret_id = pkSpend.GetID();
+
+    return stealthAddress;
+}
+
+//! Return the last index in this account that has received coins
+int AnonWallet::GetLastUsedAddressIndex(const CKeyID& idAccount) const
+{
+    if (!mapAccountCounter.count(idAccount))
+        return -1;
+
+    int nLastGenerated = mapAccountCounter.at(idAccount);
+    int n = nLastGenerated - 1;
+    while (n > 0) {
+        //Regenerate address for this path
+        CExtKey keyStealthAccount;
+        if (!RegenerateKeyFromIndex(idAccount, n, keyStealthAccount))
+            return -1;
+
+        //Regenerate the stealth address and then get full address from 
+        CStealthAddress stealthAddress = GenerateStealthAddressFromIndex(keyStealthAccount, 1);
+        if (!mapStealthAddresses.count(stealthAddress.GetID()))
+            return -2;
+
+        stealthAddress = mapStealthAddresses.at(stealthAddress.GetID());
+
+        //If this address has any stealth destinations, then it is used and is the last used address.
+        if (!stealthAddress.setStealthDestinations.empty())
+            return n;
+
+        n--;
+    }
+    return -1;
+}
+
+void AnonWallet::ForgetUnusedStealthAddresses(int nBuffer)
+{
+    int nIndexLastUsed = GetLastUsedAddressIndex(idStealthAccount);
+    if (nIndexLastUsed < 0)
+        return;
+
+    // Get the last used address (this must be done after rescanning the chain)
+    int nLastGenerated = mapAccountCounter.at(idStealthAccount);
+    if (nLastGenerated - nIndexLastUsed <= nBuffer)
+        return;
+
+    // Remove knowledge of each account beyond the buffer.
+    AnonWalletDB wdb(*walletDatabase);
+    CExtKey keyStealthAddress;
+    int n = nIndexLastUsed + nBuffer;
+
+    while (n <= nLastGenerated && RegenerateKeyFromIndex(idStealthAccount, n, keyStealthAddress)) {
+        // Erase stealth address
+        auto address = GenerateStealthAddressFromIndex(keyStealthAddress, 0);
+        wdb.EraseStealthAddress(address);
+        mapStealthAddresses.erase(address.GetID());
+        mapKeyPaths.erase(address.GetID());
+
+        // Erase account
+        auto idAccount = keyStealthAddress.key.GetPubKey().GetID();
+        wdb.EraseExtKey(idAccount);
+        mapKeyPaths.erase(idAccount);
+        n++;
+    }
+
+    // Change account counter back
+    mapAccountCounter[idStealthAccount] = nIndexLastUsed + nBuffer;
+    wdb.WriteAccountCounter(idStealthAccount, nIndexLastUsed + nBuffer);
 }
 
 
@@ -3697,6 +3793,19 @@ bool AnonWallet::RegenerateKey(const CKeyID& idKey, CKey& key) const
     return true;
 }
 
+bool AnonWallet::RegenerateKeyFromIndex(const CKeyID& idAccount, int nIndex, CExtKey& keyDerive) const
+{
+    CExtKey keyAccount;
+    if (!RegenerateAccountExtKey(idAccount, keyAccount))
+        return error("%s: failed to regenerate account key", __func__);
+
+    BIP32Path vPathNew;
+    vPathNew.emplace_back(nIndex, true);
+    keyDerive = DeriveKeyFromPath(keyAccount, vPathNew);
+
+    return true;
+}
+
 bool AnonWallet::RegenerateAccountExtKey(const CKeyID& idAccount, CExtKey& keyAccount) const
 {
     if (IsLocked())
@@ -3796,8 +3905,6 @@ bool AnonWallet::CreateAccountWithKey(const CExtKey& key)
     AnonWalletDB wdb(*walletDatabase, "r+");
     wdb.WriteAccountCounter(idAccount, (uint32_t)1);
 
-    auto idParent = mapKeyPaths.at(idAccount).first;
-
     return true;
 }
 
@@ -3852,6 +3959,16 @@ bool AnonWallet::NewStealthKey(CStealthAddress& stealthAddress, uint32_t nPrefix
         return error("%s: failed to write stealth address to db", __func__);
     mapStealthAddresses.emplace(stealthAddress.GetID(), stealthAddress);
 
+    return true;
+}
+
+bool AnonWallet::RestoreAddresses(int nCount)
+{
+    for (int i = 0; i < nCount; i++) {
+        CStealthAddress stealthAddress;
+        if (!NewStealthKey(stealthAddress, 0, nullptr))
+            return false;
+    }
     return true;
 }
 
@@ -4565,7 +4682,7 @@ void AnonWallet::RescanWallet()
 
             for (auto it = txrecord->vout.begin(); it != txrecord->vout.end(); it++) {
                 bool fUpdated = false;
-                if (txRef->vpout.size() < it->n + 1)
+                if (txRef->vpout.size() < static_cast<unsigned int>(it->n + 1))
                     continue;
 
                 auto pout = txRef->vpout[it->n];
@@ -4707,7 +4824,6 @@ bool AnonWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlo
                     MarkOutputSpent(prevout, true);
 
                     fIsFromMe = true;
-                    continue;
                 }
 
                 if (fIsFromMe)
@@ -5230,7 +5346,7 @@ bool AnonWallet::AddToRecord(CTransactionRecord &rtxIn, const CTransaction &tx,
 
         pout->n = i;
         pout->nType = txout->nVersion;
-        bool fAdded = false;
+
         switch (txout->nVersion) {
             case OUTPUT_STANDARD:
                 {
@@ -5242,7 +5358,6 @@ bool AnonWallet::AddToRecord(CTransactionRecord &rtxIn, const CTransaction &tx,
                 if (OwnBlindOut(&wdb, txhash, (CTxOutCT*)txout.get(), *pout, stx, fUpdated)
                     && !fHave) {
                     fUpdated = true;
-                    fAdded = true;
                 } else {
                     //Just set as from me.
                     if (rtx.nFlags & ORF_FROM) {
@@ -5257,7 +5372,6 @@ bool AnonWallet::AddToRecord(CTransactionRecord &rtxIn, const CTransaction &tx,
                 if (OwnAnonOut(&wdb, txhash, (CTxOutRingCT*)txout.get(), *pout, stx, fUpdated)
                     && !fHave) {
                     fUpdated = true;
-                    fAdded = true;
                 } else {
                     //Just set as from me.
                     if (rtx.nFlags & ORF_FROM) {

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -157,8 +157,11 @@ public:
     bool GetStealthAddressScanKey(CStealthAddress &sxAddr) const;
     bool GetStealthAddressSpendKey(CStealthAddress &sxAddr, CKey &key) const;
     bool GetAddressMeta(const CStealthAddress& address, CKeyID& idAccount, std::string& strPath) const;
+    int GetLastUsedAddressIndex(const CKeyID& idAccount) const;
+    void ForgetUnusedStealthAddresses(int nBuffer);
 
     bool ImportStealthAddress(const CStealthAddress &sxAddr, const CKey &skSpend);
+    bool RestoreAddresses(int nCount);
 
     std::map<CTxDestination, CAmount> GetAddressBalances() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -265,6 +268,7 @@ public:
     bool RegenerateKey(const CKeyID& idKey, CKey& key) const;
     bool RegenerateExtKey(const CKeyID& idKey, CExtKey& extkey) const;
     bool RegenerateAccountExtKey(const CKeyID& idAccount, CExtKey& keyAccount) const;
+    bool RegenerateKeyFromIndex(const CKeyID& idAccount, int nIndex, CExtKey& keyDerive) const;
     bool MakeSigningKeystore(CBasicKeyStore& keystore, const CScript& scriptPubKey);
 
     bool NewStealthKey(CStealthAddress& stealthAddress, uint32_t nPrefixBits, const char *pPrefix);

--- a/src/veil/ringct/anonwalletdb.cpp
+++ b/src/veil/ringct/anonwalletdb.cpp
@@ -94,6 +94,11 @@ bool AnonWalletDB::WriteExtKey(const CKeyID& idAccount, const CKeyID &idNew, con
     return WriteIC(std::make_pair(std::string("ek32_n"), idNew), pLocation, true);
 }
 
+bool AnonWalletDB::EraseExtKey(const CKeyID& idKey)
+{
+    return EraseIC(std::make_pair(std::string("ek32_n"), idKey));
+}
+
 bool AnonWalletDB::WriteAccountCounter(const CKeyID& idAccount, const uint32_t& nCount)
 {
     return WriteIC(std::make_pair(std::string("acct_c"), idAccount), nCount);

--- a/src/veil/ringct/anonwalletdb.h
+++ b/src/veil/ringct/anonwalletdb.h
@@ -358,6 +358,7 @@ public:
 
     bool ReadExtKey(const CKeyID &identifier, CKeyID& idAccount, BIP32Path& vPath);
     bool WriteExtKey(const CKeyID& idAccount, const CKeyID &idNew, const BIP32Path& vPath);
+    bool EraseExtKey(const CKeyID& idKey);
 
     bool WriteAccountCounter(const CKeyID& idAccount, const uint32_t& nCount);
 

--- a/src/veil/ringct/stealth.cpp
+++ b/src/veil/ringct/stealth.cpp
@@ -257,8 +257,12 @@ int StealthSecret(const CKey &secret, const ec_point &pubkey, const ec_point &pk
     uint8_t tmp33[33];
     secp256k1_ec_pubkey_serialize(secp256k1_ctx_stealth, tmp33, &len, &Q, SECP256K1_EC_COMPRESSED); // Returns: 1 always.
 
-    sharedSOut.MakeNewKey(true); //initialize the key
-    CSHA256().Write(tmp33, 33).Finalize(sharedSOut.begin_nc());
+    std::vector<unsigned char> vKey;
+    vKey.resize(32);
+    CSHA256().Write(tmp33, 33).Finalize(vKey.data());
+    memcpy(sharedSOut.begin_nc(), vKey.data(), 32);
+    sharedSOut.SetFlags(/*valide*/true, /*compressed*/true);
+    vKey.clear();
 
     //if (!secp256k1_ec_seckey_verify(secp256k1_ctx_stealth, sharedSOut.begin()))
     //    return errorN(1, "%s: secp256k1_ec_seckey_verify failed.", __func__); // Start again with a new ephemeral key

--- a/src/veil/zerocoin/zchain.cpp
+++ b/src/veil/zerocoin/zchain.cpp
@@ -87,7 +87,7 @@ bool ThreadedBatchVerify(const std::vector<libzerocoin::SerialNumberSoKProof>* p
 
     std::vector<std::vector<const libzerocoin::SerialNumberSoKProof*>> vProofGroups(1);
     int nThreadsUsed = 1;
-    if (pvProofs->size() > nThreadEfficiency)
+    if ((int)pvProofs->size() > nThreadEfficiency)
         nThreadsUsed = pvProofs->size() / nThreadEfficiency;
     if (nThreadsUsed > nMaxThreads)
         nThreadsUsed = nMaxThreads;

--- a/src/veil/zerocoin/zwallet.h
+++ b/src/veil/zerocoin/zwallet.h
@@ -28,6 +28,7 @@ public:
     CzWallet(CWallet* wallet);
 
     void AddToMintPool(const std::pair<uint256, uint32_t>& pMint, bool fVerbose);
+    bool DeterministicSearch(int nCountStart, int nCountEnd);
     bool HasEmptySeed() const { return mapMasterSeeds.empty() || mapMasterSeeds.count(seedMasterID) == 0; }
     bool GetMasterSeed(CKey& key) const;
     CKeyID GetMasterSeedID() { return seedMasterID; }

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -1472,34 +1472,7 @@ UniValue deterministiczerocoinstate(const JSONRPCRequest& request)
 void static SearchThread(CzWallet* zwallet, int nCountStart, int nCountEnd)
 {
     LogPrintf("%s: start=%d end=%d\n", __func__, nCountStart, nCountEnd);
-    WalletBatch walletdb(zwallet->GetDBHandle());
-    try {
-        CKey keyMaster;
-        if (!zwallet->GetMasterSeed(keyMaster))
-            return;
-
-        CKeyID hashSeed = keyMaster.GetPubKey().GetID();
-        for(int i = nCountStart; i < nCountEnd; i++) {
-            boost::this_thread::interruption_point();
-            CDataStream ss(SER_GETHASH, 0);
-            ss << keyMaster.GetPrivKey_256() << i;
-            uint512 zerocoinSeed = Hash512(ss.begin(), ss.end());
-
-            CBigNum bnValue;
-            CBigNum bnSerial;
-            CBigNum bnRandomness;
-            CKey key;
-            zwallet->SeedToZerocoin(zerocoinSeed, bnValue, bnSerial, bnRandomness, key);
-
-            uint256 hashPubcoin = GetPubCoinHash(bnValue);
-            zwallet->AddToMintPool(make_pair(hashPubcoin, i), true);
-            walletdb.WriteMintPoolPair(hashSeed, hashPubcoin, i);
-        }
-    } catch (std::exception& e) {
-        LogPrintf("SearchThread() exception");
-    } catch (...) {
-        LogPrintf("SearchThread() exception");
-    }
+    zwallet->DeterministicSearch(nCountStart, nCountEnd);
 }
 
 UniValue searchdeterministiczerocoin(const JSONRPCRequest& request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -508,6 +508,15 @@ bool CWallet::LoadWatchOnly(const CScript &dest)
     return CCryptoKeyStore::AddWatchOnly(dest);
 }
 
+bool CWallet::RestoreBaseCoinAddresses(int nCount)
+{
+    WalletBatch wdb(GetDBHandle());
+    for (unsigned int i = 0; i < nCount; i++) {
+        GenerateNewKey(wdb, false);
+    }
+    return true;
+}
+
 bool CWallet::LockWallet()
 {
     zwalletMain->Lock();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -996,6 +996,8 @@ public:
     void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    bool RestoreBaseCoinAddresses(int nCount) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
     void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 


### PR DESCRIPTION
`recoveraddresses` rpc can be used after importing a seed to the wallet. By default it will create 100 stealth addresses, 100 basecoin addresses, and 100 deterministic zerocoins (can be changed using `count`). It will then scan the full blockchain for any activity that is owned by the wallet. Since stealth addresses add computational overhead to block syncing, the rpc call will remove any of the unused stealth addresses. 

The process does keep a small buffer of up to 20 (`unused_buffer`) unused stealth addresses to accommodate the possibility that generated addresses were given out as a receiving addresses, but not used yet.

Users can also specify a block to start the search from in order to speed up the process (`scan_from_block`).

closes #453
