### PR TITLE
[Wallet] Add ability to autospend zerocoin denominations

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -494,16 +494,19 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x00");
+        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x00");
+        consensus.defaultAssumeValid = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
+
+        consensus.nMinRCTOutputDepth = 12;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
         pchMessageStart[2] = 0xb5;
         pchMessageStart[3] = 0xda;
         nDefaultPort = 58821;
+
         nPruneAfterHeight = 1000;
         nConsecutivePoWHeight = 1000000;
         nLastPOWBlock = 2000000;
@@ -536,15 +539,25 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
+        base58Prefixes[STEALTH_ADDRESS]    = {0x84}; // v
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
-        bech32_hrp_stealth = "bcrt";
+        bech32Prefixes[STEALTH_ADDRESS].assign("tps","tps"+3);
+        bech32Prefixes[BASE_ADDRESS].assign("tv", "tv"+2);
+
+        bech32_hrp_stealth = "tps";
+        bech32_hrp_base = "tv";
+
+        fDefaultConsistencyChecks = false;
+        fRequireStandard = false;
+        fMineBlocksOnDemand = false;
 
         /* enable fallback fee on regtest */
         m_fallback_fee_enabled = true;
 
-        strNetworkRewardAddress = "2N9sWUmygPRy1c14eFWt8FzA8YF4JgA6j6a";
+        strNetworkRewardAddress = "tv1qhzkv6xdc7zpfx9ldsrqpk84hkcf36kclsyyeeh";
+        nMaxNetworkReward = 10 * COIN;
 
         /** Zerocoin */
         zerocoinModulus = "25195908475657893494027183240048398571429282126204032027777137836043662020707595556264018525880784"
@@ -553,13 +566,22 @@ public:
                           "7259085141865462043576798423387184774447920739934236584823824281198163815010674810451660377306056201619676256133"
                           "8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
                           "31438167899885040445364023527381951378636564391212010397122822120720357";
-        nMaxZerocoinSpendsPerTransaction = 7; // Assume about 20kb each
+        nMaxZerocoinSpendsPerTransaction = 20; // Assume about 6.5kb each
         nMinZerocoinMintFee = 1 * CENT; //high fee required for zerocoin mints
-        nMintRequiredConfirmations = 20; //the maximum amount of confirmations until accumulated in 19
+        nMintRequiredConfirmations = 10; //the maximum amount of confirmations until accumulated in 19
         nRequiredAccumulation = 1;
         nDefaultSecurityLevel = 100; //full security level for accumulators
-        nZerocoinRequiredStakeDepth = 400; //The required confirmations for a zerocoin to be stakable
+        nZerocoinRequiredStakeDepth = 10; //The required confirmations for a zerocoin to be stakable
+        nHeightPoSStart = 100;
+        nKernelModulus = 10;
+        nCoinbaseMaturity = 10;
+        nProofOfFullNodeRounds = 4;
+        nLastPOWBlock = 2000000;
+        nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
         nTimeEnforceWeightReduction = 1548849600; //Stake weight must be reduced for higher denominations (GMT): Wednesday, January 30, 2019 12:00:00 PM
+
+        /** RingCT/Stealth **/
+        nDefaultRingSize = 11;
 
         nMaxHeaderRequestWithoutPoW = 50;
     }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -219,6 +219,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "showspendcaching", 0, "fVerbose"},
     { "startprecomputing", 0, "nBlockPerCycle"},
     { "setprecomputeblockpercycle", 0, "nBlockPerCycle"},
+    { "startautospend", 1, "nNumberToSpend"},
+    { "startautospend", 2, "nDenomination"},
 };
 
 class CRPCConvertTable

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -67,6 +67,10 @@ void WalletInit::AddWalletOptions() const
 
     gArgs.AddArg("-precompute=<n>", strprintf("Enable the wallet to start solving zerocoin spend proofs inorder to make staking and spending zerocoin faster (default: %u)", false), false, OptionsCategory::WALLET);
     gArgs.AddArg("-precomputeblockpercycle=<n>", strprintf("Set the number of included blocks to precompute per cycle. (minimum: %d) (maximum: %d) (default: %d)", MIN_PRECOMPUTE_BPC, DEFAULT_PRECOMPUTE_BPC, MIN_PRECOMPUTE_BPC), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-autospend", strprintf("Enable to wallet to start trying to auto spend zerocoin to an address this wallet controls (default: %u)", false), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-autospendcount=<n>", strprintf("The selected number between 1 - 3 that the wallet will try to auto spend (default: %d)", 1), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-autospenddenom=<n>", strprintf("The selected denomination (10, 100, 1000, 10000) to try and auto spend (default: %d)", 10), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-autospendaddress=<address>", strprintf("The selected destination address used for auto spend. If one isn't given, a new address will be created by the wallet, and will be saved to use until it is changed"), false, OptionsCategory::WALLET);
 
 }
 

--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -1508,6 +1508,96 @@ UniValue searchdeterministiczerocoin(const JSONRPCRequest& request)
     return "done";
 }
 
+UniValue startautospend(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+        return NullUniValue;
+
+    UniValue params = request.params;
+    if (request.fHelp || params.size() > 3)
+        throw runtime_error(
+                "startautospend\n"
+                "\nStart auto spending zerocoin to a address this wallet controls\n" +
+                HelpRequiringPassphrase(pwallet) + "\n"
+
+                                                   "\nArguments\n"
+                                                   "1. \"address\"              (string, optional  (default = "") the stealth address the zerocoin will be spent to, if \"\" is passed in a new stealth address will be used and databased for autospend\n"
+                                                   "2. \"nNumberToSpend\"       (numeric, optional (default = 1) the number of zerocoin spends to make per transaction: options are (1, 2, 3)\n"
+                                                   "3. \"nDenomination\"        (numeric, optional (default = 10) which denomination to auto spend: options are (10, 100, 1000, 10000)\n"
+
+                                                   "\nExamples\n" +
+                HelpExampleCli("startautospend", "tqqpc3eycq5nlpt2frlhpt99gqwuwn0apdhqftl9ewer7fctj2wjjgxcpqd6j3pd29hdnanjhx5n9z80pn2t4tdwm906qcjgurgznw6hkefpdjqqqxjemja 2 10") + HelpExampleRpc("startautospend", "tqqpc3eycq5nlpt2frlhpt99gqwuwn0apdhqftl9ewer7fctj2wjjgxcpqd6j3pd29hdnanjhx5n9z80pn2t4tdwm906qcjgurgznw6hkefpdjqqqxjemja 2 10"));
+
+    EnsureWalletIsUnlocked(pwallet);
+
+    std::string address = "";
+    if (params.size() > 0) {
+        address = params[0].get_str();
+
+        if (!address.empty()) {
+            CBitcoinAddress bitAddress(address);
+
+            if (!bitAddress.IsValidStealthAddress())
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Veil Stealth Address");
+        }
+    }
+
+    int nNumberToSpend = 1;
+    if (params.size() > 1) {
+        nNumberToSpend = params[1].get_int();
+    }
+
+    int nDenomToSpend = 10;
+    if (params.size() > 2) {
+        nDenomToSpend = params[2].get_int();
+    }
+
+    SetAutoSpendParameters(nNumberToSpend, nDenomToSpend, address);
+    StartAutoSpend();
+    return _("Auto spend zerocoin started");
+}
+
+UniValue stopautospend(const JSONRPCRequest& request)
+{
+    UniValue params = request.params;
+    if(request.fHelp || params.size())
+        throw runtime_error(
+                "stopautospend\n"
+                "\nStop auto spending zerocoin\n");
+
+    StopAutoSpend();
+    return _("Auto spend zerocoin stopped");
+}
+
+UniValue getautospendaddress(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+        return NullUniValue;
+
+    UniValue params = request.params;
+    if (request.fHelp || params.size())
+        throw runtime_error(
+                "getautospendaddress\n"
+                "\nShows the current autospend stealth address\n" +
+                HelpRequiringPassphrase(pwallet) + "\n"
+
+                                                   "\nExamples\n" +
+                HelpExampleCli("getautospendaddress", "") + HelpExampleRpc("getautospendaddress", ""));
+
+    EnsureWalletIsUnlocked(pwallet);
+
+    std::string address;
+    if (pwallet->GetAutoSpendAddress(address))
+        return address;
+
+    return NullUniValue;
+}
+
+
 UniValue startprecomputing(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -1689,6 +1779,9 @@ static const CRPCCommand commands[] =
     { "zerocoin",           "setprecomputeblockpercycle",       &setprecomputeblockpercycle,    {"nBlockPerCycle"} },
     { "zerocoin",           "getprecomputeblockpercycle",       &getprecomputeblockpercycle,    {} },
     { "zerocoin",           "clearspendcache",                  &clearspendcache,               {}},
+    { "zerocoin",           "startautospend",                   &startautospend,                {"nNumberToSpend", "nDenomination"} },
+    { "zerocoin",           "stopautospend",                    &stopautospend,                 {}},
+    { "zerocoin",           "getautospendaddress",              &getautospendaddress,           {}}
 };
 
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7019,6 +7019,14 @@ void AutoSpendZeroCoin()
                 continue;
             }
 
+            TRY_LOCK(cs_main, fLockedMain);
+            if (!fLockedMain)
+                continue;
+
+            TRY_LOCK(pwallet->cs_wallet, fLockedWallet);
+            if (!fLockedWallet)
+                continue;
+
             bool fSuccess = pwallet->SpendZerocoin(found * libzerocoin::ZerocoinDenominationToInt(denom_to_spend) * COIN, 1, receipt, vMintsSelected, false, false, denom_to_spend, &destination);
 
             if (fSuccess) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4039,7 +4039,7 @@ DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx>& vWtx)
     return DBErrors::LOAD_OK;
 }
 
-bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose, bool bench32){
+bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose, bool bench32) {
     bool fUpdated = false;
     {
         LOCK(cs_wallet); // mapAddressBook
@@ -4049,9 +4049,8 @@ bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& s
         if (!strPurpose.empty()) /* update purpose only if requested */
             mapAddressBook[address].purpose = strPurpose;
     }
-    NotifyAddressBookChanged(this, address, strName, ::IsMine(*this, address) != ISMINE_NO,
-                             strPurpose, (fUpdated ? CT_UPDATED : CT_NEW) );
-    if (!strPurpose.empty() && !WalletBatch(*database).WritePurpose(EncodeDestination(address,bench32), strPurpose))
+    NotifyAddressBookChanged(this, address, strName, ::IsMine(*this, address) != ISMINE_NO, strPurpose, (fUpdated ? CT_UPDATED : CT_NEW));
+    if (!strPurpose.empty() && !WalletBatch(*database).WritePurpose(EncodeDestination(address, bench32), strPurpose))
         return false;
     return WalletBatch(*database).WriteName(EncodeDestination(address,bench32), strName);
 }
@@ -4092,6 +4091,20 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
 
     WalletBatch(*database).ErasePurpose(EncodeDestination(address));
     return WalletBatch(*database).EraseName(EncodeDestination(address));
+}
+
+bool CWallet::SetAutoSpendAddress(const CTxDestination& address) {
+    return WalletBatch(*database).WriteAutoSpend(EncodeDestination(address,true));
+}
+
+bool CWallet::GetAutoSpendAddress(std::string& address)
+{
+    return WalletBatch(*database).ReadAutoSpend(address);
+}
+
+bool CWallet::EraseAutoSpendAddress()
+{
+    return WalletBatch(*database).EraseAutoSpend();
 }
 
 const std::string& CWallet::GetLabelName(const CScript& scriptPubKey) const
@@ -6843,4 +6856,182 @@ void CWallet::PrecomputeSpends()
         LogPrint(BCLog::PRECOMPUTE, "%s: Finished precompute round...\n\n", __func__);
         MilliSleep(5000);
     }
+}
+
+boost::thread_group* pthreadGroupAutoSpend;
+
+
+void LinkAutoSpendThreadGroup(void* pthreadgroup)
+{
+    pthreadGroupAutoSpend = (boost::thread_group*)pthreadgroup;
+}
+
+bool StartAutoSpend()
+{
+    if (!pthreadGroupAutoSpend) {
+        error("%s: pthreadGroupAutoSpend is null! Cannot autospend.", __func__);
+        return false;
+    }
+
+    // Close any active auto spend threads before starting new threads
+    if (pthreadGroupAutoSpend->size() > 0) {
+        StopAutoSpend();
+    }
+
+    pthreadGroupAutoSpend->create_thread(boost::bind(&AutoSpendZeroCoin));
+    return true;
+}
+
+void StopAutoSpend()
+{
+    if (!pthreadGroupAutoSpend) {
+        error("%s: pthreadGroupAutoSpend is null! Cannot stop autospending.", __func__);
+        return;
+    }
+
+    if (pthreadGroupAutoSpend->size() > 0) {
+        pthreadGroupAutoSpend->interrupt_all();
+        pthreadGroupAutoSpend->join_all();
+    }
+
+    LogPrintf("AutoSpendZeroCoin stopped\n");
+}
+
+static libzerocoin::CoinDenomination denom_to_spend = libzerocoin::CoinDenomination::ZQ_TEN;
+static int max_number_to_spend = 1;
+static std::string auto_spend_address = "";
+
+void SetAutoSpendParameters(const int& nCount, const int& nDenom, const std::string& strAddress)
+{
+    if (nCount >= 1 && nCount <= 3)
+        max_number_to_spend = nCount;
+
+    libzerocoin::CoinDenomination denom = libzerocoin::IntToZerocoinDenomination(nDenom);
+
+    if (denom != libzerocoin::CoinDenomination::ZQ_ERROR)
+        denom_to_spend = denom;
+
+    auto_spend_address = strAddress;
+}
+
+void AutoSpendZeroCoin()
+{
+    LogPrintf("AutoSpendZeroCoin started: spending at most %d of the %d denomination per cycle\n", max_number_to_spend, libzerocoin::ZerocoinDenominationToInt(denom_to_spend));
+
+    static CTxDestination destination;
+
+    boost::this_thread::interruption_point();
+    try {
+        int64_t nMilliSeconds = 3000;
+        int count = 0;
+
+        while (true) {
+            // Sleep 5 minutes between spends, but actively check to see if the thread has been interrupted every 3 seconds
+            if (count < 100) {
+                count++;
+                boost::this_thread::interruption_point();
+                MilliSleep(nMilliSeconds);
+                boost::this_thread::interruption_point();
+                continue;
+            }
+            count = 0;
+
+            boost::this_thread::interruption_point();
+
+            if (ShutdownRequested())
+                break;
+
+            if (IsInitialBlockDownload() || !HeadersAndBlocksSynced()) {
+                LogPrintf("%s: waiting for sync cannot auto spend\n", __func__);
+                continue;
+            }
+
+            auto pwallet = GetMainWallet();
+
+            if (!pwallet) {
+                LogPrintf("%s: pwallet is null cannot auto spend\n", __func__);
+                continue;
+            }
+
+            if (pwallet->IsLocked() || pwallet->IsUnlockedForStakingOnly()) {
+                LogPrintf("%s: pwallet is locked cannot auto spend\n", __func__);
+                continue;
+            }
+
+            if (!IsValidDestination(destination)) {
+                // Check to see if a new address was passed in via the argument
+                std::string address = auto_spend_address;
+                if (address.empty()) {
+                    // See if the wallet already has an autospend address databased
+                    pwallet->GetAutoSpendAddress(address);
+                }
+
+                // Create a destination from the address given or databased
+                CBitcoinAddress addr(address);
+                destination = addr.Get();
+
+                // If the destination isn't valid at this point. Create a new stealth address and database it
+                if (!IsValidDestination(destination)) {
+                    CStealthAddress stealthAddress;
+
+                    // Check to make sure the anon wallet is available
+                    auto anonwallet = pwallet->GetAnonWallet();
+                    if (!anonwallet) {
+                        LogPrintf("%s: anonwallet is null cannot auto spend\n", __func__);
+                        continue;
+                    }
+
+                    // Generate new address
+                    if (!anonwallet->NewStealthKey(stealthAddress, 0, nullptr)) {
+                        LogPrintf("%s: Failed to create new stealth address to use for auto spend\n", __func__);
+                        continue;
+                    }
+
+                    destination = stealthAddress;
+                }
+
+                // Save the destination to database
+                if (!pwallet->SetAutoSpendAddress(destination))
+                    LogPrintf("%s : Failed to set auto spend address\n", __func__);
+            }
+
+            std::vector<CZerocoinMint> vMintsSelected;
+            CZerocoinSpendReceipt receipt;
+
+            // Get the list of mints
+            std::set<CMintMeta> mints = pwallet->ListMints(true, true, false);
+
+            int found = 0;
+            for (const auto& mint : mints) {
+                // If you have a mint of the selected denom to spend
+                if (mint.denom == denom_to_spend) {
+                    found++;
+                }
+
+                // If you have found the selected number of mints to spends
+                if (found == max_number_to_spend)
+                    break;
+            }
+
+            // If no mints found to spend, don't try and spend
+            if (found == 0) {
+                LogPrintf("%s : No more denominations of the selected type (%d) to auto spend\n", __func__, ZerocoinDenominationToInt(denom_to_spend));
+                continue;
+            }
+
+            bool fSuccess = pwallet->SpendZerocoin(found * libzerocoin::ZerocoinDenominationToInt(denom_to_spend) * COIN, 1, receipt, vMintsSelected, false, false, denom_to_spend, &destination);
+
+            if (fSuccess) {
+                LogPrintf("Successfully auto spent %d %d denomination(s)\n", found, libzerocoin::ZerocoinDenominationToInt(denom_to_spend));
+            } else {
+                LogPrintf("Failed to auto spend zerocoin\n");
+            }
+        }
+    } catch (std::exception& e) {
+        LogPrintf("AutoSpendZeroCoin() exception\n");
+    } catch (boost::thread_interrupted) {
+        LogPrintf("AutoSpendZeroCoin() interrupted\n");
+    }
+
+    LogPrintf("AutoSpendZeroCoin stopping\n");
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1214,6 +1214,10 @@ public:
 
     bool DelAddressBook(const CTxDestination& address);
 
+    bool SetAutoSpendAddress(const CTxDestination& address);
+    bool GetAutoSpendAddress(std::string& address);
+    bool EraseAutoSpendAddress();
+
     const std::string& GetLabelName(const CScript& scriptPubKey) const;
 
     void GetScriptForMining(std::shared_ptr<CReserveScript> &script);
@@ -1434,6 +1438,12 @@ public:
         }
     }
 };
+
+void AutoSpendZeroCoin();
+void StopAutoSpend();
+bool StartAutoSpend();
+void LinkAutoSpendThreadGroup(void* pthreadgroup);
+void SetAutoSpendParameters(const int& nCount, const int& nDenom, const std::string& strAddress);
 
 // Calculate the size of the transaction assuming all signatures are max size
 // Use DummySignatureCreator, which inserts 71 byte signatures everywhere.

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -39,6 +39,21 @@ bool WalletBatch::EraseName(const std::string& strAddress)
     return EraseIC(std::make_pair(std::string("name"), strAddress));
 }
 
+bool WalletBatch::WriteAutoSpend(const std::string& strAddress)
+{
+    return WriteIC(std::string("autospendaddress"), strAddress);
+}
+
+bool WalletBatch::ReadAutoSpend(std::string& strAddress)
+{
+    return m_batch.Read(std::string("autospendaddress"), strAddress);
+}
+
+bool WalletBatch::EraseAutoSpend()
+{
+    return EraseIC(std::string("autospendaddress"));
+}
+
 bool WalletBatch::WritePurpose(const std::string& strAddress, const std::string& strPurpose)
 {
     return WriteIC(std::make_pair(std::string("purpose"), strAddress), strPurpose);
@@ -420,11 +435,12 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         } else if (strType != "bestblock" && strType != "bestblock_nomerkle" &&
-                strType != "minversion" && strType != "acentry") {
+                strType != "minversion" && strType != "acentry" && strType != "autospendaddress") {
             wss.m_unknown_records++;
         }
     } catch (...)
     {
+        LogPrintf("Failing here, on %s\n", strType);
         return false;
     }
     return true;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -189,6 +189,10 @@ public:
     bool WriteName(const std::string& strAddress, const std::string& strName);
     bool EraseName(const std::string& strAddress);
 
+    bool WriteAutoSpend(const std::string& strAddress);
+    bool ReadAutoSpend(std::string& strAddress);
+    bool EraseAutoSpend();
+
     bool WritePurpose(const std::string& strAddress, const std::string& purpose);
     bool ErasePurpose(const std::string& strAddress);
 


### PR DESCRIPTION
- Fixes regtest params to work with stealth addresses
- Added rpc call **startautospend** with three optional paramters (address, count, type)
    1. Address - The stealth address to auto spend to (if not given one will be generated)
    2. Number of spends: the number of spends to make per cycle ( 1 - 3)
    3. The denomination to spend ( 10, 100, 1000, 10000)
- Added rpc call **stopautospend** which stops the autospend thread
- Added rpc call **getautospendaddress** which shows the current address set to auto spend to
- Added new arugments
  1. **-autospend** enables the autospend thread
  2.  **-autospendcount=number** the number of spends to make per cycle (1-3)
  3. **-autospenddenom=number** the denomination to spend ( 10, 100, 1000, 10000)
  4. **-autospendaddress=string** the destination address for the zerocoin spends


Edit:
Spends zerocoin with security of 1


Closes #559 