### PR TITLE
Add SECURITY.md to the project repo to outline the security reporting process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Veil's Security HowTo
+
+We appreciate your help in finding bugs and identifying vulnerabilities in Veil! ***Please don't*** post security issues in [the public issue tracker](https://github.com/Veil-Project/veil/issues) and use the contacts mentioned below instead.
+
+## Responsible Disclosure
+
+For all security related issues, Veil has three main points of contact:
+
+* James Burden, (4x13) https://keybase.io/4x13
+* Tom Bradshaw (presstab), https://keybase.io/presstab 
+* Florian Maier (marsmensch), https://keybase.io/marsmensch
+
+Please send all communications to those parties and expect a reply within 72h. 
+
+## Scope
+
+The Veil project is committed to the best practices around safe harbor for good-faith security research outlined at http://disclose.io/. There is nothing considered out-of-scope for testers and researchers following the rules outlined in this policy.
+
+## Disclosure Policy
+
+Vulnerability details may be shared with third parties after the vulnerability has been fixed and the program owner has provided permission to disclose or after 90 days from submission, whichever is sooner.
+
+## Rewards & Recognition
+
+We are currently working on the creation of a formal reward policy. Until this policy is available, we will decide on a case to case basis and researchers should not expect a specific reward.
+Veil project is nonetheless grateful for all legitimate discoveries of vulnerabilities, and is happy to acknowledge the vulnerability and the researchers after a fix has been widely deployed.


### PR DESCRIPTION
There is a new development within the open source community that github supports. By adding a file named **"Security.md"**, projects document their security reporting process in a new _"Security"_ Tab.

Related information
https://github.com/github/opensource.guide/issues/981

This pull request adds a responsible disclosure statement and procedure to the project repo in a new file "SECURITY.md". This information will than be displayed at https://github.com/Veil-Project/veil/security/policy and can be easily referenced where needed.

This is my proposal how a reasonable _"Security.md"_ for Veil should look like.