### PR TITLE
[GUI] Extending clickable area of Staking & Precompute toggle switch.

### DIFF
--- a/src/qt/res/css/main.css
+++ b/src/qt/res/css/main.css
@@ -453,7 +453,6 @@ QCheckBox[cssClass~="switch"] {
 background-image: url(":/icons/ic-switch-off") ;
 background-repeat:no-repeat;
 background-position:left center;
-padding:4px 4px 8px 30px;
 }
 
 QCheckBox[cssClass~="switch"]:checked {
@@ -683,20 +682,49 @@ QLabel#line{
 QCheckBox#checkStaking::indicator {
     border: 0;
     background: none;
+    margin: 0;
+    padding: 0;
+    width:40px;
+    height:25px;
 }
 
 QCheckBox#checkStaking {
     background-image: url(":/icons/ic-switch-off-png");
     background-repeat:no-repeat;
     background-position:left center;
-    padding:8 4 8 30px;
     color:#bababa;
+    margin-right:5px;
 }
 
 QCheckBox#checkStaking:checked {
     background-image: url(":/icons/ic-switch-on-png");
     color:#105aef;
 }
+
+
+#checkPrecompute::indicator {
+    border: 0;
+    background: none;
+    margin: 0;
+    padding: 0;
+    width:40px;
+    height:25px;
+}
+
+#checkPrecompute {
+    background-image: url(":/icons/ic-switch-off-png") ;
+    background-repeat:no-repeat;
+    background-position:left center;
+    color:#bababa;
+    margin-right:5px;
+
+}
+
+#checkPrecompute:checked {
+    background-image: url(":/icons/ic-switch-on-png") ;
+    color:#105aef;
+}
+
 
 QPushButton#btnSync{
     color:#707070;

--- a/src/qt/veil/forms/veilstatusbar.ui
+++ b/src/qt/veil/forms/veilstatusbar.ui
@@ -114,16 +114,61 @@
           </property>
           <item>
            <widget class="QCheckBox" name="checkStaking">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <stylestrategy>PreferAntialias</stylestrategy>
+             </font>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::NoFocus</enum>
             </property>
+            <property name="styleSheet">
+             <string notr="true">
+ #checkStaking::indicator {
+    border: 0;
+    background: none;
+	 margin: 0;
+	 padding: 0;
+	width:40px;
+	height:30px;
+ }
+
+ #checkStaking {
+ background-image: url(&quot;:/icons/ic-switch-off-png&quot;) ;
+ background-repeat:no-repeat;
+ background-position:left center;
+ color:#bababa;
+ }
+
+ #checkStaking:checked {
+ background-image: url(&quot;:/icons/ic-switch-on-png&quot;) ;
+ color:#105aef;
+ }</string>
+            </property>
             <property name="text">
              <string>Staking</string>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="checkPrecompute">
+            <property name="font">
+             <font>
+              <stylestrategy>PreferAntialias</stylestrategy>
+             </font>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::NoFocus</enum>
             </property>
@@ -132,13 +177,16 @@
  #checkPrecompute::indicator {
      border: 0;
      background: none;
+	 margin: 0;
+	 padding: 0;
+	 width:40px;
+    height:30px;
  }
 
  #checkPrecompute {
  background-image: url(&quot;:/icons/ic-switch-off-png&quot;) ;
  background-repeat:no-repeat;
  background-position:left center;
- padding:8 4 8 30px;
  color:#bababa;
  }
 
@@ -196,7 +244,7 @@
            <string/>
           </property>
           <property name="icon">
-           <iconset>
+           <iconset resource="../../veil.qrc">
             <normaloff>:/icons/ic-locked-png</normaloff>
             <selectedoff>:/icons/ic-unlocked-png</selectedoff>:/icons/ic-locked-png</iconset>
           </property>
@@ -215,5 +263,8 @@
    </item>
   </layout>
  </widget>
+ <resources>
+  <include location="../../veil.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Closes #503 

- Indicator of `checkStaking` & `checkPrecompute` have been extended to cover toggle switch.
- `checkStaking` is now styled within `QtCreator`
- Updated `main.css` to include styling for `checkStaking` & `checkPrecompute` 

Bounty Address

```
sv1qqpdsfcqvfcljtcq8txc8kc2dw4e9upj69wnnfv7j0ufcsrv7trs9lqpqfscke6jj92aj4aup387ggk7mathznr8hz3zde6ut87jdwphrns7qqqq00jn8w
```
