### PR TITLE
[GUI] Prefences tab - revert background to allow native OS styling

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -92,7 +92,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     }
 	   
 	/*  Set the tooltip style here to override the OS style.*/
-    QString tooltipStyle = QString("QToolTip {color: #ffffff; background-color: #6f9bf5; font-size:11pt; border: none; border-radius:20px; padding:6px; margin:0px; min-height: 35px; qproperty-alignment: 'AlignVCenter | AlignCenter';}");
+    QString tooltipStyle = QString("QCheckBox {background:none;} QToolTip {color: #ffffff; background-color: #6f9bf5; font-size:11pt; border: none; border-radius:20px; padding:6px; margin:0px; min-height: 35px; qproperty-alignment: 'AlignVCenter | AlignCenter';}");
     ui->bitcoinAtStartup->setStyleSheet(tooltipStyle);
     ui->prune->setStyleSheet(tooltipStyle);
     ui->openBitcoinConfButton->setStyleSheet(tooltipStyle);
@@ -115,6 +115,8 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->minimizeOnClose->setStyleSheet(tooltipStyle);
     ui->thirdPartyTxUrlsLabel->setStyleSheet(tooltipStyle);
     ui->thirdPartyTxUrls->setStyleSheet(tooltipStyle);
+    ui->hideOrphans->setStyleSheet(tooltipStyle);
+    ui->showComputeTime->setStyleSheet(tooltipStyle);
 
     /* Display elements init */
     QDir translations(":translations");


### PR DESCRIPTION
The frame that contains the checkboxes has it background color set to transparent. The checkboxes were picking up this cascading style and making the checkbox transparent. background: none will revert the transparent background.

fixed #546 

sv1qqpj0zn0pyd2gp7w5vs93ja2rq0s6yrwvmtcvvd6lg5awdpuggsh32cpq2seytp7tg6mlqvzn2zjl9ug63gsga0q5kgzh5sjmg0uz32r2krh6qqq4tpdvx