### PR TITLE
[Wallet] Remove check for amount less than 10

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -243,7 +243,6 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             /**Spend Zerocoins first**/
             spendType = WalletModelSpendType::ZCSPEND;
             //todo, this does not support multi recipient spend yet
-
             std::vector<CZerocoinMint> vMintsSelected;
             newTx = m_wallet->prepareZerocoinSpend(total, /*nSecurityLevel*/100, receipt, vMintsSelected,
                     fMintChange, /*fMinimizeChange*/false, vCommitData, libzerocoin::CoinDenomination::ZQ_ERROR,

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -283,7 +283,7 @@ UniValue spendzerocoin(const JSONRPCRequest& request)
 
     if (request.fHelp || params.size() > 6 || params.size() < 5)
         throw std::runtime_error(
-                "spendzerocoin amount mintchange minimizechange securitylevel  \"address\"  d(denomination)\n"
+                "spendzerocoin amount mintchange minimizechange securitylevel  \"address\"  (denomination)\n"
                 "\nSpend zerocoin to a veil address.\n"
                 "\nArguments:\n"
                 "1. amount          (numeric, required) Amount to spend.\n"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5868,17 +5868,16 @@ bool CWallet::PrepareZerocoinSpend(CAmount nValue, int nSecurityLevel, CZerocoin
 {
     // Default: assume something goes wrong. Depending on the problem this gets more specific below
     int nStatus = ZSPEND_ERROR;
-
     if (IsLocked() || IsUnlockedForStakingOnly()) {
         receipt.SetStatus("Error: Wallet locked, unable to create transaction!", ZWALLET_LOCKED);
-        return false;
+        return error("%s : %s", __func__, receipt.GetStatusMessage());
     }
-
     // If not already given pre-selected mints, then select mints from the wallet
     CAmount nValueSelected = 0;
     if (vMintsSelected.empty()) {
-        if(!CollectMintsForSpend(nValue, vMintsSelected, receipt, nStatus, fMinimizeChange, denomFilter))
-            return false;
+        if(!CollectMintsForSpend(nValue, vMintsSelected, receipt, nStatus, fMinimizeChange, denomFilter)) {
+            return error("%s : %s", __func__, receipt.GetStatusMessage());
+        }
     }
 
     // todo: should we use a different reserve key for each transaction?
@@ -6249,11 +6248,6 @@ bool CWallet::CollectMintsForSpend(CAmount nValue, std::vector<CZerocoinMint>& v
     CAmount nzBalance = GetZerocoinBalance(true);
     if (nValue > nzBalance) {
         receipt.SetStatus(strprintf("You don't have enough Zerocoins in your wallet. Balance: %s", FormatMoney(nzBalance)), nStatus);
-        return false;
-    }
-
-    if (nValue < 10*COIN) {
-        receipt.SetStatus("Value is below the smallest available denomination (= 1) of zerocoin", nStatus);
         return false;
     }
 


### PR DESCRIPTION
- Sending less than 10 veil by spending a zerocoin in your wallet would make the transaction fail, without any error message being sent to the user. 
- This fixes that issue by allowing the zerocoin spend to complete
- This also adds some error logs if the spend fails to happen again, so it can be troubleshooted

Closes #555 
Closes #584 

Test Preconditions:
1. Wallet must contain at least 1 zerocoin ( I had some 10 denoms in my wallet) , and that zerocoin must be spendable

Test steps:
1. Try to send a value less than 10 veil to an address. 
2. Wait for the transaction to be confirmed
3. Try to spend the change that was made from the above transaction to another address ( you can use coincointrol to selected the specific outpoint to use when making this spend) 

Edit: Adding more QA testcases from @presstab 

  1.  Spending less than 10 to a stealth address returns proper change amount.
  2.  Spending less than 10 to a basecoin address returns proper change amount.
  3.  Using spendzerocoin rpc with the mintchange flag, and spending less than 10, will still result in proper change.

Edit:
Need new code review for commit 187d48215195a7d167a12ec21ef9502f21557f6c which adds support for the basecoin change address when spending zerocoin to basecoin addresses

Edit 2: 
Need new code review for commit fde2f5d124d9df1e21d0ab43417c482bb13e1ae5 which make change come back as ct.
