### PR TITLE
[RPC] Fix getblockstats to handle zerocoin spends, RingCT and PoS blocks

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1998,6 +1998,10 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             }
 
             CAmount txfee = tx_total_in - tx_total_out;
+            if (tx_total_in < tx_total_out) {
+                // RingCT with hidden inputs, can't count it
+                continue;
+            }
             assert(MoneyRange(txfee));
             if (do_medianfee) {
                 fee_array.push_back(txfee);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1937,6 +1937,13 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         if (tx->IsCoinBase()) {
             continue;
         }
+        if (tx->IsCoinStake()) {
+            continue;
+        }
+        if (tx->vin[0].IsAnonInput()) {
+            // Can't really do much with a ringCT transaction
+            continue;
+        }
 
         inputs += tx->vin.size(); // Don't count coinbase's fake input
         total_out += tx_total_out; // Don't count coinbase reward
@@ -1972,18 +1979,22 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             }
             CAmount tx_total_in = 0;
             for (const CTxIn& in : tx->vin) {
-                CTransactionRef tx_in;
-                uint256 hashBlock;
-                if (!GetTransaction(in.prevout.hash, tx_in, Params().GetConsensus(), hashBlock, false)) {
-                    throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Unexpected internal error (tx index seems corrupt)"));
+                if (!in.IsZerocoinSpend()) {
+                    CTransactionRef tx_in;
+                    uint256 hashBlock;
+                    if (!GetTransaction(in.prevout.hash, tx_in, Params().GetConsensus(), hashBlock, false)) {
+                        throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Unexpected internal error (tx index seems corrupt)"));
+                    }
+
+                    auto prevoutput = tx_in->vpout[in.prevout.n];
+
+                    tx_total_in += prevoutput->GetValue();
+                    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                    ss << *prevoutput.get();
+                    utxo_size_inc -= ss.size() + PER_UTXO_OVERHEAD;
+                } else {
+                    tx_total_in += in.GetZerocoinSpent();
                 }
-
-                auto prevoutput = tx_in->vpout[in.prevout.n];
-
-                tx_total_in += prevoutput->GetValue();
-                CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                ss << *prevoutput.get();
-                utxo_size_inc -= ss.size() + PER_UTXO_OVERHEAD;
             }
 
             CAmount txfee = tx_total_in - tx_total_out;


### PR DESCRIPTION
### Problem
`getblockstats` returns 'tx index seems corrupt' on many blocks.

### Root Cause
`getblockstats` did not recognize when transaction inputs were not "normal";  This occurs on zerocoin spends, as well as ringCT transactions.  Furthermore, it got confused when there was a PoS block, and most PoS blocks caused the error.

### Solution
Skip transactions that are coin stake transactions, or ring ct transactions.  For zerocoin transactions, get the amount of zerocoin spent.

### Bounty PR
#440 

### Bounty Payment Address
`sv1qqpj9l2f883k7ucs88xdzrcuus8wr6jzrnk85quv3p2u90zwyy6d5tqpq0fl2ksmvlsf5hfddf8ezqnph5q6zf05cmac28g6ytafdzp8aufsuqqqwk9ep3`

### Unit Testing Results
```
$ veil-cli getblockstats 307836
error code: -32603
error message:
Unexpected internal error (tx index seems corrupt)
$ veil-cli getblockstats 307867
error code: -32603
error message:
Unexpected internal error (tx index seems corrupt)'
$ veil-cli getblockstats 307996
error code: -32603
error message:
Unexpected internal error (tx index seems corrupt)
```
```
$ ./veil-cli getblockstats 307836
{
  "avgfee": 0,
  "avgfeerate": 0,
  "avgtxsize": 0,
  "blockhash": "69c5de6e3b125e57baecebe0f2a1e64c775c231273976f6b45b6ea58e6702c72",
  "feerate_percentiles": [
    0,
    0,
    0,
    0,
    0
  ],
  "height": 307836,
  "ins": 0,
  "maxfee": 0,
  "maxfeerate": 0,
  "maxtxsize": 0,
  "medianfee": 0,
  "mediantime": 1565376620,
  "mediantxsize": 0,
  "minfee": 0,
  "minfeerate": 0,
  "mintxsize": 0,
  "outs": 8,
  "subsidy": 2500000000,
  "swtotal_size": 0,
  "swtotal_weight": 0,
  "swtxs": 0,
  "time": 1565376714,
  "total_out": 0,
  "total_size": 0,
  "total_weight": 0,
  "totalfee": 0,
  "txs": 2,
  "utxo_increase": 8,
  "utxo_size_inc": 1207
}
$ ./veil-cli getblockstats 307867
{
  "avgfee": 480,
  "avgfeerate": 1,
  "avgtxsize": 480,
  "blockhash": "a154f2f365ef1dfc603fa3e4e6d33c47bf3ededba4fc0967c996b67a20a80747",
  "feerate_percentiles": [
    1,
    1,
    1,
    1,
    1
  ],
  "height": 307867,
  "ins": 6,
  "maxfee": 961,
  "maxfeerate": 1,
  "maxtxsize": 961,
  "medianfee": 961,
  "mediantime": 1565378303,
  "mediantxsize": 961,
  "minfee": 961,
  "minfeerate": 1,
  "mintxsize": 961,
  "outs": 6,
  "subsidy": 2500000000,
  "swtotal_size": 961,
  "swtotal_weight": 3844,
  "swtxs": 1,
  "time": 1565378702,
  "total_out": 52439904,
  "total_size": 961,
  "total_weight": 3844,
  "totalfee": 961,
  "txs": 3,
  "utxo_increase": 0,
  "utxo_size_inc": 2725
}
$ ./veil-cli getblockstats 307996
{
  "avgfee": 1000000000,
  "avgfeerate": 39644,
  "avgtxsize": 25224,
  "blockhash": "a2ce9c8c88492e54dadd909f48f01a46ef8ba24b09ea0728b1fe2066549db85d",
  "feerate_percentiles": [
    0,
    0,
    74099,
    74099,
    74099
  ],
  "height": 307996,
  "ins": 6,
  "maxfee": 3000000000,
  "maxfeerate": 74099,
  "maxtxsize": 40486,
  "medianfee": 1500000000,
  "mediantime": 1565385892,
  "mediantxsize": 37836,
  "minfee": 0,
  "minfeerate": 0,
  "mintxsize": 35186,
  "outs": 13,
  "subsidy": 2500000000,
  "swtotal_size": 0,
  "swtotal_weight": 0,
  "swtxs": 0,
  "time": 1565386100,
  "total_out": 3000000000,
  "total_size": 75672,
  "total_weight": 302688,
  "totalfee": 3000000000,
  "txs": 4,
  "utxo_increase": 7,
  "utxo_size_inc": 6769
```