### PR TITLE
[Zerocoin] GMP BigNum: Fix limits for random number generators

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,6 +94,7 @@ BITCOIN_TESTS =\
   test/versionbits_tests.cpp \
   test/monthly_rewards_tests.cpp \
   test/libzerocoin_tests.cpp \
+  test/zerocoin_bignum_tests.cpp \
   test/zerocoin_denomination_tests.cpp \
   test/zerocoin_implementation_tests.cpp \
   test/zerocoin_transactions_tests.cpp \

--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -118,7 +118,7 @@ public:
     * @param range The upper bound on the number.
     * @return
     */
-    static CBigNum  randBignum(const CBigNum& range) {
+    static CBigNum randBignum(const CBigNum& range) {
         CBigNum ret;
         if(!BN_rand_range(ret.bn, range.bn)){
             throw bignum_error("CBigNum:rand element : BN_rand_range failed");
@@ -130,7 +130,7 @@ public:
     * @param k The bit length of the number.
     * @return
     */
-    static CBigNum RandKBitBigum(const uint32_t k){
+    static CBigNum randKBitBignum(const uint32_t k){
         CBigNum ret;
         if(!BN_rand(ret.bn, k, -1, 0)){
             throw bignum_error("CBigNum:rand element : BN_rand failed");
@@ -778,12 +778,18 @@ public:
         setvch(vch);
     }
 
+    /** PRNGs use OpenSSL for consistency with seed initialization **/
+
     /** Generates a cryptographically secure random number between zero and range exclusive
     * i.e. 0 < returned number < range
+    * (returns 0 if range = 0 or 1)
     * @param range The upper bound on the number.
     * @return
     */
     static CBigNum randBignum(const CBigNum& range) {
+        if (range < 2)
+            return 0;
+
         size_t size = (mpz_sizeinbase (range.bn, 2) + CHAR_BIT-1) / CHAR_BIT;
         std::vector<unsigned char> buf(size);
 
@@ -793,14 +799,14 @@ public:
         CBigNum ret(buf);
         if (ret < 0)
             mpz_neg(ret.bn, ret.bn);
-        return ret;
+        return 1 + (ret % (range-1));
     }
 
     /** Generates a cryptographically secure random k-bit number
     * @param k The bit length of the number.
     * @return
     */
-    static CBigNum RandKBitBigum(const uint32_t k){
+    static CBigNum randKBitBignum(const uint32_t k){
         std::vector<unsigned char> buf((k+7)/8);
 
         RandAddSeed();
@@ -809,7 +815,7 @@ public:
         CBigNum ret(buf);
         if (ret < 0)
             mpz_neg(ret.bn, ret.bn);
-        return ret;
+        return ret % (CBigNum(1) << k);
     }
 
     /**Returns the size in bits of the underlying bignum.
@@ -1033,7 +1039,7 @@ public:
      * @return the prime
      */
     static CBigNum generatePrime(const unsigned int numBits, bool safe = false) {
-        CBigNum rand = RandKBitBigum(numBits);
+        CBigNum rand = randKBitBignum(numBits);
         CBigNum prime;
         mpz_nextprime(prime.bn, rand.bn);
         return prime;

--- a/src/test/zerocoin_bignum_tests.cpp
+++ b/src/test/zerocoin_bignum_tests.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2017-2018 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <boost/test/unit_test.hpp>
+#include <streams.h>
+#include "util.h"
+#include "utilstrencodings.h"
+#include "libzerocoin/bignum.h"
+
+using namespace libzerocoin;
+
+bool testRandKBitBignum(int k_bits)
+{
+    CBigNum x = CBigNum::randKBitBignum(k_bits);
+    return (x.bitSize() <= k_bits);
+}
+
+bool testRandBignum(CBigNum limit)
+{
+    CBigNum x = CBigNum::randBignum(limit);
+    if (limit < 2)
+        return x == CBigNum(0);
+    return 0 < x && x < limit;
+}
+
+BOOST_AUTO_TEST_SUITE(zerocoin_bignum_tests)
+
+std::string zerocoinModulus = "25195908475657893494027183240048398571429282126204032027777137836043662020707595556264018525880784"
+"4069182906412495150821892985591491761845028084891200728449926873928072877767359714183472702618963750149718246911"
+"6507761337985909570009733045974880842840179742910064245869181719511874612151517265463228221686998754918242243363"
+"7259085141865462043576798423387184774447920739934236584823824281198163815010674810451660377306056201619676256133"
+"8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
+"31438167899885040445364023527381951378636564391212010397122822120720357";
+
+std::string strHexModulus = "c7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
+
+BOOST_AUTO_TEST_CASE(bignum_setdecimal)
+{
+    CBigNum bnDec;
+    bnDec.SetDec(zerocoinModulus);
+    CBigNum bnHex;
+    bnHex.SetHex(strHexModulus);
+    BOOST_CHECK_MESSAGE(bnDec == bnHex, "CBigNum.SetDec() does not work correctly");
+}
+
+std::string negstrHexModulus = "-c7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
+std::string str_a = "775897c5463939bf29a02816aba7b1741162e1f6b052cd32fec36c44dfee7d4b5162de78bb0b448cb305b0a9bd7e006aec62d7c1e94a31003c2decbdc6fd7c9b261cb88801c51e7cee71a215ff113ccbd02069cf29671e6302944ca5780a2f626eb9046fa6872968addc93c74d09cf6b2872bc4c6bd08e89324cc7e9fb921488";
+std::string str_b = "-775897c5463939bf29a02816aba7b1741162e1f6b052cd32fec36c44dfee7d4b5162de78bb0b448cb305b0a9bd7e006aec62d7c1e94a31003c2decbdc6fd7c9b261cb88801c51e7cee71a215ff113ccbd02069cf29671e6302944ca5780a2f626eb9046fa6872968addc93c74d09cf6b2872bc4c6bd08e89324cc7e9fb921488";
+
+BOOST_AUTO_TEST_CASE(bignum_basic_tests)
+{
+    CBigNum bn, bn2;
+    std::vector<unsigned char> vch;
+
+    bn.SetHex(strHexModulus);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+
+    bn.SetHex(negstrHexModulus);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+
+    bn.SetHex(str_a);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+
+    bn.SetHex(str_b);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+}
+
+
+BOOST_AUTO_TEST_CASE(bignum_random_generation_tests)
+{
+    for(int i=1; i<3000; i++) {
+        BOOST_CHECK_MESSAGE(testRandKBitBignum(i), strprintf("CBigNum::randKBitBignum(%d) failed", i));
+    }
+
+    for(int i=1; i<3000; i++) {
+        CBigNum x = CBigNum::randKBitBignum(i);
+        BOOST_CHECK_MESSAGE(testRandBignum(x), strprintf("CBigNum::randBignum(x) failed with x=%s", x.ToString()));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/zerocoin_denomination_tests.cpp
+++ b/src/test/zerocoin_denomination_tests.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test241)
             nTotalAmount += currentAmount;
             CBigNum value;
             CBigNum rand;
-            CBigNum serial = CBigNum::RandKBitBigum(256);
+            CBigNum serial = CBigNum::randKBitBignum(256);
             bool isUsed = false;
             CMintMeta meta;
             meta.denom = denom;
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test115)
             nTotalAmount += currentAmount;
             CBigNum value;
             CBigNum rand;
-            CBigNum serial = CBigNum::RandKBitBigum(256);
+            CBigNum serial = CBigNum::randKBitBignum(256);
             bool isUsed = false;
             CMintMeta meta;
             meta.denom = denom;
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_245)
             nTotalAmount += currentAmount;
             CBigNum value;
             CBigNum rand;
-            CBigNum serial = CBigNum::RandKBitBigum(256);
+            CBigNum serial = CBigNum::randKBitBignum(256);
             bool isUsed = false;
             CMintMeta meta;
             meta.denom = denom;
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_145)
             nTotalAmount += currentAmount;
             CBigNum value;
             CBigNum rand;
-            CBigNum serial = CBigNum::RandKBitBigum(256);
+            CBigNum serial = CBigNum::randKBitBignum(256);
             bool isUsed = false;
             CMintMeta meta;
             meta.denom = denom;
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test99)
             nTotalAmount += currentAmount;
             CBigNum value;
             CBigNum rand;
-            CBigNum serial = CBigNum::RandKBitBigum(256);
+            CBigNum serial = CBigNum::randKBitBignum(256);
             bool isUsed = false;
             CMintMeta meta;
             meta.denom = denom;

--- a/src/test/zerocoin_implementation_tests.cpp
+++ b/src/test/zerocoin_implementation_tests.cpp
@@ -54,47 +54,6 @@ std::string zerocoinModulus = "2519590847565789349402718324004839857142928212620
 "8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
 "31438167899885040445364023527381951378636564391212010397122822120720357";
 
-std::string strHexModulus = "c7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
-
-BOOST_AUTO_TEST_CASE(bignum_setdecimal)
-{
-    CBigNum bnDec;
-    bnDec.SetDec(zerocoinModulus);
-    CBigNum bnHex;
-    bnHex.SetHex(strHexModulus);
-    BOOST_CHECK_MESSAGE(bnDec == bnHex, "CBigNum.SetDec() does not work correctly");
-}
-
-std::string negstrHexModulus = "-c7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
-std::string str_a = "775897c5463939bf29a02816aba7b1741162e1f6b052cd32fec36c44dfee7d4b5162de78bb0b448cb305b0a9bd7e006aec62d7c1e94a31003c2decbdc6fd7c9b261cb88801c51e7cee71a215ff113ccbd02069cf29671e6302944ca5780a2f626eb9046fa6872968addc93c74d09cf6b2872bc4c6bd08e89324cc7e9fb921488";
-std::string str_b = "-775897c5463939bf29a02816aba7b1741162e1f6b052cd32fec36c44dfee7d4b5162de78bb0b448cb305b0a9bd7e006aec62d7c1e94a31003c2decbdc6fd7c9b261cb88801c51e7cee71a215ff113ccbd02069cf29671e6302944ca5780a2f626eb9046fa6872968addc93c74d09cf6b2872bc4c6bd08e89324cc7e9fb921488";
-
-BOOST_AUTO_TEST_CASE(bignum_basic_tests)
-{
-    CBigNum bn, bn2;
-    std::vector<unsigned char> vch;
-
-    bn.SetHex(strHexModulus);
-    vch = bn.getvch();
-    bn2.setvch(vch);
-    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
-
-    bn.SetHex(negstrHexModulus);
-    vch = bn.getvch();
-    bn2.setvch(vch);
-    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
-
-    bn.SetHex(str_a);
-    vch = bn.getvch();
-    bn2.setvch(vch);
-    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
-
-    bn.SetHex(str_b);
-    vch = bn.getvch();
-    bn2.setvch(vch);
-    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
-}
-
 //ZQ_TEN mints
 std::string rawTx1 = "0100000001983d5fd91685bb726c0ebc3676f89101b16e663fd896fea53e19972b95054c49000000006a473044022010fbec3e78f9c46e58193d481caff715ceb984df44671d30a2c0bde95c54055f0220446a97d9340da690eaf2658e5b2bf6a0add06f1ae3f1b40f37614c7079ce450d012103cb666bd0f32b71cbf4f32e95fa58e05cd83869ac101435fcb8acee99123ccd1dffffffff0200e1f5050000000086c10280004c80c3a01f94e71662f2ae8bfcd88dfc5b5e717136facd6538829db0c7f01e5fd793cccae7aa1958564518e0223d6d9ce15b1e38e757583546e3b9a3f85bd14408120cd5192a901bb52152e8759fdd194df230d78477706d0e412a66398f330be38a23540d12ab147e9fb19224913f3fe552ae6a587fb30a68743e52577150ff73042c0f0d8f000000001976a914d6042025bd1fff4da5da5c432d85d82b3f26a01688ac00000000";
 std::string rawTxpub1 = "473ff507157523e74680ab37f586aae52e53f3f912492b19f7e14ab120d54238ae30b338f39662a410e6d707784d730f24d19dd9f75e85221b51b902a19d50c120844d15bf8a3b9e346355857e7381e5be19c6d3d22e01845565819aae7cacc93d75f1ef0c7b09d823865cdfa3671715e5bfc8dd8fc8baef26216e7941fa0c3";
@@ -388,7 +347,7 @@ BOOST_AUTO_TEST_CASE(checkzerocoinspend_test)
 
     //Get the checksum of the accumulator we use for the spend and also add it to our checksum map
 //    auto hashChecksum_v2 = GetChecksum(accumulator_v2.getValue());
-//    uint256 ptxHash = CBigNum::RandKBitBigum(256).getuint256();
+//    uint256 ptxHash = CBigNum::randKBitBignum(256).getuint256();
 //    try {
 //        CoinSpend coinSpend_v2(Params().Zerocoin_Params(), coin, accumulator_v2, hashChecksum_v2, witness_v2,
 //                               ptxHash, SpendType::SPEND);
@@ -565,7 +524,7 @@ BOOST_AUTO_TEST_CASE(test_zerocoinspend_ringct_change)
     }
 
     uint256 nChecksum = GetChecksum(accumulator.getValue());
-    uint256 ptxHash = CBigNum::RandKBitBigum(256).getuint256();
+    uint256 ptxHash = CBigNum::randKBitBignum(256).getuint256();
     bool fSpendValid = true;
     CoinSpend* pspend;
     try {


### PR DESCRIPTION
This fixes an issue where the GMP bignum PRNGs could output numbers slightly bigger than the max size set.