### PR TITLE
[Wallet][RPC]Fix missing RingCt Blinds. Add RingCt inputs print to getrawtransaction.

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 class CBlock;
+class COutPoint;
 class CScript;
 class CTransaction;
 struct CMutableTransaction;
@@ -35,6 +36,6 @@ std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vector<std::vector<COutPoint>>& vTxRingCtInputs, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
 
 #endif // BITCOIN_CORE_IO_H

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -380,7 +380,7 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
 
     case RetFormat::JSON: {
         UniValue objTx(UniValue::VOBJ);
-        TxToUniv(*tx, hashBlock, objTx);
+        TxToUniv(*tx, hashBlock, {{}}, objTx);
         std::string strJSON = objTx.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -32,6 +32,7 @@
 #include <hash.h>
 #include <validationinterface.h>
 #include <warnings.h>
+#include <veil/ringct/anon.h>
 
 #include <assert.h>
 #include <stdint.h>
@@ -137,7 +138,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         if(txDetails)
         {
             UniValue objTx(UniValue::VOBJ);
-            TxToUniv(*tx, uint256(), objTx, true, RPCSerializationFlags());
+            auto vInputs = GetTxRingCtInputs(tx);
+            TxToUniv(*tx, uint256(), vInputs, objTx, true, RPCSerializationFlags());
             txs.push_back(objTx);
         }
         else

--- a/src/veil-tx.cpp
+++ b/src/veil-tx.cpp
@@ -719,7 +719,7 @@ static void MutateTx(CMutableTransaction& tx, const std::string& command,
 static void OutputTxJSON(const CTransaction& tx)
 {
     UniValue entry(UniValue::VOBJ);
-    TxToUniv(tx, uint256(), entry);
+    TxToUniv(tx, uint256(), {{}}, entry);
 
     std::string jsonOutput = entry.write(4);
     fprintf(stdout, "%s\n", jsonOutput.c_str());

--- a/src/veil/ringct/anon.cpp
+++ b/src/veil/ringct/anon.cpp
@@ -300,6 +300,49 @@ bool RollBackRCTIndex(int64_t nLastValidRCTOutput, int64_t nExpectErase, std::se
     return true;
 }
 
+std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin)
+{
+    std::vector<COutPoint> vInputs;
+    uint32_t nInputs, nRingSize;
+    txin.GetAnonInfo(nInputs, nRingSize);
+
+    size_t nCols = nRingSize;
+    size_t nRows = nInputs + 1;
+
+    if (txin.scriptData.stack.size() != 1)
+        return vInputs;
+
+    if (txin.scriptWitness.stack.size() != 2)
+        return vInputs;
+
+    const std::vector<uint8_t> vKeyImages = txin.scriptData.stack[0];
+    const std::vector<uint8_t> vMI = txin.scriptWitness.stack[0];
+    const std::vector<uint8_t> vDL = txin.scriptWitness.stack[1];
+
+    if (vKeyImages.size() != nInputs * 33)
+        return vInputs;
+    std::vector<uint8_t> vM(nCols * nRows * 33);
+    std::set<CKey> setKeyCandidates;
+
+    size_t ofs = 0, nB = 0;
+    for (size_t k = 0; k < nInputs; ++k) {
+        for (size_t i = 0; i < nCols; ++i) {
+            int64_t nIndex;
+
+            if (0 != GetVarInt(vMI, ofs, (uint64_t&) nIndex, nB))
+                continue;
+            ofs += nB;
+
+            CAnonOutput ao;
+            if (!pblocktree->ReadRCTOutput(nIndex, ao)) {
+                continue;
+            }
+            vInputs.emplace_back(ao.outpoint);
+        }
+    }
+    return vInputs;
+}
+
 //bool RewindToCheckpoint(int nCheckPointHeight, int &nBlocks, std::string &sError)
 //{
 //    LogPrintf("%s: At height %d\n", __func__, nCheckPointHeight);

--- a/src/veil/ringct/anon.cpp
+++ b/src/veil/ringct/anon.cpp
@@ -300,6 +300,18 @@ bool RollBackRCTIndex(int64_t nLastValidRCTOutput, int64_t nExpectErase, std::se
     return true;
 }
 
+std::vector<std::vector<COutPoint>> GetTxRingCtInputs(const CTransactionRef ptx)
+{
+    std::vector<std::vector<COutPoint> > vTxRingCtInputs;
+    for (const CTxIn& txin : ptx->vin) {
+        if (txin.IsAnonInput()) {
+            std::vector<COutPoint> vInputs = GetRingCtInputs(txin);
+            vTxRingCtInputs.emplace_back(vInputs);
+        }
+    }
+    return vTxRingCtInputs;
+}
+
 std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin)
 {
     std::vector<COutPoint> vInputs;

--- a/src/veil/ringct/anon.h
+++ b/src/veil/ringct/anon.h
@@ -30,6 +30,7 @@ bool RollBackRCTIndex(int64_t nLastValidRCTOutput, int64_t nExpectErase, std::se
 bool RewindToCheckpoint(int nCheckPointHeight, int &nBlocks, std::string &sError);
 
 std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin);
+std::vector<std::vector<COutPoint>> GetTxRingCtInputs(const CTransactionRef ptx);
 
 
 #endif //VEIL_ANON_H

--- a/src/veil/ringct/anon.h
+++ b/src/veil/ringct/anon.h
@@ -29,5 +29,7 @@ bool RollBackRCTIndex(int64_t nLastValidRCTOutput, int64_t nExpectErase, std::se
 
 bool RewindToCheckpoint(int nCheckPointHeight, int &nBlocks, std::string &sError);
 
+std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin);
+
 
 #endif //VEIL_ANON_H

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -302,7 +302,7 @@ public:
     int InsertTempTxn(const uint256 &txid, const CTransactionRecord *rtx) const;
 
     bool GetCTBlindsFromOutput(const CTxOutBase *pout, uint256& blind) const;
-    bool GetCTBlinds(CScript scriptPubKey, std::vector<uint8_t>& vData, secp256k1_pedersen_commitment* commitment, std::vector<uint8_t>& vRangeproof, uint256 &blind, int64_t& nValue) const;
+    bool GetCTBlinds(CKeyID idKey, std::vector<uint8_t>& vData, secp256k1_pedersen_commitment* commitment, std::vector<uint8_t>& vRangeproof, uint256 &blind, int64_t& nValue) const;
     bool OwnBlindOut(AnonWalletDB *pwdb, const uint256 &txhash, const CTxOutCT *pout, COutputRecord &rout, CStoredTransaction &stx, bool &fUpdated);
     int OwnAnonOut(AnonWalletDB *pwdb, const uint256 &txhash, const CTxOutRingCT *pout, COutputRecord &rout, CStoredTransaction &stx, bool &fUpdated);
 

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -238,7 +238,7 @@ public:
         std::string &sError);
 
 
-    bool IsMyAnonInput(const CTxIn& txin);
+    bool IsMyAnonInput(const CTxIn& txin, COutPoint& myOutpoint);
     int AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend,
         bool sign, size_t nRingSize, size_t nInputsPerSig, CAmount &nFeeRet, const CCoinControl *coinControl,
         std::string &sError, bool fZerocoinInputs, CAmount nInputValue);

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -1878,7 +1878,7 @@ static UniValue verifyrawtransaction(const JSONRPCRequest &request)
 
     if (!request.params[2].isNull() && request.params[2].get_bool()) {
         UniValue txn(UniValue::VOBJ);
-        TxToUniv(CTransaction(std::move(mtx)), uint256(), txn, false);
+        TxToUniv(CTransaction(std::move(mtx)), uint256(), {{}}, txn, false);
         result.pushKV("txn", txn);
     }
 


### PR DESCRIPTION
In some situations spending RingCt would fail because of missing blinds.

`gettransaction` and `getrawtransaction` will now print the list of RingCt inputs used in a RingCt spend.