### PR TITLE
'wallet-..-..' default filename 

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -280,7 +280,7 @@ bool WalletView::encryptWallet(bool status)
 void WalletView::backupWallet()
 {
     QString filename = GUIUtil::getSaveFileName(this,
-        tr("Backup Wallet"), QString(),
+        tr("Backup Wallet"), QDateTime::currentDateTime().toString("'wallet'-yyyy-MM-dd-hh-mm-ss"),
         tr("Wallet Data (*.dat)"), nullptr);
 
     if (filename.isEmpty())


### PR DESCRIPTION
sets 'wallet-..-..' default filename in backup dialog fix #247  
bv1qxmzawm3a085u2vlq9pn27zphr7nteqdeeal6y9