### PR TITLE
[GUI ] Fixing inconsistent tab transitions.

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -23,6 +23,9 @@
 #include <QPainter>
 #include <QSettings>
 #include <QDesktopWidget>
+#include <QGraphicsOpacityEffect>
+#include <QPropertyAnimation>
+#include <QPixmap>
 
 #include <QDebug>
 
@@ -546,4 +549,25 @@ void OverviewPage::showEvent(QShowEvent *event){
     bool fHide = settings.value("bHideOrphans", true).toBool();
     if (fHide != filter->orphansHidden())
         hideOrphans(fHide);
+
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(0.25);
+    a->setEndValue(1);
+    a->setEasingCurve(QEasingCurve::InBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+}
+
+void OverviewPage::hideEvent(QHideEvent *event){
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(1);
+    a->setEndValue(0);
+    a->setEasingCurve(QEasingCurve::OutBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -62,6 +62,7 @@ private Q_SLOTS:
     void filterTxes(int selectedTxType);
     void onFaqClicked();
     virtual void showEvent(QShowEvent *event) override;
+    virtual void hideEvent(QHideEvent *event) override;
 
     void hideOrphans(bool fHide);
 };

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -30,6 +30,9 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextDocument>
+#include <QGraphicsOpacityEffect>
+#include <QPropertyAnimation>
+#include <QPixmap>
 #include <veil/dandelioninventory.h>
 
 #include <qt/veil/qtutils.h>
@@ -1026,6 +1029,29 @@ void SendCoinsDialog::toggleDandelion(bool fchecked)
                 tr("Dandelion protocol is in beta. Any communications of this transaction may be inconsistent."));
     }
     fDandelion = fchecked;
+}
+
+void SendCoinsDialog::showEvent(QShowEvent *event){
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(0.25);
+    a->setEndValue(1);
+    a->setEasingCurve(QEasingCurve::InBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+}
+
+ void SendCoinsDialog::hideEvent(QHideEvent *event){
+    QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
+    this->setGraphicsEffect(eff);
+    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
+    a->setDuration(100);
+    a->setStartValue(1);
+    a->setEndValue(0);
+    a->setEasingCurve(QEasingCurve::OutBack);
+    a->start(QPropertyAnimation::DeleteWhenStopped);
+    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
 SendConfirmationDialog::SendConfirmationDialog(const QString &title, const QString &text, int _secDelay,

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -137,7 +137,9 @@ private Q_SLOTS:
     void updateSmartFeeLabel();
     void toggleDandelion(bool);
     void StatusTimerTimeout();
-
+    virtual void showEvent(QShowEvent *event) override;
+    virtual void hideEvent(QHideEvent *event) override;
+    
 Q_SIGNALS:
     // Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -254,7 +254,6 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
     }
     menu->move(pos);
     menu->show();
-
 }
 
 void AddressesWidget::initAddressesView(){
@@ -318,7 +317,6 @@ void AddressesWidget::onButtonChanged() {
     }else{
         ui->btnAdd->setText("New Contact");
         showHideMineAddressBtn(false);
-
     }
     if(this->menu){
         this->menu->hide();
@@ -426,7 +424,6 @@ void AddressesWidget::showList(bool show){
         ui->listAddresses->setVisible(false);
         ui->listContacts->setVisible(false);
     }
-
 }
 
 AddressesWidget::~AddressesWidget() {


### PR DESCRIPTION
Adding `showEvent` & `hideEvent` slots `sendcoindialog` & `overviewpage`.

Page/tab transition animations are now consistent.

closes #174 (Rebased)