### PR TITLE
[RPC] Require a valid destination address in spendzerocoin

### DIFF
--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -336,6 +336,9 @@ UniValue spendzerocoin(const JSONRPCRequest& request)
 
     CTxDestination dest;
     dest = DecodeDestination(params[4].get_str());
+    if (!IsValidDestination(dest)) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address");
+    }
 
     if (nSecurityLevel < 1 || nSecurityLevel > 100) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid security level value (%d). Must be in [1, 100] range.", nSecurityLevel));


### PR DESCRIPTION
Add destination address validition to spendzerocoin

Closes: #495 

payment address:
sv1qqp0j5cm6vrrkvkajpnq39gczt09eclw5z8h2zrmvrwndw7ppqaa28spqfqmkpana500t0jmjnhcjekg0rgt9jfll3w03m46p7ard9lqrpxduqqqe9a2qv