### PR TITLE
[Build] Fix windows build with boost thread

### DIFF
--- a/src/veil/zerocoin/zwallet.cpp
+++ b/src/veil/zerocoin/zwallet.cpp
@@ -13,6 +13,7 @@
 #include "validation.h"
 #include "consensus/validation.h"
 #include "shutdown.h"
+#include "boost/thread.hpp"
 
 using namespace libzerocoin;
 


### PR DESCRIPTION
- Statically compile windows builds on linux was failing. This change fixes the windows build problem