### PR TITLE
[GUI] Adding new wallet lock/unlock tab to FAQ.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -53,6 +53,7 @@ QT_FORMS_UI = \
   qt/veil/forms/settingsfaq09.ui \
   qt/veil/forms/settingsfaq10.ui \
   qt/veil/forms/settingsfaq11.ui \
+  qt/veil/forms/settingsfaq12.ui \
   qt/veil/forms/settingsminting.ui \
   qt/veil/forms/settingsnetwork.ui \
   qt/veil/forms/settingspreferences.ui \
@@ -149,6 +150,7 @@ QT_MOC_CPP = \
   qt/veil/settings/moc_settingsfaq09.cpp \
   qt/veil/settings/moc_settingsfaq10.cpp \
   qt/veil/settings/moc_settingsfaq11.cpp \
+  qt/veil/settings/moc_settingsfaq12.cpp \
   qt/veil/settings/moc_settingsminting.cpp \
   qt/veil/settings/moc_settingsnetwork.cpp \
   qt/veil/settings/moc_settingspreferences.cpp \
@@ -274,6 +276,7 @@ BITCOIN_QT_H = \
   qt/veil/settings/settingsfaq09.h \
   qt/veil/settings/settingsfaq10.h \
   qt/veil/settings/settingsfaq11.h \
+  qt/veil/settings/settingsfaq12.h \
   qt/veil/settings/settingsminting.h \
   qt/veil/settings/settingsnetwork.h \
   qt/veil/settings/settingspreferences.h \
@@ -678,6 +681,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/veil/settings/settingsfaq09.cpp \
   qt/veil/settings/settingsfaq10.cpp \
   qt/veil/settings/settingsfaq11.cpp \
+  qt/veil/settings/settingsfaq12.cpp \
   qt/veil/settings/settingsminting.cpp \
   qt/veil/settings/settingsnetwork.cpp \
   qt/veil/settings/settingspreferences.cpp \

--- a/src/qt/locale/veil_en.ts
+++ b/src/qt/locale/veil_en.ts
@@ -3961,6 +3961,19 @@ For the latest information, please see the Official Veil Bounty Program thread o
     </message>
 </context>
 <context>
+    <name>SettingsFaq12</name>
+    <message>
+        <location filename="../veil/forms/settingsfaq12.ui" line="+14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unlocking/locking the wallet from within the GUI&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;At the bottom right of the Veil wallet GUI a padlock icon is displayed showing the current lock status of your wallet. Clicking the padlock when it shows the locked state will display a prompt asking you for your wallet password. If entered correctly, your wallet will be unlocked.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;To lock your wallet again, click the now unlocked padlock icon.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SettingsMinting</name>
     <message>
         <location filename="../veil/forms/settingsminting.ui" line="+14"/>

--- a/src/qt/veil/forms/settingsfaq.ui
+++ b/src/qt/veil/forms/settingsfaq.ui
@@ -851,6 +851,59 @@ Address / Exchange or Service mode?</string>
                  </widget>
                 </item>
                 <item>
+                 <widget class="QRadioButton" name="radioButton_12">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>400</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">#radioButton_12 {
+    border-radius: 0px;
+    border:  none;
+    margin:0px;
+    background-color:#ffffff;
+    color: #707070;
+    font-size: 18px;
+    padding:10px 30px 10px 30px;
+    text-align:center !important;
+}
+
+#radioButton_12:checked {
+    border:  none;
+     background-color:rgba(16,90,239,0.2);
+    color: #707070;
+    margin:0px;
+}
+
+#radioButton_12:unchecked {
+    border:  none;
+    background-color:white;
+    color: #707070;
+}
+
+#radioButton_12::indicator {
+    width:                  0px;
+    height:                 0px;
+    border-radius:          0px;
+}</string>
+                  </property>
+                  <property name="text">
+                   <string>How do I lock/unlock my wallet?</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <spacer name="verticalSpacer">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>

--- a/src/qt/veil/forms/settingsfaq12.ui
+++ b/src/qt/veil/forms/settingsfaq12.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsFaq12</class>
+ <widget class="QWidget" name="SettingsFaq12">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>656</width>
+    <height>575</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">font-size:16px;
+color:#707070;</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="rightMargin">
+    <number>60</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font-weight:200;</string>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unlocking/locking the wallet from within the GUI&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;At the bottom right of the Veil wallet GUI a padlock icon is displayed showing the current lock status of your wallet. Clicking the padlock when it shows the locked state will display a prompt asking you for your wallet password. If entered correctly, your wallet will be unlocked.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;To lock your wallet again, click the now unlocked padlock icon.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/veil/settings/settingsfaq.cpp
+++ b/src/qt/veil/settings/settingsfaq.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <qt/veil/settings/settingsfaq.h>
 #include <qt/veil/forms/ui_settingsfaq.h>
 #include <qt/veil/settings/settingsfaq01.h>
@@ -11,6 +15,7 @@
 #include <qt/veil/settings/settingsfaq09.h>
 #include <qt/veil/settings/settingsfaq10.h>
 #include <qt/veil/settings/settingsfaq11.h>
+#include <qt/veil/settings/settingsfaq12.h>
 #include <qt/guiutil.h>
 
 
@@ -35,6 +40,7 @@ SettingsFaq::SettingsFaq(QWidget *parent, bool howToObtainVeil) :
     ui->radioButton_09->setProperty("cssClass" , "radio-button-faq");
     ui->radioButton_10->setProperty("cssClass" , "radio-button-faq");
     //ui->radioButton_11->setProperty("cssClass" , "radio-button-faq");
+    ui->radioButton_12->setProperty("cssClass" , "radio-button-faq");
 
     connect(ui->radioButton_01,SIGNAL(clicked()),this, SLOT(onRadioButton01Clicked()));
     //connect(ui->radioButton_02,SIGNAL(clicked()),this, SLOT(onRadioButton02Clicked()));
@@ -47,6 +53,9 @@ SettingsFaq::SettingsFaq(QWidget *parent, bool howToObtainVeil) :
     connect(ui->radioButton_09,SIGNAL(clicked()),this, SLOT(onRadioButton09Clicked()));
     connect(ui->radioButton_10,SIGNAL(clicked()),this, SLOT(onRadioButton10Clicked()));
     //connect(ui->radioButton_11,SIGNAL(clicked()),this, SLOT(onRadioButton11Clicked()));
+    connect(ui->radioButton_12,SIGNAL(clicked()),this, SLOT(onRadioButton12Clicked()));
+
+
 
     faq01 = new SettingsFaq01(this);
 
@@ -169,6 +178,15 @@ void SettingsFaq::onRadioButton11Clicked(){
     }
 
     changeScreen(faq11);
+}
+
+void SettingsFaq::onRadioButton12Clicked(){
+    if(!faq12) {
+        faq12 = new SettingsFaq12(this);
+        ui->stackedWidget->addWidget(faq12);
+    }
+
+    changeScreen(faq12);
 }
 
 

--- a/src/qt/veil/settings/settingsfaq.h
+++ b/src/qt/veil/settings/settingsfaq.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef SETTINGSFAQ_H
 #define SETTINGSFAQ_H
 
@@ -14,6 +18,7 @@
 #include <qt/veil/settings/settingsfaq09.h>
 #include <qt/veil/settings/settingsfaq10.h>
 #include <qt/veil/settings/settingsfaq11.h>
+#include <qt/veil/settings/settingsfaq12.h>
 
 
 namespace Ui {
@@ -40,6 +45,8 @@ private Q_SLOTS:
     void onRadioButton09Clicked();
     void onRadioButton10Clicked();
     void onRadioButton11Clicked();
+    void onRadioButton12Clicked();
+
     void changeScreen(QWidget *widget);
 
 private:
@@ -55,6 +62,7 @@ private:
     SettingsFaq09 *faq09 = nullptr;
     SettingsFaq10 *faq10 = nullptr;
     SettingsFaq11 *faq11 = nullptr;
+    SettingsFaq12 *faq12 = nullptr;
 };
 
 #endif // SETTINGSFAQ_H

--- a/src/qt/veil/settings/settingsfaq12.cpp
+++ b/src/qt/veil/settings/settingsfaq12.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/veil/settings/settingsfaq12.h>
+#include <qt/veil/forms/ui_settingsfaq12.h>
+
+SettingsFaq12::SettingsFaq12(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::SettingsFaq12)
+{
+    ui->setupUi(this);
+
+    ui->label_2->setTextFormat( Qt::RichText );
+    ui->label_2->setWordWrap(true);
+}
+
+SettingsFaq12::~SettingsFaq12()
+{
+    delete ui;
+}

--- a/src/qt/veil/settings/settingsfaq12.h
+++ b/src/qt/veil/settings/settingsfaq12.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SETTINGSFAQ12_H
+#define SETTINGSFAQ12_H
+
+#include <QWidget>
+
+namespace Ui {
+class SettingsFaq12;
+}
+
+class SettingsFaq12 : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SettingsFaq12(QWidget *parent = nullptr);
+    ~SettingsFaq12();
+
+private:
+    Ui::SettingsFaq12 *ui;
+};
+
+#endif // SETTINGSFAQ12_H

--- a/veil-qt.files
+++ b/veil-qt.files
@@ -435,6 +435,7 @@ src/qt/transactionview.h
 src/qt/utilitydialog.cpp
 src/qt/utilitydialog.h
 src/qt/veil.cpp
+src/qt/veil/forms/settingsfaq12.ui
 src/qt/walletframe.cpp
 src/qt/walletframe.h
 src/qt/walletmodel.cpp


### PR DESCRIPTION
Adding a new section to the FAQ that describes how to lock/unlock the wallet using the GUI.

![Screenshot from 2019-06-27 03-51-48](https://user-images.githubusercontent.com/8047888/60230775-000b5a00-988f-11e9-90ee-851d02a774da.png)

closes #612 