### PR TITLE
[GUI] Status bar – Horizontally center the sync status button

### DIFF
--- a/src/qt/veil/forms/veilstatusbar.ui
+++ b/src/qt/veil/forms/veilstatusbar.ui
@@ -91,7 +91,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0">
         <property name="leftMargin">
          <number>9</number>
         </property>
@@ -203,14 +203,7 @@
          </layout>
         </item>
         <item>
-         <widget class="QPushButton" name="btnSync">
-          <property name="text">
-           <string>100% Synced</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_left">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -219,7 +212,30 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>100</width>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnSync">
+          <property name="text">
+           <string>100% Synced</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_right">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
             <height>20</height>
            </size>
           </property>


### PR DESCRIPTION
The status bar was missing a horizontal spacer on the left side of the sync status button

fixed #602 

sv1qqpj0zn0pyd2gp7w5vs93ja2rq0s6yrwvmtcvvd6lg5awdpuggsh32cpq2seytp7tg6mlqvzn2zjl9ug63gsga0q5kgzh5sjmg0uz32r2krh6qqq4tpdvx

Before Fix:
![image](https://user-images.githubusercontent.com/46700212/59897630-24f55e00-93b3-11e9-8901-c758cc8249b2.png)

After Fix:
![image](https://user-images.githubusercontent.com/46700212/59897533-b1ebe780-93b2-11e9-8f13-cfb39103cfaa.png)
