### PR TITLE
[Qt] Update pay amount text box

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -33,8 +33,13 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
     ui->payTo->setAttribute(Qt::WA_MacShowFocusRect, 0);
     ui->payTo->setProperty("cssClass" , "edit-primary");
 
+    QLocale locale(QLocale::C);
+    locale.setNumberOptions(QLocale::RejectGroupSeparator); // Don't allow commas in the amount
+    auto val = new QDoubleValidator(0, 100000000000, 8, this);
+    val->setLocale(locale);
+
     ui->payAmount->setPlaceholderText("Amount to send");
-    ui->payAmount->setValidator(new QDoubleValidator(0, 100000000000, 7, this) );
+    ui->payAmount->setValidator(val);
     ui->payAmount->setAttribute(Qt::WA_MacShowFocusRect, 0);
     ui->payAmount->setProperty("cssClass" , "edit-primary");
 


### PR DESCRIPTION
- Allow for 8 decimals instead of the current 7
- Remove commas from being added to the amount

Closes #488 