### PR TITLE
Add ReturnPressed event to labels

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -100,6 +100,9 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent) :
     ui->btnSave->setEnabled(false);
     connect(ui->btnEsc,SIGNAL(clicked()),this, SLOT(close()));
     connect(ui->btnSave,SIGNAL(clicked()),this, SLOT(accept()));
+    connect(ui->passEdit1, SIGNAL(returnPressed()), this, SLOT(accept()));
+    connect(ui->passEdit2, SIGNAL(returnPressed()), this, SLOT(accept()));
+    connect(ui->passEdit3, SIGNAL(returnPressed()), this, SLOT(accept()));
 }
 
 AskPassphraseDialog::~AskPassphraseDialog()

--- a/src/qt/veil/settings/settingsminting.cpp
+++ b/src/qt/veil/settings/settingsminting.cpp
@@ -67,6 +67,7 @@ SettingsMinting::SettingsMinting(QWidget *parent, WalletView *mainWindow, Wallet
 
     connect(ui->btnEsc,SIGNAL(clicked()),this, SLOT(close()));
     connect(ui->btnSendMint,SIGNAL(clicked()),this, SLOT(btnMint()));
+    connect(ui->editAmount, SIGNAL(returnPressed()), this, SLOT(btnMint()));
     connect(ui->radioButton10, SIGNAL(toggled(bool)), this, SLOT(onCheck10Clicked(bool)));
     connect(ui->radioButton100, SIGNAL(toggled(bool)), this, SLOT(onCheck100Clicked(bool)));
     connect(ui->radioButton1000, SIGNAL(toggled(bool)), this, SLOT(onCheck1000Clicked(bool)));


### PR DESCRIPTION
Make input boxes work on Return/Enter event.

This changes unlock wallet, encrypt, change password and mint settings screens.

Fixes #502 