### PR TITLE
[GUI][Wallet] Remove unnecessary fee amount from Zerocoin spend

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -595,6 +595,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     std::vector<uint256> vCoinControlSerials;
     coinControl()->ListSelected(vCoinControlSerials);
 
+	bool fZerocoinMintSelected = false;
     for (auto serialHash: vCoinControlSerials) {
         CZerocoinMint mint;
 
@@ -609,7 +610,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         }
 
         nQuantity++;
-
+		fZerocoinMintSelected = true;
         nAmount += mint.GetDenominationAsAmount();
     }
 
@@ -633,7 +634,12 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
                 nBytes -= 34;
 
         // Fee
-        nPayFee = model->wallet().getMinimumFee(nBytes, *coinControl(), nullptr /* returned_target */, nullptr /* reason */);
+		if (fZerocoinMintSelected) {
+			nPayFee = 0; // No fee to spend zerocoin
+		}
+		else {
+			nPayFee = model->wallet().getMinimumFee(nBytes, *coinControl(), nullptr /* returned_target */, nullptr /* reason */);
+		}
 
         if (nPayAmount > 0)
         {


### PR DESCRIPTION
When spending zerocoin the UI was displaying a fee amount that was not included in the actual transaction. 

fixes #596 

sv1qqpj0zn0pyd2gp7w5vs93ja2rq0s6yrwvmtcvvd6lg5awdpuggsh32cpq2seytp7tg6mlqvzn2zjl9ug63gsga0q5kgzh5sjmg0uz32r2krh6qqq4tpdvx