### PR TITLE
Fix mintable ringct and ct balances to show correcly

### DIFF
--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -1005,7 +1005,7 @@ bool AnonWallet::GetBalances(BalanceList &bal)
 
         bool fTrusted = IsTrusted(txhash, rtx.blockHash);
         int nDepth = GetDepthInMainChain(rtx.blockHash, 0);
-        bool fConfirmed = nDepth >= 11;
+        bool fConfirmed = nDepth > 11;
         bool fInMempool = false;
         if (!fTrusted) {
             CTransactionRef ptx = mempool.get(txhash);


### PR DESCRIPTION
- Fixes issue 471 by making the balance become available after the 11 confirmation block, not on the 11 confirmation

Closes #471 