### PR TITLE
[GUI ] Fixing inconsistent tab transitions 

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -216,4 +216,5 @@ void ModalOverlay::closeClicked()
 
 void ModalOverlay::showEvent(QShowEvent *event){
     resizeOp();
+
 }

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -216,5 +216,4 @@ void ModalOverlay::closeClicked()
 
 void ModalOverlay::showEvent(QShowEvent *event){
     resizeOp();
-
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -23,7 +23,9 @@
 #include <QPainter>
 #include <QSettings>
 #include <QDesktopWidget>
-
+#include <QGraphicsOpacityEffect>
+#include <QPropertyAnimation>
+#include <QPixmap>
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 3
 
@@ -412,4 +414,25 @@ void OverviewPage::hideOrphans(bool fHide)
 void OverviewPage::showEvent(QShowEvent *event){
     QSettings settings;
     hideOrphans(settings.value("bHideOrphans", true).toBool());
+
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(0.25);
+    a->setEndValue(1);
+    a->setEasingCurve(QEasingCurve::InBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+}
+
+void OverviewPage::hideEvent(QHideEvent *event){
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(1);
+    a->setEndValue(0);
+    a->setEasingCurve(QEasingCurve::OutBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -61,6 +61,7 @@ private Q_SLOTS:
     void sortTxes(const QString& selectedStr);
     void onFaqClicked();
     virtual void showEvent(QShowEvent *event) override;
+    virtual void hideEvent(QHideEvent *event) override;
 
     void hideOrphans(bool fHide);
 };

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -29,6 +29,9 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextDocument>
+#include <QGraphicsOpacityEffect>
+#include <QPropertyAnimation>
+#include <QPixmap>
 #include <veil/dandelioninventory.h>
 
 #include <qt/veil/qtutils.h>
@@ -958,6 +961,29 @@ void SendCoinsDialog::toggleDandelion(bool fchecked)
                 tr("Dandelion protocol is in beta. Any communications of this transaction may be inconsistent."));
     }
     fDandelion = fchecked;
+}
+
+void SendCoinsDialog::showEvent(QShowEvent *event){
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(0.25);
+    a->setEndValue(1);
+    a->setEasingCurve(QEasingCurve::InBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+}
+
+void SendCoinsDialog::hideEvent(QHideEvent *event){
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(1);
+    a->setEndValue(0);
+    a->setEasingCurve(QEasingCurve::OutBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
 SendConfirmationDialog::SendConfirmationDialog(const QString &title, const QString &text, int _secDelay,

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -104,6 +104,8 @@ private Q_SLOTS:
     void updateMinFeeLabel();
     void updateSmartFeeLabel();
     void toggleDandelion(bool);
+    virtual void showEvent(QShowEvent *event) override;
+    virtual void hideEvent(QHideEvent *event) override;
 
 Q_SIGNALS:
     // Fired when a message should be reported to the user

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -250,7 +250,6 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
     }
     menu->move(pos);
     menu->show();
-
 }
 
 void AddressesWidget::initAddressesView(){
@@ -268,7 +267,6 @@ void AddressesWidget::showEvent(QShowEvent *event){
     a->setEasingCurve(QEasingCurve::InBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
     reloadTab(isOnMyAddresses);
-
 }
 
 void AddressesWidget::hideEvent(QHideEvent *event){
@@ -281,7 +279,6 @@ void AddressesWidget::hideEvent(QHideEvent *event){
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
-
 
     if(menu != nullptr){
         menu->hide();
@@ -317,7 +314,6 @@ void AddressesWidget::onButtonChanged() {
     }else{
         ui->btnAdd->setText("New Contact");
         showHideMineAddressBtn(false);
-
     }
     if(this->menu){
         this->menu->hide();
@@ -425,7 +421,6 @@ void AddressesWidget::showList(bool show){
         ui->listAddresses->setVisible(false);
         ui->listContacts->setVisible(false);
     }
-
 }
 
 AddressesWidget::~AddressesWidget() {

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -256,7 +256,6 @@ void AddressesWidget::initAddressesView(){
     // Complete me..
 }
 
-
 void AddressesWidget::showEvent(QShowEvent *event){
     QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
     this->setGraphicsEffect(eff);

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -257,6 +257,7 @@ void AddressesWidget::initAddressesView(){
     // Complete me..
 }
 
+
 void AddressesWidget::showEvent(QShowEvent *event){
     QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
     this->setGraphicsEffect(eff);
@@ -267,6 +268,7 @@ void AddressesWidget::showEvent(QShowEvent *event){
     a->setEasingCurve(QEasingCurve::InBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
     reloadTab(isOnMyAddresses);
+
 }
 
 void AddressesWidget::hideEvent(QHideEvent *event){
@@ -279,6 +281,7 @@ void AddressesWidget::hideEvent(QHideEvent *event){
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
+
 
     if(menu != nullptr){
         menu->hide();


### PR DESCRIPTION
Adding `showEvent` & `hideEvent` slots `sendcoindialog` & `overviewpage`.

Page/tab transition animations are now consistent.

closes #174 