### PR TITLE
[GUI] Remove invalid combobox styling

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -958,7 +958,6 @@ padding:9px;
                  <property name="styleSheet">
                   <string notr="true">QValueComboBox{
 	font-size:13px;
-	qproperty-alignment: AlignCenter;
     selection-color: #000000;
 }
 
@@ -1012,7 +1011,6 @@ QToolTip {
                  <property name="styleSheet">
                   <string notr="true">QValueComboBox{
 	font-size:13px;
-	qproperty-alignment: AlignCenter;
     selection-color: #000000;
 }
 


### PR DESCRIPTION
The qproperty-alignment property is not a valid css or qt property. 

closes #533

sv1qqpj0zn0pyd2gp7w5vs93ja2rq0s6yrwvmtcvvd6lg5awdpuggsh32cpq2seytp7tg6mlqvzn2zjl9ug63gsga0q5kgzh5sjmg0uz32r2krh6qqq4tpdvx