### PR TITLE
Remove obsolote wallet lock check

### DIFF
--- a/src/qt/veil/balance.cpp
+++ b/src/qt/veil/balance.cpp
@@ -231,10 +231,9 @@ void Balance::updateDisplayUnit()
 void Balance::refreshWalletStatus() {
     // Check wallet status
     interfaces::Wallet& wallet = walletModel->wallet();
-    bool isLocked = walletModel->getEncryptionStatus() == WalletModel::Locked;
     std::string strAddress;
     std::vector<interfaces::WalletAddress> addresses = wallet.getLabelAddress("stealth");
-    if(isLocked || !addresses.empty()) {
+    if(!addresses.empty()) {
         interfaces::WalletAddress address = addresses[0];
         if (address.dest.type() == typeid(CStealthAddress)){
             bool fBech32 = true;

--- a/src/qt/veil/receivewidget.cpp
+++ b/src/qt/veil/receivewidget.cpp
@@ -89,10 +89,9 @@ bool ReceiveWidget::generateNewAddress(){
     // Address
     interfaces::Wallet& wallet = walletModel->wallet();
 
-    bool isLocked = walletModel->getEncryptionStatus() == WalletModel::Locked;
     std::string strAddress;
     std::vector<interfaces::WalletAddress> addresses = wallet.getLabelAddress("stealth");
-    if(isLocked || !addresses.empty()) {
+    if(!addresses.empty()) {
         interfaces::WalletAddress address = addresses[0];
         if (address.dest.type() == typeid(CStealthAddress)){
             bool fBech32 = true;


### PR DESCRIPTION
Removes an unnecessary wallet lock check, which could cause a segmentation fault under certain conditions. If no address labeled "stealth" was present (due to renaming) in an encrypted (password locked) wallet at startup, the client would segfault.

This resolves #452 