### PR TITLE
[Wallet] Add Transaction Size to Transaction Detail Dialog

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -39,8 +39,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
         const CTransactionRecord &rtx = wtx.rtx;
 
         const uint256 &hash = wtx.tx->GetHash();
+        int nSize = wtx.tx->GetTotalSize();
         int64_t nTime = wtx.time;
-        TransactionRecord sub(hash, nTime);
+        TransactionRecord sub(hash, nTime, nSize);
         sub.computetime = wtx.computetime;
 
         uint8_t nFlags = 0;
@@ -223,11 +224,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
     CAmount nNet = nCredit - nDebit - wtx.ct_fee.second;
 
     uint256 hash = wtx.tx->GetHash();
+    int nSize = wtx.tx->GetTotalSize();
     std::map<std::string, std::string> mapValue = wtx.value_map;
 
     if (wtx.is_coinstake) {
         if (wtx.tx->IsZerocoinSpend() && (wtx.is_my_zerocoin_spend || wtx.is_my_zerocoin_mint)) {
-            TransactionRecord sub(hash, nTime);
+            TransactionRecord sub(hash, nTime, nSize);
             sub.computetime = wtx.computetime;
             sub.involvesWatchAddress = false;
             sub.type = TransactionRecord::ZeroCoinStake;
@@ -274,7 +276,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 if (!wtx.is_my_zerocoin_spend)
                     continue;
 
-                TransactionRecord sub(hash, nTime);
+                TransactionRecord sub(hash, nTime, nSize);
                 sub.computetime = wtx.computetime;
                 sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
                 sub.type = TransactionRecord::ZeroCoinSpendRemint;
@@ -298,7 +300,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
 
             // a zerocoinspend that was sent to an address held by this wallet
             if (mine || (precord && precord->IsReceive())) {
-                TransactionRecord sub(hash, nTime);
+                TransactionRecord sub(hash, nTime, nSize);
                 sub.computetime = wtx.computetime;
                 sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
                 if (wtx.is_my_zerocoin_spend) {
@@ -342,7 +344,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 continue;
 
             // zerocoin spend that was sent to someone else
-            TransactionRecord sub(hash, nTime);
+            TransactionRecord sub(hash, nTime, nSize);
             sub.computetime = wtx.computetime;
             sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
             if (pOut->GetType() == OUTPUT_STANDARD)
@@ -380,7 +382,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
             if (!mine)
                 continue;
 
-            TransactionRecord sub(hash, nTime);
+            TransactionRecord sub(hash, nTime, nSize);
             sub.computetime = wtx.computetime;
             sub.idx = i;
             sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
@@ -452,7 +454,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
 
             parts.append(
                     TransactionRecord(
-                            hash, nTime, recordType, "",
+                            hash, nTime, nSize, recordType, "",
                     -(nDebit - nChange), nCredit - nChange, nTxFee, wtx.tx->GetNumVOuts(), wtx.tx->GetNumVOuts(), 0, wtx.computetime
                     )
             );
@@ -466,7 +468,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 nTxFee = wtx.ct_fee.second;
 
             for (unsigned int nOut = 0; nOut < wtx.tx->vpout.size(); nOut++) {
-                TransactionRecord sub(hash, nTime);
+                TransactionRecord sub(hash, nTime, nSize);
                 sub.computetime = wtx.computetime;
                 sub.idx = nOut;
                 sub.involvesWatchAddress = involvesWatchAddress;
@@ -524,7 +526,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
             //
             // Mixed debit transaction, can't break down payees
             //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+            parts.append(TransactionRecord(hash, nTime, nSize, TransactionRecord::Other, "", nNet, 0));
             parts.last().involvesWatchAddress = involvesWatchAddress;
         }
     }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -111,30 +111,30 @@ public:
     static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)
+            hash(), time(0), size(0), type(Other), address(""), debit(0), credit(0), idx(0)
     {
     }
 
-    TransactionRecord(uint256 _hash, qint64 _time):
-            hash(_hash), time(_time), type(Other), address(""), debit(0),
+    TransactionRecord(uint256 _hash, qint64 _time, int _size):
+            hash(_hash), time(_time), size(_size), type(Other), address(""), debit(0),
             credit(0), idx(0)
     {
     }
 
-    TransactionRecord(uint256 _hash, qint64 _time,
+    TransactionRecord(uint256 _hash, qint64 _time, int _size,
                 Type _type, const std::string &_address,
                 const CAmount& _debit, const CAmount& _credit):
-            hash(_hash), time(_time), type(_type), address(_address), debit(_debit), credit(_credit),
+            hash(_hash), time(_time), size (_size), type(_type), address(_address), debit(_debit), credit(_credit),
             idx(0)
     {
     }
 
-    TransactionRecord(uint256 _hash, qint64 _time,
+    TransactionRecord(uint256 _hash, qint64 _time, int _size,
                       Type _type, const std::string &_address,
                       const CAmount& _debit, const CAmount& _credit,
                         const CAmount& _fee, int _outputsSize, int _inputsSize, int _confirmations, int _computetime):
 
-            hash(_hash), time(_time), type(_type), address(_address), debit(_debit), credit(_credit),
+            hash(_hash), time(_time), size(_size), type(_type), address(_address), debit(_debit), credit(_credit),
             idx(0), fee(_fee), outputsSize(_outputsSize), inputsSize(_inputsSize), confirmations(_confirmations), computetime(_computetime)
     {
     }
@@ -148,6 +148,7 @@ public:
       @{*/
     uint256 hash;
     qint64 time;
+    int size;
     Type type;
     std::string address;
     CAmount debit = 0;

--- a/src/qt/veil/transactiondetaildialog.cpp
+++ b/src/qt/veil/transactiondetaildialog.cpp
@@ -56,8 +56,7 @@ TransactionDetailDialog::TransactionDetailDialog(QWidget *parent, TransactionRec
         } else{
             ui->textSend->setText(QString::fromStdString((rec->getAddress())));
         }
-        // TODO: add size to TransactionRecord.
-        ui->textSize->setText("n/a Kb");
+        ui->textSize->setText(tr("%1 Bytes").arg(rec->size));
         ui->textDate->setText(GUIUtil::dateTimeStr(QDateTime::fromTime_t(static_cast<uint>(rec->time))));
         ui->textStatus->setText(QString::fromStdString(rec->statusToString()));
         if (rec->getComputeTime()) {


### PR DESCRIPTION
Adds Transaction Size to Transaction Detail Dialog.

I chose to display the size in Bytes, for the sake clarity.

Closes: #523 

Bounty payment address:
sv1qqp0j5cm6vrrkvkajpnq39gczt09eclw5z8h2zrmvrwndw7ppqaa28spqfqmkpana500t0jmjnhcjekg0rgt9jfll3w03m46p7ard9lqrpxduqqqe9a2qv