### PR TITLE
[RPC] Correcting help format of `rescanringctwallet`

### DIFF
--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -146,9 +146,14 @@ static UniValue rescanringctwallet(const JSONRPCRequest &request)
 
     if (request.fHelp || !request.params.empty())
         throw std::runtime_error(
-                "rescanringctwallet\n"
-                "Rescans all transactions in the ringct wallet (CT and RingCT transactions)"
-                + HelpRequiringPassphrase(wallet.get()));
+                "rescanringctwallet()\n"
+                "Rescans all transactions in the RingCT & CT Wallets."
+                + HelpRequiringPassphrase(wallet.get()) +
+                "\nExamples:\n"
+                + HelpExampleCli("rescanringctwallet", "")
+                + HelpExampleRpc("rescanringctwallet", ""));
+
+
 
     EnsureWalletIsUnlocked(wallet.get());
     auto pAnonWallet = wallet->GetAnonWallet();


### PR DESCRIPTION
Help block now matches standard format of other help blocks.

![ringct](https://user-images.githubusercontent.com/8047888/57771848-d8f82f00-770b-11e9-9eea-029cac91323d.png)


Closes #428 