### PR TITLE
[Qt][Wallet]Make send dialog more asynchronous.

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=eed620cb268b199bd83b3fc6a471c51d51e1dc2dbb5374fc97a0cc75f
 $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
-$(package)_qt_libs=corelib network widgets gui plugins testlib
+$(package)_qt_libs=corelib network widgets gui plugins testlib concurrent
 $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch xkb-default.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -70,7 +70,7 @@ $(package)_config_opts += -silent
 $(package)_config_opts += -v
 $(package)_config_opts += -no-feature-printer
 $(package)_config_opts += -no-feature-printdialog
-$(package)_config_opts += -no-feature-concurrent
+$(package)_config_opts += -feature-concurrent
 $(package)_config_opts += -no-feature-xml
 
 ifneq ($(build_os),darwin)

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -64,6 +64,13 @@ border:none;</string>
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="labelCreationStatus">
+          <property name="text">
+           <string>Tx Status</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -363,8 +370,8 @@ margin:0px;</string>
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>842</width>
-           <height>526</height>
+           <width>832</width>
+           <height>500</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -543,5 +543,7 @@ void OverviewPage::hideOrphans(bool fHide)
 
 void OverviewPage::showEvent(QShowEvent *event){
     QSettings settings;
-    hideOrphans(settings.value("bHideOrphans", true).toBool());
+    bool fHide = settings.value("bHideOrphans", true).toBool();
+    if (fHide != filter->orphansHidden())
+        hideOrphans(fHide);
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -13,6 +13,7 @@
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/sendcoinsentry.h>
+#include <QtConcurrent/QtConcurrent>
 
 #include <qt/veil/sendconfirmation.h>
 
@@ -64,6 +65,10 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     platformStyle(_platformStyle)
 {
     ui->setupUi(this);
+    prepareData = nullptr;
+    m_statusAnimationState = 0;
+    m_timerStatus = new QTimer(this);
+    connect(m_timerStatus, SIGNAL(timeout()), this, SLOT(StatusTimerTimeout()));
 
     setStyleSheet(GUIUtil::loadStyleSheet());
 
@@ -85,6 +90,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
 
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+    connect(this, SIGNAL(TransactionPrepared()), this, SLOT(PrepareTransactionFinished()));
 
     // Coin Control
     connect(ui->pushButtonCoinControl, SIGNAL(clicked()), this, SLOT(coinControlButtonClicked()));
@@ -123,6 +129,8 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
 
     //Hide all coincontrol labels
     HideCoinControlLabels();
+
+    SetTransactionLabelState(TxPrepState::BEGIN);
 }
 
 void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
@@ -238,75 +246,73 @@ void SendCoinsDialog::ShowCoinCointrolLabels()
     ui->labelCoinControlChangeText->show();
 }
 
-void SendCoinsDialog::on_sendButton_clicked()
+void SendCoinsDialog::StatusTimerTimeout()
 {
-    if(!model || !model->getOptionsModel())
-        return;
-
-    QList<SendCoinsRecipient> recipients;
-    bool valid = true;
-
-    std::string error;
-    for(int i = 0; i < ui->entries->count(); ++i)
-    {
-        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
-        if(entry) {
-            if(entry->validate(model->node(), error)) {
-                recipients.append(entry->getValue());
-            }
-            else {
-                valid = false;
-            }
-        }
+    if (m_statusAnimationState < 3) {
+        //Add another dot
+        auto text = ui->labelCreationStatus->text();
+        text.push_back(".");
+        ui->labelCreationStatus->setText(text);
+        m_statusAnimationState++;
+    } else {
+        //Remove all dots
+        ui->labelCreationStatus->setText(tr("Generating Transaction"));
+        m_statusAnimationState = 0;
     }
+}
 
-    if(!valid){
-        openToastDialog(QString::fromStdString("Invalid data\n" + error), this);
-        return;
+void SendCoinsDialog::SetTransactionLabelState(TxPrepState state)
+{
+    QPalette palette = ui->labelCreationStatus->palette();
+    m_timerStatus->stop();
+    switch (state) {
+        case TxPrepState::BEGIN:
+        case TxPrepState::DONE:
+            ui->labelCreationStatus->setHidden(true);
+            ui->sendButton->setEnabled(true);
+            break;
+        case TxPrepState::GENERATING:
+            ui->labelCreationStatus->setHidden(false);
+            ui->labelCreationStatus->setText(tr("Generating Transaction"));
+            palette.setColor(ui->labelCreationStatus->foregroundRole(), QColor(204,0,0)); //red
+            ui->labelCreationStatus->setPalette(palette);
+
+            //start timer that adds "..." to the label to give some animation
+            m_timerStatus->start(500);
+
+            //While a tx is generating, disable send button
+            ui->sendButton->setEnabled(false);
+            break;
+        case TxPrepState::WAITING_USER:
+            ui->labelCreationStatus->setHidden(false);
+            ui->labelCreationStatus->setText(tr("Waiting For User"));
+            palette.setColor(ui->labelCreationStatus->foregroundRole(), QColor(0,102,0)); //green
+            ui->labelCreationStatus->setPalette(palette);
+            break;
     }
+}
 
-    if(recipients.isEmpty()){
-        openToastDialog("No recipients", this);
-        return;
-    }
+void SendCoinsDialog::AsyncPrepareTransaction()
+{
+    prepareData->prepareStatus = model->prepareTransaction(*prepareData->tx, prepareData->ctrl, prepareData->spendType, prepareData->receipt, prepareData->vCommitData);
+    Q_EMIT TransactionPrepared();
+}
 
-    fNewRecipientAllowed = false;
-    WalletModel::UnlockContext ctx(model->requestUnlock());
-    if(!ctx.isValid())
-    {
-        // Unlock wallet was cancelled
-        fNewRecipientAllowed = true;
-        return;
-    }
+void SendCoinsDialog::PrepareTransactionFinished()
+{
+    SetTransactionLabelState(TxPrepState::WAITING_USER);
 
-    int64_t nComputeTimeStart = GetTimeMillis();
-
-    // prepare transaction for getting txFee earlier
-    WalletModelTransaction currentTransaction(recipients);
-    WalletModel::SendCoinsReturn prepareStatus;
-
-    // Always use a CCoinControl instance, use the CoinControlDialog instance if CoinControl has been enabled
-    CCoinControl ctrl;
-    if (model->getOptionsModel()->getCoinControlFeatures())
-        ctrl = *CoinControlDialog::coinControl();
-
-    updateCoinControlState(ctrl);
-
-    WalletModelSpendType spendType;
-    CZerocoinSpendReceipt receipt;
-    std::vector<CommitData> vCommitData;
-
-    prepareStatus = model->prepareTransaction(currentTransaction, ctrl, spendType, receipt, vCommitData);
     // process prepareStatus and on error generate message shown to user
-    processSendCoinsReturn(prepareStatus,
-        BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), currentTransaction.getTransactionFee()));
+    processSendCoinsReturn(prepareData->prepareStatus,
+                           BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), prepareData->tx->getTransactionFee()));
 
-    if(prepareStatus.status != WalletModel::OK) {
+    if (prepareData->prepareStatus.status != WalletModel::OK) {
         fNewRecipientAllowed = true;
+        SetTransactionLabelState(TxPrepState::DONE);
         return;
     }
 
-    CAmount txFee = currentTransaction.getTransactionFee();
+    CAmount txFee = prepareData->tx->getTransactionFee();
 
     int64_t nComputeTimeFinish = GetTimeMillis();
 
@@ -314,8 +320,8 @@ void SendCoinsDialog::on_sendButton_clicked()
     QStringList formatted;
     QStringList formattedAddresses;
 
-    bool isOne = currentTransaction.getRecipients().size() == 1;
-    for (const SendCoinsRecipient &rcp : currentTransaction.getRecipients())
+    bool isOne = prepareData->tx->getRecipients().size() == 1;
+    for (const SendCoinsRecipient &rcp : prepareData->tx->getRecipients())
     {
         // generate bold amount string with wallet name in case of multiwallet
         QString amount = "<b align=right>" + BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
@@ -373,7 +379,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         questionString.append("</b>");
 
         // append transaction size
-        questionString.append(" (" + QString::number((double)currentTransaction.getTransactionSize() / 1000) + " kB): ");
+        questionString.append(" (" + QString::number((double)prepareData->tx->getTransactionSize() / 1000) + " kB): ");
 
         // append transaction fee value
         questionString.append("<span style='color:#aa0000; font-weight:bold;'>");
@@ -385,14 +391,14 @@ void SendCoinsDialog::on_sendButton_clicked()
         //if (ui->optInRBF->isChecked()) {
         //    questionString.append(tr("You can increase the fee later (signals Replace-By-Fee, BIP-125)."));
         //} else {
-            questionString.append(tr("Not signalling Replace-By-Fee, BIP-125."));
+        questionString.append(tr("Not signalling Replace-By-Fee, BIP-125."));
         //}
         questionString.append("</span>");
     }
 
     // add total amount in all subdivision units
     questionString.append("<hr />");
-    CAmount totalAmount = currentTransaction.getTotalTransactionAmount() + txFee;
+    CAmount totalAmount = prepareData->tx->getTotalTransactionAmount() + txFee;
     QStringList alternativeUnits;
     for (BitcoinUnits::Unit u : BitcoinUnits::availableUnits())
     {
@@ -400,10 +406,9 @@ void SendCoinsDialog::on_sendButton_clicked()
             alternativeUnits.append(BitcoinUnits::formatHtmlWithUnit(u, totalAmount));
     }
     questionString.append(QString("<b>%1</b>: <b>%2</b>").arg(tr("Total Amount"))
-        .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount)));
+                                  .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount)));
     questionString.append(QString("<br /><span style='font-size:10pt; font-weight:normal;'>(=%1)</span>")
-        .arg(alternativeUnits.join(" " + tr("or") + " ")));
-
+                                  .arg(alternativeUnits.join(" " + tr("or") + " ")));
 
     // TODO: Connect confirm dialog..
     int unit = model->getOptionsModel()->getDisplayUnit();
@@ -419,15 +424,16 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     if(!res){
         fNewRecipientAllowed = true;
+        SetTransactionLabelState(TxPrepState::DONE);
         return;
     }
 
     // now send the prepared transaction
     WalletModel::SendCoinsReturn sendStatus;
-    if (spendType == ZCSPEND)
-        sendStatus = model->sendZerocoins(receipt, vCommitData, nComputeTimeFinish - nComputeTimeStart);
+    if (prepareData->spendType == ZCSPEND)
+        sendStatus = model->sendZerocoins(prepareData->receipt, prepareData->vCommitData, nComputeTimeFinish - prepareData->nComputeTimeStart);
     if (sendStatus.status == WalletModel::OK)
-        sendStatus = model->sendCoins(currentTransaction, spendType == ZCSPEND);
+        sendStatus = model->sendCoins(*prepareData->tx, prepareData->spendType == ZCSPEND);
     // process sendStatus and on error generate message shown to user
     processSendCoinsReturn(sendStatus);
 
@@ -436,7 +442,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         accept();
         CoinControlDialog::coinControl()->UnSelectAll();
         coinControlUpdateLabels();
-        uint256 hashCurrentTx = currentTransaction.getWtx()->get().GetHash();
+        uint256 hashCurrentTx = prepareData->tx->getWtx()->get().GetHash();
         if (fDandelion) {
             LOCK(veil::dandelion.cs);
             veil::dandelion.Add(hashCurrentTx, GetAdjustedTime() + veil::dandelion.nDefaultStemTime, veil::dandelion.nDefaultNodeID);
@@ -444,6 +450,68 @@ void SendCoinsDialog::on_sendButton_clicked()
         Q_EMIT coinsSent(hashCurrentTx);
     }
     fNewRecipientAllowed = true;
+    SetTransactionLabelState(TxPrepState::DONE);
+}
+
+void SendCoinsDialog::on_sendButton_clicked()
+{
+    if(!model || !model->getOptionsModel())
+        return;
+
+    QList<SendCoinsRecipient> recipients;
+    bool valid = true;
+
+    std::string error;
+    for(int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
+        if(entry) {
+            if(entry->validate(model->node(), error)) {
+                recipients.append(entry->getValue());
+            }
+            else {
+                valid = false;
+            }
+        }
+    }
+
+    if(!valid){
+        openToastDialog(QString::fromStdString("Invalid data\n" + error), this);
+        return;
+    }
+
+    if(recipients.isEmpty()){
+        openToastDialog("No recipients", this);
+        return;
+    }
+
+    fNewRecipientAllowed = false;
+    WalletModel::UnlockContext ctx(model->requestUnlock());
+    if(!ctx.isValid())
+    {
+        // Unlock wallet was cancelled
+        fNewRecipientAllowed = true;
+        return;
+    }
+
+    prepareData = new PrepareTxData();
+    prepareData->nComputeTimeStart = GetTimeMillis();
+    prepareData->tx = new WalletModelTransaction(recipients);
+
+    // Always use a CCoinControl instance, use the CoinControlDialog instance if CoinControl has been enabled
+    CCoinControl ctrl;
+    if (model->getOptionsModel()->getCoinControlFeatures())
+        ctrl = *CoinControlDialog::coinControl();
+
+    prepareData->ctrl = ctrl;
+    updateCoinControlState(ctrl);
+    QtConcurrent::run(this, &SendCoinsDialog::AsyncPrepareTransaction);
+
+    //Show a message box that says transaction is being generated
+    SetTransactionLabelState(TxPrepState::GENERATING);
+    QMessageBox::information(this, tr("Transaction Is Being Generated"),
+            tr("The transaction is now being generated. A confirmation window will pop up when the transaction is ready to be sent."),
+            QMessageBox::Ok);
 }
 
 void SendCoinsDialog::clear()

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -96,7 +96,7 @@ private:
     bool fFeeMinimized;
     bool fDandelion = false;
     const PlatformStyle *platformStyle;
-    PrepareTxData* prepareData;
+    std::unique_ptr<PrepareTxData> m_prepareData;
     QTimer* m_timerStatus;
     int m_statusAnimationState;
 
@@ -109,7 +109,7 @@ private:
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
 
-    void AsyncPrepareTransaction();
+    void PrepareTransaction();
     void SetTransactionLabelState(TxPrepState state);
 
 private Q_SLOTS:

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -12,6 +12,9 @@
 #include <QString>
 #include <QTimer>
 #include <qt/walletview.h>
+#include <wallet/wallet.h>
+#include <wallet/coincontrol.h>
+#include <qt/walletmodel.h>
 
 class ClientModel;
 class PlatformStyle;
@@ -26,6 +29,19 @@ namespace Ui {
 QT_BEGIN_NAMESPACE
 class QUrl;
 QT_END_NAMESPACE
+
+struct PrepareTxData
+{
+    WalletModelTransaction* tx;
+    CCoinControl ctrl;
+    CZerocoinSpendReceipt receipt;
+    WalletModelSpendType spendType;
+    std::vector<CommitData> vCommitData;
+    WalletModel::SendCoinsReturn prepareStatus;
+    int64_t nComputeTimeStart;
+
+    PrepareTxData(){};
+};
 
 /** Dialog for sending bitcoins */
 class SendCoinsDialog : public QDialog
@@ -50,6 +66,14 @@ public:
     void HideCoinControlLabels();
     void ShowCoinCointrolLabels();
 
+    enum TxPrepState
+    {
+        BEGIN,
+        GENERATING,
+        WAITING_USER,
+        DONE
+    };
+
 public Q_SLOTS:
     void clear();
     void reject();
@@ -57,9 +81,11 @@ public Q_SLOTS:
     SendCoinsEntry *addEntry();
     void updateTabsAndLabels();
     void setBalance(const interfaces::WalletBalances& balances);
+    void PrepareTransactionFinished();
 
 Q_SIGNALS:
     void coinsSent(const uint256& txid);
+    void TransactionPrepared();
 
 private:
     Ui::SendCoinsDialog *ui;
@@ -70,6 +96,9 @@ private:
     bool fFeeMinimized;
     bool fDandelion = false;
     const PlatformStyle *platformStyle;
+    PrepareTxData* prepareData;
+    QTimer* m_timerStatus;
+    int m_statusAnimationState;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting
     // of a message and message flags for use in Q_EMIT message().
@@ -79,6 +108,9 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
+
+    void AsyncPrepareTransaction();
+    void SetTransactionLabelState(TxPrepState state);
 
 private Q_SLOTS:
     void on_sendButton_clicked();
@@ -104,6 +136,7 @@ private Q_SLOTS:
     void updateMinFeeLabel();
     void updateSmartFeeLabel();
     void toggleDandelion(bool);
+    void StatusTimerTimeout();
 
 Q_SIGNALS:
     // Fired when a message should be reported to the user

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -52,6 +52,8 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
 
     void setHideOrphans(bool hide);
+    bool orphansHidden() const { return fHideOrphans; }
+
 
 
 protected:

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -403,7 +403,7 @@ void AddressesWidget::setModel(AddressTableModel *_model)
 void AddressesWidget::onForeground(){
     if(walletModel){
         interfaces::Wallet& wallet = walletModel->wallet();
-        const size_t listsize = wallet.getAddresses().size();
+        auto listsize = model->rowCount(QModelIndex());
         ui->empty->setVisible(listsize == 0);
         showList(listsize > 0);
     }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -233,7 +233,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             vMintsSelected.emplace_back(mint);
         }
 
-        newTx = m_wallet->prepareZerocoinSpend(total, /*nSecurityLevel*/100, receipt, vMintsSelected,
+        //Use low security level while zerocoin is in limp mode
+        newTx = m_wallet->prepareZerocoinSpend(total, /*nSecurityLevel*/3, receipt, vMintsSelected,
                 /*fMintChange*/true, /*fMinimizeChange*/false, vCommitData, libzerocoin::CoinDenomination::ZQ_ERROR,
                                                &vecSend[0].address);
         nBalance = m_wallet->getAvailableZerocoinBalance(coinControl);
@@ -245,7 +246,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             //todo, this does not support multi recipient spend yet
 
             std::vector<CZerocoinMint> vMintsSelected;
-            newTx = m_wallet->prepareZerocoinSpend(total, /*nSecurityLevel*/100, receipt, vMintsSelected,
+            //Use low security level while zerocoin is in limp mode
+            newTx = m_wallet->prepareZerocoinSpend(total, /*nSecurityLevel*/3, receipt, vMintsSelected,
                     fMintChange, /*fMinimizeChange*/false, vCommitData, libzerocoin::CoinDenomination::ZQ_ERROR,
                     &vecSend[0].address);
             nBalance = balances.zerocoin_balance;

--- a/src/veil/zerocoin/accumulators.cpp
+++ b/src/veil/zerocoin/accumulators.cpp
@@ -390,7 +390,10 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
     }
 
     if (nSecurityLevel != 100) {
-        nHeightStop = std::min(coinwitness->nHeightCheckpoint + nSecurityLevel*100, nHeightStop);
+        nHeightStop = std::min(coinwitness->nHeightCheckpoint + nSecurityLevel*10, nHeightStop);
+        //Height stop needs to be a multiple of 10
+        if (nHeightStop % 10)
+            nHeightStop -= nHeightStop % 10;
     }
 
     // If we are already at the tip, no reason to Accumulate Range

--- a/src/veil/zerocoin/accumulators.cpp
+++ b/src/veil/zerocoin/accumulators.cpp
@@ -267,21 +267,6 @@ bool ValidateAccumulatorCheckpoint(const CBlock& block, CBlockIndex* pindex, Acc
     return true;
 }
 
-void RandomizeSecurityLevel(int& nSecurityLevel)
-{
-    //security level: this is an important prevention of tracing the coins via timing. Security level represents how many checkpoints
-    //of accumulated coins are added *beyond* the checkpoint that the mint being spent was added too. If each spend added the exact same
-    //amounts of checkpoints after the mint was accumulated, then you could know the range of blocks that the mint originated from.
-    if (nSecurityLevel < 100) {
-        //add some randomness to the user's selection so that it is not always the same
-        nSecurityLevel += CBigNum::randBignum(10).getint();
-
-        //security level 100 represents adding all available coins that have been accumulated - user did not select this
-        if (nSecurityLevel >= 100)
-            nSecurityLevel = 99;
-    }
-}
-
 //Compute how many coins were added to an accumulator up to the end height
 int ComputeAccumulatedCoins(int nHeightEnd, libzerocoin::CoinDenomination denom)
 {
@@ -346,9 +331,9 @@ void AccumulateRange(CoinWitnessData* coinWitness, int nHeightEnd)
 {
     int nHeightStart = std::max(coinWitness->nHeightAccStart, coinWitness->nHeightPrecomputed + 1);
     CBlockIndex* pindex = chainActive[nHeightStart];
-//    LogPrintf("%s:%d Accumulate %d until height %d\n", __func__, __LINE__, nHeightStart, nHeightEnd);
     libzerocoin::PublicCoin pubCoinSelected = *coinWitness->coin;
     while (pindex && pindex->nHeight <= nHeightEnd) {
+        LOCK(cs_main);
         coinWitness->nMintsAdded += AddBlockMintsToAccumulator(pubCoinSelected, coinWitness->nHeightMintAdded, pindex, coinWitness->pAccumulator.get(), true);
         coinWitness->nHeightPrecomputed = pindex->nHeight;
 
@@ -366,7 +351,6 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
 
         //If there is a Acc End height filled in, then this has already been partially accumulated.
         if (!coinwitness->nHeightPrecomputed) {
-//            LogPrintf("Starting precompute for mint %s accumulated height=%d\n", coinwitness->coin->getValue().GetHex().substr(0, 6), coinwitness->nHeightMintAdded);
             coinwitness->pAccumulator = std::unique_ptr<Accumulator>(new Accumulator(Params().Zerocoin_Params(), coinwitness->denom));
             coinwitness->pWitness = std::unique_ptr<AccumulatorWitness>(new AccumulatorWitness(Params().Zerocoin_Params(), *coinwitness->pAccumulator, coin));
         }
@@ -389,7 +373,6 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
         //Get the accumulator that is right before the cluster of blocks containing our mint was added to the accumulator
         bnAccValue = 0;
         if (!coinwitness->nHeightPrecomputed && GetAccumulatorValue(coinwitness->nHeightCheckpoint, coin.getDenomination(), bnAccValue)) {
-//            LogPrintf("%s: using new accumulator from checkpoint block %d\n", __func__, coinwitness->nHeightCheckpoint);
             libzerocoin::Accumulator witnessAccumulator(Params().Zerocoin_Params(), coinwitness->denom, bnAccValue);
             coinwitness->pAccumulator->setValue(witnessAccumulator.getValue());
         }
@@ -403,8 +386,11 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
         if (pindexCheckpoint) {
             nHeightStop = pindexCheckpoint->nHeight - 10;
             nHeightStop -= nHeightStop % 10;
-//            LogPrintf("%s: using checkpoint height %d\n", __func__, pindexCheckpoint->nHeight);
         }
+    }
+
+    if (nSecurityLevel != 100) {
+        nHeightStop = std::min(coinwitness->nHeightCheckpoint + nSecurityLevel*100, nHeightStop);
     }
 
     // If we are already at the tip, no reason to Accumulate Range
@@ -426,8 +412,8 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinwitness, AccumulatorMap& ma
     }
 
     // calculate how many mints of this denomination existed in the accumulator we initialized
+    LOCK(cs_main);
     coinwitness->nMintsAdded += ComputeAccumulatedCoins(coinwitness->nHeightAccStart, coin.getDenomination());
-//    LogPrintf("%s : %d mints added to witness\n", __func__, coinwitness->nMintsAdded);
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6381,7 +6381,6 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
     CAmount nChangeDust;
     wtxNew.BindWallet(this);
     {
-        LOCK2(cs_main, cs_wallet);
         {
             txNew.vin.clear();
             txNew.vpout.clear();
@@ -6465,6 +6464,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
                 }
 
                 if (nChangeRemint > 0) {
+                    LOCK(cs_wallet);
                     //mint change as zerocoins and RingCT
                     CAmount nFeeRet = 0;
                     std::string strFailReason = "";
@@ -6494,6 +6494,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
 
             CTransactionRecord rtx;
             if (!vecSend.empty()) {
+                LOCK(cs_wallet);
                 CAmount nFeeRet;
                 std::string sError;
                 CCoinControl coinControl;


### PR DESCRIPTION
- Run send coins on a different thread and emit a signal when it is done.
- Make `cs_wallet` lock more fine grain on `SpendZerocoin()` so that it does halt all other items that use `cs_wallet`. This allows the UI to continue to be used while a transaction is being created.
- Add a status label that displays (and animates) the current state of transaction creation.
- Disable spend button if a transaction is being generated.
- Use a small security level for zerocoinspends since zerocoin is not anon right now anyways.
- Refactor some bad GUI code that pointlessly calls wallet methods that wait on `cs_wallet` lock.

Dev Note: This adds QtConcurrent to the depends.

Use Example:
![ui_send1](https://user-images.githubusercontent.com/6628210/58900334-37d21800-86bc-11e9-8655-cf7a335b9898.gif)

Tabs Being Switch While Tx Is Being Generated:
![ui_send2](https://user-images.githubusercontent.com/6628210/58900409-5cc68b00-86bc-11e9-8fe4-d1d32b990714.gif)

Button disabled when send is pressed:
![ui_send3](https://user-images.githubusercontent.com/6628210/58900478-7c5db380-86bc-11e9-8515-3bf66dfec4f8.gif)

