### PR TITLE
fix address generation button in wallet receive tab

### DIFF
--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -289,6 +289,10 @@ void AddressesWidget::hideEvent(QHideEvent *event){
     }
 }
 
+void AddressesWidget::hideThisWidget(){
+    this->hide();
+}
+
 // We override the virtual resizeEvent of the QWidget to adjust tables column
 // sizes as the tables width is proportional to the dialogs width.
 void AddressesWidget::resizeEvent(QResizeEvent* event)

--- a/src/qt/veil/addresseswidget.h
+++ b/src/qt/veil/addresseswidget.h
@@ -59,6 +59,7 @@ private Q_SLOTS:
     void handleAddressClicked(const QModelIndex &index);
     virtual void showEvent(QShowEvent *event) override;
     virtual void hideEvent(QHideEvent *event) override;
+    void hideThisWidget();
 
 private:
     Ui::AddressesWidget *ui;

--- a/src/qt/veil/receivewidget.cpp
+++ b/src/qt/veil/receivewidget.cpp
@@ -207,6 +207,10 @@ void ReceiveWidget::hideEvent(QHideEvent *event){
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
+void ReceiveWidget::hideThisWidget(){
+    this->hide();
+}
+
 ReceiveWidget::~ReceiveWidget()
 {
     delete ui;

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -35,6 +35,9 @@ public Q_SLOTS:
     void on_btnCopyAddress_clicked();
     void generateNewAddressClicked();
 
+private Q_SLOTS:
+    void hideThisWidget();
+
 private:
     Ui::ReceiveWidget *ui;
     ClientModel *clientModel;

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -47,7 +47,7 @@ private:
     CPubKey newKey;
     QString qAddress;
 
-    bool generateNewAddress();
+    bool generateNewAddress(bool force=false);
 };
 
 #endif // RECEIVEWIDGET_H

--- a/src/qt/veil/settings/settingswidget.cpp
+++ b/src/qt/veil/settings/settingswidget.cpp
@@ -276,6 +276,10 @@ void SettingsWidget::hideEvent(QHideEvent *event){
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
+void SettingsWidget::hideThisWidget(){
+    this->hide();
+}
+
 void SettingsWidget::setWalletModel(WalletModel *model){
     this->walletModel = model;
 

--- a/src/qt/veil/settings/settingswidget.h
+++ b/src/qt/veil/settings/settingswidget.h
@@ -40,6 +40,8 @@ private Q_SLOTS:
     void onAdvanceClicked();
     void onCheckStakingClicked(bool res);
     void onLabelStakingClicked();
+    void hideThisWidget();
+
 private:
     Ui::SettingsWidget *ui;
     WalletView *mainWindow;

--- a/src/qt/veil/toast.cpp
+++ b/src/qt/veil/toast.cpp
@@ -45,6 +45,10 @@ void Toast::hideEvent(QHideEvent *event){
     //connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
+void Toast::hideThisWidget(){
+    this->hide();
+}
+
 Toast::~Toast()
 {
     delete ui;

--- a/src/qt/veil/toast.h
+++ b/src/qt/veil/toast.h
@@ -22,6 +22,9 @@ public:
     virtual void showEvent(QShowEvent *event) override;
     virtual void hideEvent(QHideEvent *event) override;
 
+private Q_SLOTS:
+    void hideThisWidget();
+
 private:
     Ui::Toast *ui;
 };


### PR DESCRIPTION
This PR resolves two things.
- Adds missing QT slots that were initially believed to be the cause of the address generation issue (although the issue occurred in receivewidget.cpp, several similar slots were also missing in other widgets and have been added with this PR)
- Resolves the root cause of the address generation bug. Currently, the latest address generated in the GUI wallet is labeled "stealth". If an address with that label already exists, no additional addresses are generated.  The issue is resolved by removing the label of the old address in order to allow the generation of a new address with the "stealth" label.

resolves #509 

