### PR TITLE
New lru cache

### DIFF
--- a/src/veil/zerocoin/lrucache.cpp
+++ b/src/veil/zerocoin/lrucache.cpp
@@ -4,19 +4,19 @@
 
 #include "lrucache.h"
 
-LRUCache::LRUCache()
+PrecomputeLRUCache::PrecomputeLRUCache()
 {
     Clear();
 }
 
-void LRUCache::Clear()
+void PrecomputeLRUCache::Clear()
 {
     cache_list.clear();
     mapCacheLocation.clear();
     mapDirtyWitnessData.clear();
 }
 
-void LRUCache::AddNew(const uint256& hash, CoinWitnessCacheData& data)
+void PrecomputeLRUCache::AddNew(const uint256& hash, CoinWitnessCacheData& data)
 {
     cache_list.push_front(std::make_pair(hash, data));
     mapCacheLocation.insert(make_pair(hash, cache_list.begin()));
@@ -25,29 +25,29 @@ void LRUCache::AddNew(const uint256& hash, CoinWitnessCacheData& data)
     mapDirtyWitnessData.erase(hash);
 }
 
-int LRUCache::Size() const
+int PrecomputeLRUCache::Size() const
 {
     return mapCacheLocation.size();
 }
 
-int LRUCache::DirtyCacheSize() const
+int PrecomputeLRUCache::DirtyCacheSize() const
 {
     return mapDirtyWitnessData.size();
 }
 
-bool LRUCache::Contains(const uint256& hash) const
+bool PrecomputeLRUCache::Contains(const uint256& hash) const
 {
     return mapCacheLocation.count(hash) > 0 || mapDirtyWitnessData.count(hash) > 0;
 }
 
-void LRUCache::MoveDirtyToLRU(const uint256& hash)
+void PrecomputeLRUCache::MoveDirtyToLRU(const uint256& hash)
 {
     auto data = CoinWitnessData(mapDirtyWitnessData.at(hash));
     auto cachedata = CoinWitnessCacheData(&data);
     AddNew(hash, cachedata);
 }
 
-void LRUCache::MoveLastToDirtyIfFull()
+void PrecomputeLRUCache::MoveLastToDirtyIfFull()
 {
     if (mapCacheLocation.size() > PRECOMPUTE_LRU_CACHE_SIZE) {
         auto last_it = cache_list.end(); last_it --;
@@ -58,7 +58,7 @@ void LRUCache::MoveLastToDirtyIfFull()
     }
 }
 
-CoinWitnessData LRUCache::GetWitnessData(const uint256& hash)
+CoinWitnessData PrecomputeLRUCache::GetWitnessData(const uint256& hash)
 {
     if (mapDirtyWitnessData.count(hash)) {
         MoveDirtyToLRU(hash);
@@ -74,7 +74,7 @@ CoinWitnessData LRUCache::GetWitnessData(const uint256& hash)
     return CoinWitnessData();
 }
 
-void LRUCache::Remove(const uint256& hash)
+void PrecomputeLRUCache::Remove(const uint256& hash)
 {
     auto it = mapCacheLocation.find(hash);
     if (it != mapCacheLocation.end()) {
@@ -84,7 +84,7 @@ void LRUCache::Remove(const uint256& hash)
     mapDirtyWitnessData.erase(hash);
 }
 
-void LRUCache::AddToCache(const uint256& hash, CoinWitnessCacheData& serialData)
+void PrecomputeLRUCache::AddToCache(const uint256& hash, CoinWitnessCacheData& serialData)
 {
     // If the LRU cache already has a entry for it, update the entry and move it to the front of the list
     auto it = mapCacheLocation.find(hash);
@@ -100,7 +100,7 @@ void LRUCache::AddToCache(const uint256& hash, CoinWitnessCacheData& serialData)
     MoveLastToDirtyIfFull();
 }
 
-void LRUCache::FlushToDisk(CPrecomputeDB* pprecomputeDB)
+void PrecomputeLRUCache::FlushToDisk(CPrecomputeDB* pprecomputeDB)
 {
     // Save all cache data that was dirty back into the database
     for (auto item : mapDirtyWitnessData) {

--- a/src/veil/zerocoin/lrucache.h
+++ b/src/veil/zerocoin/lrucache.h
@@ -7,8 +7,10 @@
 #define VEIL_LRUCACHE_H
 
 #include <veil/zerocoin/witness.h>
+#include <unordered_map>
+#include <list>
 
-class LRUCache
+class PrecomputeLRUCache
 {
 private:
     std::list<std::pair<uint256, CoinWitnessCacheData> > cache_list;
@@ -22,12 +24,58 @@ public:
     void Clear();
     void FlushToDisk(CPrecomputeDB* pprecomputeDB);
     CoinWitnessData GetWitnessData(const uint256& hash);
-    LRUCache();
+    PrecomputeLRUCache();
     void MoveDirtyToLRU(const uint256& hash);
     void MoveLastToDirtyIfFull();
     void Remove(const uint256& hash);
     int Size() const;
     int DirtyCacheSize() const;
+};
+
+
+
+template<typename K, typename V = K>
+class LRUCacheTemplate
+{
+
+private:
+    std::list<K>items;
+    std::unordered_map <K, std::pair<V, typename std::list<K>::iterator>> keyValuesMap;
+    int csize;
+
+public:
+    LRUCacheTemplate(int s) :csize(s) {
+        if (csize < 1)
+            csize = 10;
+    }
+
+    void set(const K key, const V value) {
+        auto pos = keyValuesMap.find(key);
+        if (pos == keyValuesMap.end()) {
+            items.push_front(key);
+            keyValuesMap[key] = { value, items.begin() };
+            if (keyValuesMap.size() > csize) {
+                keyValuesMap.erase(items.back());
+                items.pop_back();
+            }
+        }
+        else {
+            items.erase(pos->second.second);
+            items.push_front(key);
+            keyValuesMap[key] = { value, items.begin() };
+        }
+    }
+
+    bool get(const K key, V &value) {
+        auto pos = keyValuesMap.find(key);
+        if (pos == keyValuesMap.end())
+            return false;
+        items.erase(pos->second.second);
+        items.push_front(key);
+        keyValuesMap[key] = { pos->second.first, items.begin() };
+        value = pos->second.first;
+        return true;
+    }
 };
 
 #endif //VEIL_LRUCACHE_H

--- a/src/veil/zerocoin/precompute.h
+++ b/src/veil/zerocoin/precompute.h
@@ -20,7 +20,7 @@ private:
 
 public:
 
-    LRUCache lru;
+    PrecomputeLRUCache lru;
 
     Precompute();
     void SetNull();

--- a/src/veil/zerocoin/witness.cpp
+++ b/src/veil/zerocoin/witness.cpp
@@ -144,7 +144,7 @@ CPrecomputeDB::CPrecomputeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBW
 {
 }
 
-bool CPrecomputeDB::LoadPrecomputes(LRUCache* lru)
+bool CPrecomputeDB::LoadPrecomputes(PrecomputeLRUCache* lru)
 {
 
     std::unique_ptr<CDBIterator> pcursor(NewIterator());

--- a/src/veil/zerocoin/witness.h
+++ b/src/veil/zerocoin/witness.h
@@ -13,7 +13,7 @@
 #define PRECOMPUTE_FLUSH_TIME 3600 // 1 Hour
 
 class CoinWitnessCacheData;
-class LRUCache;
+class PrecomputeLRUCache;
 
 class CoinWitnessData
 {
@@ -90,7 +90,7 @@ private:
 
 public:
     /** Veil zerocoin precompute database functions */
-    bool LoadPrecomputes(LRUCache* lru);
+    bool LoadPrecomputes(PrecomputeLRUCache* lru);
     bool LoadPrecomputes(std::set<uint256> setHashes);
     bool EraseAllPrecomputes();
     bool WritePrecompute(const uint256& hash, const CoinWitnessCacheData& data);


### PR DESCRIPTION
- Rename the precompute lru cache class
- Create new lru cache template class that is bare bones and easy to use
- Replace set that was causing segfault to occur when checking zerocoinmint

Closes #531 