### PR TITLE
[Net] Add P2P version tracker & update notifier

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -17,6 +17,15 @@ static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 /** Default for BIP61 (sending reject messages) */
 static constexpr bool DEFAULT_ENABLE_BIP61 = true;
 
+extern bool fUpdateCheck;
+extern int higherVerPeers;
+extern int currentVerPeers;
+extern int lowerVerPeers;
+extern bool shouldUpgrade;
+
+int CheckForUpdates(std::string addr, std::string ver);
+void replaceAll(std::string& str, const std::string& from, const std::string& to);
+
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
     CConnman* const connman;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -108,6 +108,7 @@ void ClientModel::updateTimer()
 void ClientModel::updateNumConnections(int numConnections)
 {
     Q_EMIT numConnectionsChanged(numConnections);
+    Q_EMIT alertsChanged(getStatusBarWarnings());
 }
 
 void ClientModel::updateNetworkActive(bool networkActive)

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -10,6 +10,7 @@
 
 CCriticalSection cs_warnings;
 std::string strMiscWarning GUARDED_BY(cs_warnings);
+bool fUpdateFound GUARDED_BY(cs_warnings) = false;
 bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
 bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
 
@@ -17,6 +18,12 @@ void SetMiscWarning(const std::string& strWarning)
 {
     LOCK(cs_warnings);
     strMiscWarning = strWarning;
+}
+
+void SetfUpdateFound(bool flag)
+{
+    LOCK(cs_warnings);
+    fUpdateFound = flag;
 }
 
 void SetfLargeWorkForkFound(bool flag)
@@ -55,6 +62,12 @@ std::string GetWarnings(const std::string& strFor)
     {
         strStatusBar = strMiscWarning;
         strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
+    }
+    
+    if (fUpdateFound)
+    {
+        strStatusBar = "Over 50% of our peers are running a newer wallet version than yours. An update may be available.";
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Over 50% of our peers are running a newer wallet version than yours. An update may be available.");
     }
 
     if (fLargeWorkForkFound)

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -10,6 +10,7 @@
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);
+void SetfUpdateFound(bool flag);
 void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);


### PR DESCRIPTION
This PR closes #404 by adding a check onto every new connection that measures and saves the connection's peer subversion, this can then be used to measure the average network version, and figure out if the client is "behind", "forward" or "current" in version integers, if the client is behind, the check will trigger a messagein warnings.cpp which displays an warning of `"Over 50% of our peers are running a newer wallet version than yours. An update may be available."`

The update tracker is relatively simple, but the functions of it must be known clearly, so that it doesn't get abused by malicious actors, and doesn't false-positive on specific version integers.

- Atleast 50% of historical peers, must be a higher version before an update warning is triggered.
- Atleast 2 historical peers minimum must be a higher version before an update is considered.

This means at minimum, if you have 4 connections, two are older or matching wallets, two are new wallets higher than our own, the update warning **WILL** fire.

If you connect to only 1 peer, and they are a higher version, the update warning will **NOT** fire, due to the minimum requirement of 2 higher-ver peers, to help prevent false-positives.

It is theoretically possible to do an "attack" if an actor is to compile a wallet with a fake, higher version than the official wallet. But, due to seednodes and the natural size of the network, it would take a very high amount of 'fake version' nodes before an update notif. would fire.

No arbitrary data can be inserted into the update tracker, it will not display a URL or version text when an update triggers, it will just purely notify that an update may be possible, due to >50% of peers having higher subversions.

-------------
A possible bug with the current system, is that it cannot properly parse updates with a larger integer than 10. I'll copy-paste a comment I wrote in net_processing.cpp
```
        Due to the nature of this splicing mechanic, a version integer over 10
        will cause the updater to get 'confused'.
        
        For example, v1.2.3 would equate to 123 when spliced, but v1.10.3 would
        equate to 1103, which, even though in versioning terms is an OLDER
        version, the updater cannot see that in integer form.
        
        This problem is avoided if you do less than 10 major / minor / patch
        updates in a row, but if that cannot be done, I'd recommend we find
        a way to splice without breaking version tracking over 10 updates.
```
