### PR TITLE
[Wallet] Fix regtest chainparams

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -546,6 +546,9 @@ public:
 
         bech32Prefixes[STEALTH_ADDRESS].assign("tps","tps"+3);
         bech32Prefixes[BASE_ADDRESS].assign("tv", "tv"+2);
+        nBIP44ID = 0x80000001;
+        nRingCTAccount = 20000;
+        nZerocoinAccount = 100000;
 
         bech32_hrp_stealth = "tps";
         bech32_hrp_base = "tv";


### PR DESCRIPTION
- Regtest doesn't function correctly because of an issue with some issue chain params. With the chain params added back, we are able to use regtest again.