### PR TITLE
[Wallet] Use one default stealth change address for CT/RingCT transactions.

### DIFF
--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -112,6 +112,8 @@ class AnonWallet
     CKeyID idMaster;
     CKeyID idDefaultAccount;
     CKeyID idStealthAccount;
+    CKeyID idChangeAccount;
+    CKeyID idChangeAddress;
 
     typedef std::multimap<COutPoint, uint256> TxSpends;
     TxSpends mapTxSpends;
@@ -209,8 +211,6 @@ public:
 
     bool IsChange(const CTxOutBase *txout) const;
 
-    int GetChangeAddress(CPubKey &pk);
-
     void AddOutputRecordMetaData(CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend);
     bool ExpandTempRecipients(std::vector<CTempRecipient> &vecSend, std::string &sError);
     void MarkInputsAsPendingSpend(CTransactionRecord &rtx);
@@ -255,7 +255,9 @@ public:
     int UnloadTransaction(const uint256 &hash);
 
     bool MakeDefaultAccount(const CExtKey& extKeyMaster);
+    bool CreateStealthChangeAccount(AnonWalletDB* wdb);
     bool SetMasterKey(const CExtKey& keyMasterIn);
+    bool UnlockWallet(const CExtKey& keyMasterIn);
     bool LoadAccountCounters();
     bool LoadKeys();
     CKeyID GetSeedHash() const;
@@ -271,7 +273,8 @@ public:
     bool RegenerateKeyFromIndex(const CKeyID& idAccount, int nIndex, CExtKey& keyDerive) const;
     bool MakeSigningKeystore(CBasicKeyStore& keystore, const CScript& scriptPubKey);
 
-    bool NewStealthKey(CStealthAddress& stealthAddress, uint32_t nPrefixBits, const char *pPrefix);
+    bool NewStealthKey(CStealthAddress& stealthAddress, uint32_t nPrefixBits, const char *pPrefix, CKeyID* paccount = nullptr);
+    CStealthAddress GetStealthChangeAddress();
 
     /**
      * Insert additional inputs into the transaction by

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -106,6 +106,30 @@ static UniValue getnewaddress(const JSONRPCRequest &request)
     return stealthAddress.ToString(fBech32);
 }
 
+static UniValue getstealthchangeaddress(const JSONRPCRequest &request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+                "getstealthchangeaddress\n"
+                "Returns the default stealth change address."
+                + HelpRequiringPassphrase(wallet.get()) +
+                "\nResult:\n"
+                "\"address\"              (string) The stealth change address\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getstealthchangeaddress", "")
+                + HelpExampleRpc("getstealthchangeaddress", ""));
+
+    EnsureWalletIsUnlocked(wallet.get());
+    auto pAnonWallet = wallet->GetAnonWallet();
+    auto address = pAnonWallet->GetStealthChangeAddress();
+
+    return address.ToString(true);
+}
+
 static UniValue restoreaddresses(const JSONRPCRequest &request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -1897,7 +1921,7 @@ static const CRPCCommand commands[] =
                 { "wallet",             "getnewaddress",             &getnewaddress,          {"label","num_prefix_bits","prefix_num","bech32","makeV2"} },
                 { "wallet",             "restoreaddresses",          &restoreaddresses,          {"generate_count"} },
                 { "wallet",             "rescanringctwallet",          &rescanringctwallet,          {} },
-
+                { "wallet",             "getstealthchangeaddress",          &getstealthchangeaddress,          {} },
                 { "wallet",             "sendbasecointostealth", &sendbasecointostealth,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },
 
                 { "wallet",             "sendstealthtobasecoin", &sendstealthtobasecoin,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -551,7 +551,7 @@ bool CWallet::UnlockAnonWallet()
     if (idDerived != idSeedDB)
         return error("%s: derived anon wallet key %s does not match expected key %s", __func__, idDerived.GetHex(), idSeedDB.GetHex());
 
-    pAnonWalletMain->SetMasterKey(keyAnonMaster);
+    pAnonWalletMain->UnlockWallet(keyAnonMaster);
     return true;
 }
 
@@ -5384,7 +5384,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         if (!walletInstance->GetAnonWalletSeed(extMasterAnon))
             throw std::runtime_error(strprintf("%s: could not get anon wallet seed on wallet load", __func__));
         AnonWallet* anonwallet = walletInstance->GetAnonWallet();
-        assert(anonwallet->SetMasterKey(extMasterAnon));
+        assert(anonwallet->UnlockWallet(extMasterAnon));
     }
 
     return walletInstance;


### PR DESCRIPTION
Currently the wallet generates a new stealth address everytime it needs to issue change in a transaction that has CT or RingCT outputs. Creating a new stealth address each time is bulky and increases the amount of scanning that needs to happen when checking the blockchain for transactions that belong to the wallet.

Since a new stealth destination is derived from a stealth address each time it is used, it provides the same utility if the wallet uses a dedicated change address.

This adds a dedicated change address that is in a specific location on the seed's key path.

This also adds `getstealthchangeaddress` RPC which will print out the default change address.