### PR TITLE
[GUI] Add transaction list filtering

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -127,6 +127,34 @@
                </spacer>
               </item>
               <item>
+               <widget class="QComboBox" name="comboFilter">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>120</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">#comboFilter{\n margin-right:6px;\n}</string>
+                </property>
+                <property name="currentText">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QComboBox" name="comboSort">
                 <property name="minimumSize">
                  <size>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -136,7 +136,7 @@
                 </property>
                 <property name="minimumSize">
                  <size>
-                  <width>120</width>
+                  <width>150</width>
                   <height>0</height>
                  </size>
                 </property>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -278,7 +278,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, WalletView *paren
         TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt)
     );
 
-    ui->comboFilter->addItem(tr("Minted"),
+    ui->comboFilter->addItem(tr("Mined"),
         TransactionFilterProxy::TYPE(TransactionRecord::Generated)
     );
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -24,6 +24,9 @@
 #include <QSettings>
 #include <QDesktopWidget>
 
+#include <QDebug>
+
+
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 3
 
@@ -228,8 +231,124 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, WalletView *paren
     for (int i = 0 ; i < ui->comboSort->count() ; ++i) {
        ui->comboSort->setItemData(i, Qt::AlignRight, Qt::TextAlignmentRole);
     }
+
+    // Filter
+    ui->comboFilter->setProperty("cssClass" , "btn-text-primary-inactive");
+
+    // Filter Default Option
+    ui->comboFilter->addItem(tr("Filter Type"), TransactionFilterProxy::ALL_TYPES);
+
+
+    ui->comboFilter->addItem(tr("Sent"),
+        TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::SendToOther) |
+        TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTSendToAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTSendToAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpend) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpendSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpend)
+    );
+
+
+    ui->comboFilter->addItem(tr("Received"),
+        TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther) |
+        TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTRecvWithAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTGenerated) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTRecvWithAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTGenerated) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMint) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpendRemint) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinRecv) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinStake) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertBasecoinToCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertBasecoinToRingCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertCtToRingCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertCtToBasecoin) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertRingCtToCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertRingCtToBasecoin) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertZerocoinToCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt)
+    );
+
+    ui->comboFilter->addItem(tr("Minted"),
+        TransactionFilterProxy::TYPE(TransactionRecord::Generated)
+    );
+
+    ui->comboFilter->addItem(tr("Minted"),
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMint) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpendRemint) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt)
+    );
+
+    ui->comboFilter->addItem(tr("Stake"),
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinStake)
+    );
+
+    ui->comboFilter->addItem(tr("Basecoin"),
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertBasecoinToCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertBasecoinToRingCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertCtToBasecoin) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertRingCtToBasecoin)
+    );
+
+
+    ui->comboFilter->addItem(tr("CT"),
+        TransactionFilterProxy::TYPE(TransactionRecord::CTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTSendToAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTRecvWithAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::CTGenerated) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertBasecoinToCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertCtToRingCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertCtToBasecoin) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertZerocoinToCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertRingCtToCt)
+    );
+
+    ui->comboFilter->addItem(tr("RingCT"),
+        TransactionFilterProxy::                     TYPE(TransactionRecord::RingCTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTSendToAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTRecvWithAddress) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTGenerated) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertBasecoinToRingCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertCtToRingCT) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertRingCtToCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertRingCtToBasecoin) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt)
+    );
+
+    ui->comboFilter->addItem(tr("ZeroCoin"),
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMint) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpendRemint) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpend) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpendSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinRecv) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinStake) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ConvertZerocoinToCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromCt) |
+        TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt)
+    );
+
+    ui->comboFilter->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
+
+    for (int i = 0 ; i < ui->comboFilter->count() ; ++i) {
+       ui->comboFilter->setItemData(i, Qt::AlignRight, Qt::TextAlignmentRole);
+    }
+
     // combo selection:
     connect(ui->comboSort,SIGNAL(currentIndexChanged(const QString&)),this,SLOT(sortTxes(const QString&)));
+    connect(ui->comboFilter,SIGNAL(currentIndexChanged(int)),this,SLOT(filterTxes(int)));
 
     this->setContentsMargins(0,0,0,0);
 
@@ -282,6 +401,10 @@ void OverviewPage::sortTxes(const QString& selectedStr){
     }
 }
 
+void OverviewPage::filterTxes(int type){
+    filter->setTypeFilter(ui->comboFilter->itemData(type).toInt());
+}
+
 void OverviewPage::handleOutOfSyncWarningClicks()
 {
     Q_EMIT outOfSyncWarningClicked();
@@ -329,7 +452,16 @@ void OverviewPage::setWalletModel(WalletModel *model)
         filter->setDynamicSortFilter(true);
         filter->setSortRole(Qt::EditRole);
         filter->setShowInactive(false);
+
+
+
         filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
+
+        // Set default filtering to show all transaction types.
+        // filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
+
+
+
 
         ui->listTransactions->setModel(filter.get());
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -315,7 +315,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, WalletView *paren
     );
 
     ui->comboFilter->addItem(tr("RingCT"),
-        TransactionFilterProxy::                     TYPE(TransactionRecord::RingCTSendToSelf) |
+        TransactionFilterProxy::TYPE(TransactionRecord::RingCTSendToSelf) |
         TransactionFilterProxy::TYPE(TransactionRecord::RingCTSendToAddress) |
         TransactionFilterProxy::TYPE(TransactionRecord::RingCTRecvWithAddress) |
         TransactionFilterProxy::TYPE(TransactionRecord::RingCTGenerated) |
@@ -326,7 +326,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, WalletView *paren
         TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromRingCt)
     );
 
-    ui->comboFilter->addItem(tr("ZeroCoin"),
+    ui->comboFilter->addItem(tr("Zerocoin"),
         TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMint) |
         TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinSpendRemint) |
         TransactionFilterProxy::TYPE(TransactionRecord::ZeroCoinMintFromCt) |

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -59,6 +59,7 @@ private Q_SLOTS:
     void updateWatchOnlyLabels(bool showWatchOnly);
     void handleOutOfSyncWarningClicks();
     void sortTxes(const QString& selectedStr);
+    void filterTxes(int selectedTxType);
     void onFaqClicked();
     virtual void showEvent(QShowEvent *event) override;
 


### PR DESCRIPTION
Adding filtering functionality to the transactions list.

Closes #540 

Transactions can now be filtered using the Taxonomies;
- Sent
- Received
- Mint
- Mined
- Stake
- Basecoin
- RingCT
- CT
- ZeroCoin
- All

![Screenshot from 2019-05-11 03-47-43](https://user-images.githubusercontent.com/8047888/57564251-ec6c6880-73a0-11e9-9181-3aa44efd85e2.png)
![aaa](https://user-images.githubusercontent.com/8047888/57564253-eecec280-73a0-11e9-9fdd-1c38802a9f5e.png)


Bounty Address
```
sv1qqpdsfcqvfcljtcq8txc8kc2dw4e9upj69wnnfv7j0ufcsrv7trs9lqpqfscke6jj92aj4aup387ggk7mathznr8hz3zde6ut87jdwphrns7qqqq00jn8w
```
