### PR TITLE
[Consensus][Wallet]Put Zerocoin into "Limp Mode"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(veil)
 set(CMAKE_CXX_STANDARD 11)
 
 add_compile_definitions(ENABLE_WALLET=1)
+add_compile_definitions(USE_NUM_GMP)
 
 include_directories(src)
 include_directories(src/bench)
@@ -63,6 +64,8 @@ include_directories(src/zmq)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Core Gui)
 
 add_executable(veil
+        src/libzerocoin/PubcoinSignature.h
+        src/libzerocoin/PubcoinSignature.cpp
         src/veil/zerocoin/witness.h
         src/veil/zerocoin/witness.cpp
         src/bench/base58.cpp
@@ -1016,6 +1019,6 @@ add_executable(veil
         src/versionbits.h
         src/walletinitinterface.h
         src/warnings.cpp
-        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/veil/zerocoin/lrucache.h src/veil/zerocoin/lrucache.cpp src/veil/zerocoin/precompute.h src/veil/zerocoin/precompute.cpp)
+        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/veil/zerocoin/lrucache.h src/veil/zerocoin/lrucache.cpp src/veil/zerocoin/precompute.h src/veil/zerocoin/precompute.cpp src/libzerocoin/PubcoinSignature.h src/libzerocoin/PubcoinSignature.cpp src/test/zerocoin_pubcoinsig_tests.cpp)
 
 qt5_use_modules(veil Core Widgets Gui)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -442,6 +442,7 @@ libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
   libzerocoin/Commitment.cpp \
   libzerocoin/ParamGeneration.cpp \
   libzerocoin/Params.cpp \
+  libzerocoin/PubcoinSignature.cpp \
   libzerocoin/PolynomialCommitment.cpp \
   libzerocoin/SerialNumberSignatureOfKnowledge.cpp \
   libzerocoin/SerialNumberSoK_small.cpp \
@@ -456,6 +457,7 @@ libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
   libzerocoin/Denominations.h \
   libzerocoin/ParamGeneration.h \
   libzerocoin/Params.h \
+  libzerocoin/PubcoinSignature.h \
   libzerocoin/PolynomialCommitment.h \
   libzerocoin/SerialNumberSignatureOfKnowledge.h \
   libzerocoin/SerialNumberSoK_small.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -96,6 +96,7 @@ BITCOIN_TESTS =\
   test/libzerocoin_tests.cpp \
   test/zerocoin_denomination_tests.cpp \
   test/zerocoin_implementation_tests.cpp \
+  test/zerocoin_pubcoinsig_tests.cpp \
   test/zerocoin_transactions_tests.cpp \
   test/zerocoin_zkp_tests.cpp
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -201,8 +201,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1556226440;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].bit = 3;
-        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1956226442;
-        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1979805817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1556347500;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -442,7 +442,7 @@ public:
                           "31438167899885040445364023527381951378636564391212010397122822120720357";
         nMaxZerocoinSpendsPerTransaction = 20; // Assume about 6.5kb each
         nMinZerocoinMintFee = 1 * CENT; //high fee required for zerocoin mints
-        nMintRequiredConfirmations = 20; //the maximum amount of confirmations until accumulated in 19
+        nMintRequiredConfirmations = 10; //the maximum amount of confirmations until accumulated in 19
         nRequiredAccumulation = 1;
         nDefaultSecurityLevel = 100; //full security level for accumulators
         nZerocoinRequiredStakeDepth = 10; //The required confirmations for a zerocoin to be stakable

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -180,8 +180,8 @@ public:
         consensus.nDgwPastBlocks = 30; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 1080; // 75% of confirmation window
-        consensus.nMinerConfirmationWindow = 1440; // 1 day at 1 block per minute
+        consensus.nRuleChangeActivationThreshold = 252; // 70% of confirmation window
+        consensus.nMinerConfirmationWindow = 360; // 6 hours at 1 block per minute
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -199,6 +199,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548161817;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1556226442;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -331,7 +335,7 @@ public:
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 84; // 75% for testchains
+        consensus.nRuleChangeActivationThreshold = 84; // 70% for testchains
         consensus.nMinerConfirmationWindow = 120; // 2 hours
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
@@ -350,6 +354,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548269817;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1556226442;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -180,8 +180,8 @@ public:
         consensus.nDgwPastBlocks = 30; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 252; // 70% of confirmation window
-        consensus.nMinerConfirmationWindow = 360; // 6 hours at 1 block per minute
+        consensus.nRuleChangeActivationThreshold = 84; // 70% of confirmation window
+        consensus.nMinerConfirmationWindow = 120; // 2 hours at 1 block per minute
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -198,11 +198,11 @@ public:
 
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548161817;
-        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1556226440;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].bit = 3;
-        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1556226442;
-        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1579805817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1956226442;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1979805817;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -335,8 +335,8 @@ public:
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 84; // 70% for testchains
-        consensus.nMinerConfirmationWindow = 120; // 2 hours
+        consensus.nRuleChangeActivationThreshold = 15; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 20; // 20 minutes
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -353,10 +353,10 @@ public:
 
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nStartTime = 1548269817;
-        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1579805817;
+        consensus.vDeployments[Consensus::DEPLOYMENT_POS_WEIGHT].nTimeout = 1556226440;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].bit = 3;
-        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1556226442;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nStartTime = 1556321954;
         consensus.vDeployments[Consensus::DEPLOYMENT_ZC_LIMP].nTimeout = 1579805817;
 
         // The best chain should have at least this much work.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -135,6 +135,7 @@ public:
     int EnforceWeightReductionTime() const { return nTimeEnforceWeightReduction; }
     int HeightProtocolBumpEnforcement() const { return nHeightProtocolBumpEnforcement; }
     int MaxHeaderRequestWithoutPoW() const { return nMaxHeaderRequestWithoutPoW; }
+    int BIP9Period() const { return consensus.nMinerConfirmationWindow; }
 
 protected:
     CChainParams() {}

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -19,6 +19,7 @@ enum DeploymentPos
     DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
     DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
     DEPLOYMENT_POS_WEIGHT,
+    DEPLOYMENT_ZC_LIMP,
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1681,12 +1681,14 @@ bool AppInitMain()
                                 "Only rebuild the block database if you are sure that your computer's date and time are correct");
                         break;
                     }
-
+                    fVerifying = true;
                     if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview.get(), gArgs.GetArg("-checklevel", DEFAULT_CHECKLEVEL),
                                   gArgs.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
                         strLoadError = _("Corrupted block database detected");
+                        fVerifying = false;
                         break;
                     }
+                    fVerifying = false;
                 }
 
                 if (gArgs.GetBoolArg("-reindex-zdb", false)) {

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -19,6 +19,7 @@
 #include "Coin.h"
 #include "Commitment.h"
 #include "Params.h"
+#include "PubcoinSignature.h"
 #include "SerialNumberSignatureOfKnowledge.h"
 #include "SpendType.h"
 
@@ -39,6 +40,7 @@ class CoinSpend
 public:
 
     static int const V3_SMALL_SOK = 3;
+    static int const V4_LIMP = 4;
 
     //! \param paramsV1 - if this is a V1 zerocoin, then use params that existed with initial modulus, ignored otherwise
     //! \param paramsV2 - params that begin when V2 zerocoins begin on the VEIL network
@@ -107,6 +109,7 @@ public:
     CBigNum getSerialComm() const { return serialCommitmentToCoinValue; }
     SerialNumberSoK_small getSmallSoK() const { return smallSoK; }
     uint8_t getVersion() const { return version; }
+    CBigNum getPubcoinValue() const;
     CPubKey getPubKey() const { return pubkey; }
     SpendType getSpendType() const { return spendType; }
     std::vector<unsigned char> getSignature() const { return vchSig; }
@@ -117,7 +120,7 @@ public:
         return hashSig;
     }
 
-    bool Verify(const Accumulator& a, std::string& strError, bool verifySoK = true) const;
+    bool Verify(const Accumulator& a, std::string& strError, bool verifySoK = true, bool verifyPubcoin = false) const;
     bool HasValidSerial(ZerocoinParams* params) const;
     bool HasValidSignature() const;
     std::string ToString() const;
@@ -139,6 +142,9 @@ public:
         READWRITE(accumulatorPoK);
         READWRITE(smallSoK);
         READWRITE(commitmentPoK);
+        if (version == V4_LIMP) {
+            READWRITE(pubcoinSig);
+        }
     }
 
 private:
@@ -161,6 +167,9 @@ private:
 
     // Cached hashSig
     uint256 hashSig;
+
+    // Version 4 "Limp Mode"
+    PubcoinSignature pubcoinSig;
 };
 
 } /* namespace libzerocoin */

--- a/src/libzerocoin/PubcoinSignature.cpp
+++ b/src/libzerocoin/PubcoinSignature.cpp
@@ -1,0 +1,64 @@
+/**
+* @file       PubcoinSignature.cpp
+*
+* @brief      De-anonymize zerocoins for times that the integrity of the accumulators or related libzerocoin zkp's are broken.
+*
+* @author     presstab https://github.com/presstab, random-zebra https://github.com/random-zebra
+* @date       April 2019
+*
+* @copyright  Copyright 2019 The Veil Developers, Copyright 2019 The PIVX Developers
+* @license    This project is released under the MIT license.
+**/
+
+#include "PubcoinSignature.h"
+
+namespace libzerocoin {
+
+    /**
+     * Prove ownership of a pubcoin and prove that it links to the C1 commitment
+     *
+     * @param params: zerocoin params
+     * @param bnPubcoin: pubcoin value that is being spent
+     * @param C1: serialCommitmentToCoinValue
+     * @return PubcoinSignature object containing C1 randomness and pubcoin value
+     */
+    PubcoinSignature::PubcoinSignature(const ZerocoinParams* params, const CBigNum& bnPubcoin, const Commitment& C1)
+    {
+        m_params = params;
+        m_version = CURRENT_VERSION;
+        m_bnPubcoin = bnPubcoin;
+        m_bnC1Randomness = C1.getRandomness();
+    }
+
+    /**
+     * Validate signature by revealing C1's (a commitment to pubcoin) randomness, building a new commitment
+     * C(pubcoin, C1.randomness) and checking equality between C and C1.
+     *
+     * @param bnC1 - This C1 value must be the same value as the serialCommitmentToCoinValue in the coinspend object
+     * @return true if bnPubcoin matches the value that was committed to in C1
+     */
+    bool PubcoinSignature::Verify(const CBigNum& bnC1, std::string& strError) const
+    {
+        // Check that given member vars are as expected
+        if (m_version == 0 || m_bnC1Randomness <= CBigNum(0) || m_bnC1Randomness >= m_params->serialNumberSoKCommitmentGroup.groupOrder) {
+            strError = "member var sanity check failed.";
+            return false;
+        }
+
+        // Check that the pubcoin is valid according to libzerocoin::PublicCoin standards (denom does not matter here)
+        try {
+            PublicCoin coin(m_params, m_bnPubcoin, CoinDenomination::ZQ_TEN);
+            if (!coin.validate()) {
+                strError = "pubcoin did not validate";
+                return false;
+            }
+        } catch (...) {
+            strError = "pubcoin threw an error";
+            return false;
+        }
+
+        // Check that C1, the commitment to the pubcoin under serial params, uses the same pubcoin
+        Commitment commitmentCheck(&m_params->serialNumberSoKCommitmentGroup, m_bnPubcoin, m_bnC1Randomness);
+        return commitmentCheck.getCommitmentValue() == bnC1;
+    }
+}

--- a/src/libzerocoin/PubcoinSignature.h
+++ b/src/libzerocoin/PubcoinSignature.h
@@ -1,0 +1,56 @@
+/**
+* @file       PubcoinSignature.h
+*
+* @brief      De-anonymize zerocoins for times that the integrity of the accumulators or related libzerocoin zkp's are broken.
+*
+* @author     presstab https://github.com/presstab, random-zebra https://github.com/random-zebra
+* @date       April 2019
+*
+* @copyright  Copyright 2019 The Veil Developers, Copyright 2019 The PIVX Developers
+* @license    This project is released under the MIT license.
+**/
+
+#ifndef VEIL_PUBCOINSIGNATURE_H
+#define VEIL_PUBCOINSIGNATURE_H
+
+#include "bignum.h"
+#include "Coin.h"
+#include "Commitment.h"
+
+namespace libzerocoin {
+
+class PubcoinSignature
+{
+private:
+    uint8_t m_version;
+    const ZerocoinParams* m_params;
+    CBigNum m_bnPubcoin;
+    CBigNum m_bnC1Randomness;
+
+public:
+    static const uint8_t CURRENT_VERSION = 1;
+
+    PubcoinSignature()
+    {
+        m_version = 0;
+        m_bnPubcoin = CBigNum(0);
+        m_bnC1Randomness = CBigNum(0);
+    }
+
+    PubcoinSignature(const ZerocoinParams* params, const CBigNum& bnPubcoin, const Commitment& C1);
+    bool Verify(const CBigNum& bnC2, std::string& strError) const;
+    CBigNum GetPubcoinValue() const { return m_bnPubcoin; }
+
+    ADD_SERIALIZE_METHODS;
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_version);
+        READWRITE(m_bnPubcoin);
+        READWRITE(m_bnC1Randomness);
+    }
+};
+
+}
+
+#endif //VEIL_PUBCOINSIGNATURE_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1363,7 +1363,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     UniValue bip9_softforks(UniValue::VOBJ);
-    for (int pos = Consensus::DEPLOYMENT_POS_WEIGHT; pos != Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++pos) {
+    for (int pos = Consensus::DEPLOYMENT_ZC_LIMP; pos != Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++pos) {
         BIP9SoftForkDescPushBack(bip9_softforks, consensusParams, static_cast<Consensus::DeploymentPos>(pos));
     }
     obj.pushKV("bip9_softforks", bip9_softforks);

--- a/src/test/zerocoin_implementation_tests.cpp
+++ b/src/test/zerocoin_implementation_tests.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2019 The Veil developers
 // Copyright (c) 2017-2019 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -9,6 +10,7 @@
 #include "txdb.h"
 //#include "primitives/deterministicmint.h"
 #include "key.h"
+#include "libzerocoin/PubcoinSignature.h"
 //#include "accumulatorcheckpoints.h"
 #include "libzerocoin/bignum.h"
 #include <boost/test/unit_test.hpp>
@@ -34,7 +36,6 @@ BOOST_AUTO_TEST_CASE(zcparams_test)
     cout << "Running zcparams_test...\n";
     RandomInit();
     ECC_Start();
-
     bool fPassed = true;
     try{
         SelectParams(CBaseChainParams::MAIN);

--- a/src/test/zerocoin_pubcoinsig_tests.cpp
+++ b/src/test/zerocoin_pubcoinsig_tests.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 The Veil developers
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <test/test_veil.h>
+#include "libzerocoin/Denominations.h"
+#include "libzerocoin/PubcoinSignature.h"
+#include "libzerocoin/bignum.h"
+#include "streams.h"
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+using namespace libzerocoin;
+
+BOOST_AUTO_TEST_SUITE(zerocoin_pubcoinsig_tests)
+
+std::string zerocoinModulus = "25195908475657893494027183240048398571429282126204032027777137836043662020707595556264018525880784"
+                              "4069182906412495150821892985591491761845028084891200728449926873928072877767359714183472702618963750149718246911"
+                              "6507761337985909570009733045974880842840179742910064245869181719511874612151517265463228221686998754918242243363"
+                              "7259085141865462043576798423387184774447920739934236584823824281198163815010674810451660377306056201619676256133"
+                              "8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
+                              "31438167899885040445364023527381951378636564391212010397122822120720357";
+
+BOOST_AUTO_TEST_CASE(checkpubcoinsig_test)
+{
+    RandomInit();
+    ECC_Start();
+
+    CBigNum bnTrustedModulus = 0;
+    if (!bnTrustedModulus)
+        bnTrustedModulus.SetDec(zerocoinModulus);
+    libzerocoin::ZerocoinParams zerocoinParams = libzerocoin::ZerocoinParams(bnTrustedModulus);
+
+    libzerocoin::PrivateCoin coin(&zerocoinParams, CoinDenomination::ZQ_TEN, true);
+    PublicCoin pubCoin = coin.getPublicCoin();
+    auto bnPubcoin = pubCoin.getValue();
+
+    //! Expect Pass: Standard scenario
+    Commitment C1(&zerocoinParams.serialNumberSoKCommitmentGroup, bnPubcoin);
+    libzerocoin::PubcoinSignature pubcoinSig_valid(&zerocoinParams, bnPubcoin, C1);
+    std::string strError;
+    bool fVerified = pubcoinSig_valid.Verify(C1.getCommitmentValue(), strError);
+    strError = std::string("Pubcoin Signature Failed to Verify: ") + strError;
+    BOOST_CHECK_MESSAGE(fVerified, strError);
+
+    //! Expect Fail: pubcoin + serialparams.grouporder (same commitment value, but to different pubcoin value)
+    auto pubcoinSig = PubcoinSignature(&zerocoinParams, bnPubcoin+zerocoinParams.serialNumberSoKCommitmentGroup.groupOrder, C1);
+    auto C1_mod = Commitment(&zerocoinParams.serialNumberSoKCommitmentGroup, bnPubcoin+zerocoinParams.serialNumberSoKCommitmentGroup.groupOrder, C1.getRandomness());
+    BOOST_CHECK(C1.getCommitmentValue() == C1_mod.getCommitmentValue());
+    fVerified = pubcoinSig.Verify(C1.getCommitmentValue(), strError);
+    strError = std::string("Pubcoin Signature Failed to Verify: ") + strError;
+    BOOST_CHECK_MESSAGE(!fVerified, "Pubcoin sig passed testing even though it did not have the pubcoin that was committed to");
+
+    //! Expect Fail: empty pubcoin
+    CDataStream ss(0, 0);
+    ss << uint8_t(1) << CBigNum(0) << C1.getRandomness();
+    ss >> pubcoinSig;
+    fVerified = pubcoinSig.Verify(C1.getCommitmentValue(), strError);
+    BOOST_CHECK_MESSAGE(!fVerified , "Pubcoin sig passed testing even though it has 0 pubcoin value");
+
+    //! Expect Fail: empty C1.randomness
+    ss.clear();
+    ss << uint8_t(1) << bnPubcoin << CBigNum(0);
+    ss >> pubcoinSig;
+    fVerified = pubcoinSig.Verify(C1.getCommitmentValue(), strError);
+    BOOST_CHECK_MESSAGE(!fVerified , "Pubcoin sig passed testing even though it has 0 c1.r value");
+
+    //! Expect Fail: commitment to different pubcoin
+    libzerocoin::PrivateCoin coin2(&zerocoinParams, CoinDenomination::ZQ_TEN, true);
+    Commitment C1_alt(&zerocoinParams.serialNumberSoKCommitmentGroup, coin2.getPublicCoin().getValue());
+    pubcoinSig = PubcoinSignature(&zerocoinParams, bnPubcoin, C1_alt);
+    fVerified = pubcoinSig.Verify(C1_alt.getCommitmentValue(), strError);
+    BOOST_CHECK_MESSAGE(!fVerified , "Pubcoin sig passed testing even though the sig is made to a commitment to a different pubcoin");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4042,6 +4042,8 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::Coi
         const CBigNum& bnPubcoin = spend.getPubcoinValue();
         if ((!fVerifying && !fReindex) && !IsPubcoinInBlockchain(GetPubCoinHash(bnPubcoin), nHeightTx, txid, pindex->pprev))
             return error("%s: pubcoinhash %s is not found in the blockchain", __func__, GetPubCoinHash(bnPubcoin).GetHex());
+    } else if (spend.getVersion() == libzerocoin::CoinSpend::V4_LIMP) {
+        return error("%s: zerocoinspend v4 while v4 is not active", __func__);
     }
 
     libzerocoin::SpendType expectedType = libzerocoin::SpendType::SPEND;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4040,7 +4040,7 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::Coi
         int nHeightTx;
         uint256 txid;
         const CBigNum& bnPubcoin = spend.getPubcoinValue();
-        if (!IsPubcoinInBlockchain(GetPubCoinHash(bnPubcoin), nHeightTx, txid, pindex))
+        if ((!fVerifying && !fReindex) && !IsPubcoinInBlockchain(GetPubCoinHash(bnPubcoin), nHeightTx, txid, pindex->pprev))
             return error("%s: pubcoinhash %s is not found in the blockchain", __func__, GetPubCoinHash(bnPubcoin).GetHex());
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -776,7 +776,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                     return state.Invalid(false, REJECT_DUPLICATE, "zcspend-already-in-mempool");
                 }
 
-                if (!ContextualCheckZerocoinSpend(tx, *spend, pindexBestHeader->GetBlockHash(), pindexBestHeader, /*fSkipVerify*/true))
+                ThresholdState tstate = VersionBitsState(chainActive.Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_ZC_LIMP, versionbitscache);
+                bool fZCLimpMode = tstate == ThresholdState::ACTIVE;
+                if (!ContextualCheckZerocoinSpend(tx, *spend, pindexBestHeader->GetBlockHash(), pindexBestHeader, fZCLimpMode,/*fSkipVerify*/true))
                     return state.Invalid(false, REJECT_INVALID, "failed-zcspend-context-checks");
 
                 libzerocoin::SerialNumberSoKProof proof(spend->getSmallSoK(), spend->getCoinSerialNumber(),
@@ -2349,6 +2351,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     std::set <CBigNum> setSerialsInBlock;
     std::map<libzerocoin::CoinSpend, uint256> mapSpends;
     std::map<libzerocoin::PublicCoin, uint256> mapMints;
+    ThresholdState tstate = VersionBitsState(pindex->pprev, Params().GetConsensus(), Consensus::DEPLOYMENT_ZC_LIMP, versionbitscache);
+    bool fZCLimpMode = tstate == ThresholdState::ACTIVE;
 
     CAmount nBlockValueIn = 0;
     CAmount nBlockValueOut = 0;
@@ -2434,7 +2438,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
                     setSerialsInBlock.emplace(spend->getCoinSerialNumber());
                     mapSpends.emplace(*spend, tx.GetHash());
-                    if (!ContextualCheckZerocoinSpend(tx, *spend.get(), block.GetHash(), pindex, /*fSkipVerify*/true))
+                    if (!ContextualCheckZerocoinSpend(tx, *spend.get(), block.GetHash(), pindex, fZCLimpMode, /*fSkipVerify*/true))
                         return state.DoS(100, error("%s: failed to add block %s with invalid zerocoinspend", __func__,
                                                     tx.GetHash().GetHex()), REJECT_INVALID);
                     libzerocoin::SerialNumberSoKProof proof(spend->getSmallSoK(), spend->getCoinSerialNumber(),
@@ -4018,7 +4022,7 @@ bool ContextualCheckZerocoinMint(const CTransaction& tx, const libzerocoin::Publ
 }
 
 bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend& spend, const uint256& hashBlock,
-        CBlockIndex* pindex, bool fSkipSignatureVerify)
+        CBlockIndex* pindex, bool fZCLimpMode, bool fSkipSignatureVerify)
 {
     //Before v3 should not even serialize correctly, but double check here
     if (spend.getVersion() < libzerocoin::CoinSpend::V3_SMALL_SOK)
@@ -4026,6 +4030,19 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::Coi
 
     if (!spend.HasValidSignature())
         return error("%s: zerocoin spend does not have a valid signature", __func__);
+
+    //Turn on enforcement of de-anonymization of zerocoins
+    if (fZCLimpMode) {
+        if (spend.getVersion() != libzerocoin::CoinSpend::V4_LIMP)
+            return error("%s zerocoin spend is required to be V4", __func__);
+
+        //Get pubcoin and check if it has been accumulated
+        int nHeightTx;
+        uint256 txid;
+        const CBigNum& bnPubcoin = spend.getPubcoinValue();
+        if (!IsPubcoinInBlockchain(GetPubCoinHash(bnPubcoin), nHeightTx, txid, pindex))
+            return error("%s: pubcoinhash %s is not found in the blockchain", __func__, GetPubCoinHash(bnPubcoin).GetHex());
+    }
 
     libzerocoin::SpendType expectedType = libzerocoin::SpendType::SPEND;
     if (tx.IsCoinStake())
@@ -4057,7 +4074,7 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::Coi
 
         //Check that the coin has been accumulated
         std::string strError;
-        if (!spend.Verify(accumulator, strError, true))
+        if (!spend.Verify(accumulator, strError, true, fZCLimpMode))
             return error("CheckZerocoinSpend(): zerocoin spend did not verify");
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -164,6 +164,7 @@ extern uint256 g_best_block;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 extern std::atomic_bool fReindexChainState;
+extern std::atomic_bool fVerifying;
 extern bool fSkipRangeproof;
 extern bool fBusyImporting;
 extern int nScriptCheckThreads;

--- a/src/validation.h
+++ b/src/validation.h
@@ -378,7 +378,7 @@ bool TestLockPointValidity(const LockPoints* lp);
  */
 bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false);
 
-bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend& spend, const uint256& hashBlock, CBlockIndex* pindex, bool fSkipSignatureVerify = false);
+bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend& spend, const uint256& hashBlock, CBlockIndex* pindex, bool fZCLimpMode, bool fSkipSignatureVerify = false);
 bool ContextualCheckZerocoinMint(const CTransaction& tx, const libzerocoin::PublicCoin& coin, CBlockIndex* pindex);
 
 /**

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70023;
+static const int PROTOCOL_VERSION = 70024;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -18,9 +18,10 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 31800;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70020;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70023;
-static const int MIN_PEER_PROTO_VERSION_TESTNET = 70021;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70023;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70024;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT_TESTNET = 70021;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT_TESTNET = 70024;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -22,6 +22,10 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.name =*/ "pos_weight",
         /*.gbt_force =*/ true,
     },
+    {
+        /*.name =*/ "zc_limp",
+        /*.gbt_force =*/ true,
+    },
 };
 
 ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2491,6 +2491,10 @@ static UniValue gettransaction(const JSONRPCRequest& request)
                 obj_vin.pushKV("serial", bnSerial.GetHex());
                 obj_vin.pushKV("serial_hash", GetSerialHash(bnSerial).GetHex());
                 obj_vin.pushKV("denom", (int64_t)spend->getDenomination());
+                obj_vin.pushKV("version", (int64_t)spend->getVersion());
+                if (spend->getVersion() == 4) {
+                    obj_vin.pushKV("pubcoin", spend->getPubcoinValue().GetHex());
+                }
             }
         } else {
             //Have to specifically look up type to determine whether it is CT or Basecoin

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5553,7 +5553,12 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
         return error("%s: could not find checksum used for spend\n", __func__);
 
     try {
-        libzerocoin::CoinSpend spend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, *coinwitness.pWitness, hashTxOut, spendType);
+
+        ThresholdState tstate = VersionBitsState(chainActive.Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_ZC_LIMP, versionbitscache);
+        bool fZCLimpMode = tstate == ThresholdState::ACTIVE;
+        uint8_t nVersion = fZCLimpMode ? libzerocoin::CoinSpend::V4_LIMP : libzerocoin::CoinSpend::V3_SMALL_SOK;
+
+        libzerocoin::CoinSpend spend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, *coinwitness.pWitness, hashTxOut, spendType, nVersion);
 
         std::string strError;
         if (!spend.Verify(accumulator, strError, true)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5561,7 +5561,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
         libzerocoin::CoinSpend spend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, *coinwitness.pWitness, hashTxOut, spendType, nVersion);
 
         std::string strError;
-        if (!spend.Verify(accumulator, strError, true)) {
+        if (!spend.Verify(accumulator, strError, true, fZCLimpMode)) {
             receipt.SetStatus(_("The new spend coin transaction did not verify"), ZINVALID_WITNESS);
             return false;
         }


### PR DESCRIPTION
## Overview
Due to disclosures made by [ZCoin](https://zcoin.io/further-disclosure-on-zerocoin-vulnerability/), and lots of analysis done with other teams such as ZCoin and PIVX, Veil will be placing its zerocoin protocol into a functional but **not anonymous** state. The transition will occur rapidly and be done using bit signalling in the block header.

Every zerocoin spend/stake will have no longer have any privacy associated with it and should be considered as transparent as a basecoin transaction. More details will follow soon that will provide a complete detailed breakdown and analysis of why these changes are being made.

### Important Notes:
- This puts zerocoin into what we call *limp mode*. 
- The privacy of both **CT and RingCT are not impacted by this.**

### Normal Zerocoin Operating
Every zerocoin mint has an identifier that gets added to the cryptographic accumulator. During normal operation of zerocoin, when someone goes to spend their mint they create a zero knowledge proof that their mint's identifier has been added to the accumulator. The proof does not reveal the mint, and the spent mint is indistinguishable from all other mints of that same denomination. This is the mechanism that makes the zerocoin protocol private and removes the link between mint and spend.

### Limp Mode
Limp Mode is being used by Veil to allow the payment protocol of zerocoin to function, while disabling the privacy aspect of zerocoin. Each zerocoin spend will also include its mint identifier so that it can be linked by Veil's blockchain database to ensure that it is a valid zerocoin that has been accumulated. This effectively removes any privacy aspect of the zerocoin protocol.

Limp Mode is useful in times that call for zerocoin to be disabled because of concerns over the ability to spend coins that have not been accumulated. For Veil this is especially critical because a large majority of the coin supply is held in zerocoins, and the proof of stake consensus system relies on zerocoin. Veil's limp mode allows staking to continue and zerocoin transactions to continue to take place.

This is should be seen as a temporary protocol that allows Veil to have more time to work on creating the best solutions to some complex problems that may not be solved in such a short time span, and especially not solved with the level of quality we would like it to be.

### Thanks To:
- The team at ZCoin, specifically [Peter](https://github.com/psolstice) and [Reuben](https://github.com/zcoinofficial/zcoin/commits?author=reubenyap) for promptly notifying members of the Veil team as well as a few other trusted developers, as well as doing the tedious work of identifying the errors as well as figuring out how to reproduce the errors.

- [random-zebra](https://github.com/random-zebra/), a contributor to both Veil and PIVX, who spent countless hours over the last week analyzing the complex and sensitive cryptography in `libzerocoin` and coming up with a solution that lets users safely send and receive zerocoin transactions without privacy aspects enabled.

- [blondfrogs](https://github.com/blondfrogs), a core developer for Veil, who helped test and implement the blockchain's transition to Limp Mode.