### PR TITLE
[GUI] Lock button focus & signal blocking fix.

### DIFF
--- a/src/qt/veil/forms/veilstatusbar.ui
+++ b/src/qt/veil/forms/veilstatusbar.ui
@@ -187,7 +187,7 @@
         <item>
          <widget class="QPushButton" name="btnLock">
           <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
+           <enum>Qt::StrongFocus</enum>
           </property>
           <property name="layoutDirection">
            <enum>Qt::LeftToRight</enum>
@@ -196,7 +196,7 @@
            <string/>
           </property>
           <property name="icon">
-           <iconset>
+           <iconset resource="../../veil.qrc">
             <normaloff>:/icons/ic-locked-png</normaloff>
             <selectedoff>:/icons/ic-unlocked-png</selectedoff>:/icons/ic-locked-png</iconset>
           </property>
@@ -215,5 +215,8 @@
    </item>
   </layout>
  </widget>
+ <resources>
+  <include location="../../veil.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/qt/veil/veilstatusbar.cpp
+++ b/src/qt/veil/veilstatusbar.cpp
@@ -133,12 +133,6 @@ void VeilStatusBar::onBtnLockClicked()
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
         return;
 
-    // When our own dialog internally changes the checkstate, block signal from executing
-    if (fBlockNextBtnLockSignal) {
-        fBlockNextBtnLockSignal = false;
-        return;
-    }
-
     if(walletModel->getEncryptionStatus() == WalletModel::Unlocked || walletModel->getEncryptionStatus() == WalletModel::UnlockedForStakingOnly){
         if (walletModel->setWalletLocked(true, false)){
             ui->btnLock->setIcon(QIcon(":/icons/ic-locked-png"));
@@ -202,7 +196,6 @@ void VeilStatusBar::updateLockCheckbox(){
         if (ui->btnLock->isChecked() != lockStatus) {
             ui->btnLock->setChecked(lockStatus);
             ui->btnLock->setIcon(QIcon( (lockStatus) ? ":/icons/ic-locked-png" : ":/icons/ic-unlocked-png"));
-            fBlockNextBtnLockSignal = true;
         }
 
         QString strToolTip;


### PR DESCRIPTION
A single click now triggers the initial unlock of the wallet by clicking `btnLock`

- Added focus policy
- Removed unnecessary signal blocks.

closes #553 

Bounty Address
```
sv1qqpdsfcqvfcljtcq8txc8kc2dw4e9upj69wnnfv7j0ufcsrv7trs9lqpqfscke6jj92aj4aup387ggk7mathznr8hz3zde6ut87jdwphrns7qqqq00jn8w
```