### PR TITLE
[RPC] Allow all address types in spendzerocoinmints

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -355,7 +355,7 @@ public:
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000000000000037a8cd3e06cd5edbfe9dd1dbcc5dacab279376ef7cfc2b4c75"); //1354312
+        consensus.defaultAssumeValid = uint256S("0xe95fc76c6c9016e8ed2e4e4a2641dfc91dbf6bad4df659f664d8f7614bc010c0"); //103000
 
         consensus.nMinRCTOutputDepth = 12;
 
@@ -409,6 +409,7 @@ public:
         checkpointData = {
             {
                     {98429, uint256S("fecff045e98e30c6e077d160883d73500e4d96463d8333436403298fea5ecda3")},
+                    {103000, uint256S("e95fc76c6c9016e8ed2e4e4a2641dfc91dbf6bad4df659f664d8f7614bc010c0")},
             }
         };
 

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -643,10 +643,10 @@ UniValue DoZerocoinSpend(CWallet* pwallet, const CAmount nAmount, bool fMintChan
     bool fSuccess;
 
     if(address_str != "") { // Spend to supplied destination address
-        CBitcoinAddress address(address_str);
-        dest = CBitcoinAddress(address_str).Get();
-        if(!address.IsValid())
+        dest = DecodeDestination(address_str);
+        if(!IsValidDestination(dest))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid VEIL address");
+
         fSuccess = pwallet->SpendZerocoin(nAmount, nSecurityLevel, receipt, vMintsSelected, fMintChange, fMinimizeChange, libzerocoin::CoinDenomination::ZQ_ERROR, &dest);
     } else                   // Spend to newly generated local address
         fSuccess = pwallet->SpendZerocoin(nAmount, nSecurityLevel, receipt, vMintsSelected, fMintChange, fMinimizeChange, libzerocoin::CoinDenomination::ZQ_ERROR);


### PR DESCRIPTION
- Added new testnet checkpoint for quicker signature verification
- Added support for stealth address to the **spendzerocoinmints** rpc call
- Added support for bech32 addresses to the **spendzerocoinmints** rpc call

Example use of the rpc call to a stealth address
![image](https://user-images.githubusercontent.com/8285518/56254757-42d6d780-607f-11e9-9795-178813ddd0f5.png)

Example use of the rpc call to a bech32 address
![image](https://user-images.githubusercontent.com/8285518/56254782-5b46f200-607f-11e9-849f-65ca0f8608c3.png)

Closes #459 


