### PR TITLE
[GUI][QT] Fix "no such slot" and "no matching signal" log errors

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -129,10 +129,10 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode _mode,
     contextMenu->addSeparator();
 
     // Connect signals for context menu actions
-    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(on_copyAddress_clicked()));
+    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(onCopyAddressClicked()));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(onCopyLabelAction()));
     connect(editAction, SIGNAL(triggered()), this, SLOT(onEditAction()));
-    connect(deleteAction, SIGNAL(triggered()), this, SLOT(on_deleteAddress_clicked()));
+    connect(deleteAction, SIGNAL(triggered()), this, SLOT(onDeleteAddressClicked()));
 
     connect(ui->tableView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
 
@@ -172,7 +172,7 @@ void AddressBookPage::setModel(AddressTableModel *_model)
     selectionChanged();
 }
 
-void AddressBookPage::on_copyAddress_clicked()
+void AddressBookPage::onCopyAddressClicked()
 {
     GUIUtil::copyEntryData(ui->tableView, AddressTableModel::Address);
 }
@@ -220,7 +220,7 @@ void AddressBookPage::on_newAddress_clicked()
     }
 }
 
-void AddressBookPage::on_deleteAddress_clicked()
+void AddressBookPage::onDeleteAddressClicked()
 {
     QTableView *table = ui->tableView;
     if(!table->selectionModel())

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -60,11 +60,11 @@ private:
 
 private Q_SLOTS:
     /** Delete currently selected address entry */
-    void on_deleteAddress_clicked();
+    void onDeleteAddressClicked();
     /** Create a new address for receiving coins and / or add a new address book entry */
     void on_newAddress_clicked();
     /** Copy address of currently selected address entry to clipboard */
-    void on_copyAddress_clicked();
+    void onCopyAddressClicked();
     /** Copy label of currently selected address entry to clipboard (no button) */
     void onCopyLabelAction();
     /** Edit currently selected address entry (no button) */

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -63,7 +63,7 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
     connect(ui->btnRemove, SIGNAL(clicked()), this, SLOT(deleteClicked()));
     connect(ui->deleteButton_is, SIGNAL(clicked()), this, SLOT(deleteClicked()));
     connect(ui->deleteButton_s, SIGNAL(clicked()), this, SLOT(deleteClicked()));
-    connect(ui->btnAddressBook, SIGNAL(clicked()), this, SLOT(on_addressBookButton_clicked()));
+    connect(ui->btnAddressBook, SIGNAL(clicked()), this, SLOT(onAddressBookButtonClicked()));
     //connect(ui->useAvailableBalanceButton, SIGNAL(clicked()), this, SLOT(useAvailableBalanceClicked()));
 }
 
@@ -72,7 +72,7 @@ SendCoinsEntry::~SendCoinsEntry()
     delete ui;
 }
 
-void SendCoinsEntry::on_addressBookButton_clicked()
+void SendCoinsEntry::onAddressBookButtonClicked()
 {
     if(!model)
         return;

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -62,7 +62,7 @@ private Q_SLOTS:
     void deleteClicked();
     void useAvailableBalanceClicked();
     void on_payTo_textChanged(const QString &address);
-    void on_addressBookButton_clicked();
+    void onAddressBookButtonClicked();
     void updateDisplayUnit();
 
 private:

--- a/src/qt/veil/addressesmenu.cpp
+++ b/src/qt/veil/addressesmenu.cpp
@@ -19,23 +19,23 @@ AddressesMenu::AddressesMenu(const QString _type, const QModelIndex &_index, QWi
 {
     ui->setupUi(this);
 
-    connect(ui->btnCopy,SIGNAL(clicked()),this,SLOT(on_btnCopyAddress_clicked()));
-    connect(ui->btnDelete,SIGNAL(clicked()),this,SLOT(on_btnDeleteAddress_clicked()));
-    connect(ui->btnEdit,SIGNAL(clicked()),this,SLOT(on_btnEditAddress_clicked()));
+    connect(ui->btnCopy,SIGNAL(clicked()),this,SLOT(onBtnCopyAddressClicked()));
+    connect(ui->btnDelete,SIGNAL(clicked()),this,SLOT(onBtnDeleteAddressClicked()));
+    connect(ui->btnEdit,SIGNAL(clicked()),this,SLOT(onBtnEditAddressClicked()));
 
     if(AddressTableModel::Receive == type){
         ui->btnDelete->setVisible(false);
     }
 }
 
-void AddressesMenu::on_btnDeleteAddress_clicked(){
+void AddressesMenu::onBtnDeleteAddressClicked(){
     if(this->model->removeRows(index.row(), 1, index)){
         openToastDialog("Address deleted", this->mainWindow);
     }
     hide();
 }
 
-void AddressesMenu::on_btnEditAddress_clicked(){
+void AddressesMenu::onBtnEditAddressClicked(){
     auto address = this->model->index(index.row(), AddressTableModel::Address, index);
     QString addressStr = this->model->data(address, Qt::DisplayRole).toString();
 
@@ -60,7 +60,7 @@ void AddressesMenu::on_btnEditAddress_clicked(){
     hide();
 }
 
-void AddressesMenu::on_btnCopyAddress_clicked(){
+void AddressesMenu::onBtnCopyAddressClicked(){
     auto address = this->model->index(index.row(), AddressTableModel::Address, index);
     QString addressStr = this->model->data(address, Qt::DisplayRole).toString();
     GUIUtil::setClipboard(addressStr);

--- a/src/qt/veil/addressesmenu.h
+++ b/src/qt/veil/addressesmenu.h
@@ -34,9 +34,9 @@ public Q_SLOTS:
     virtual void showEvent(QShowEvent *event) override;
 
 private Q_SLOTS:
-    void on_btnCopyAddress_clicked();
-    void on_btnEditAddress_clicked();
-    void on_btnDeleteAddress_clicked();
+    void onBtnCopyAddressClicked();
+    void onBtnEditAddressClicked();
+    void onBtnDeleteAddressClicked();
 
 private:
     Ui::AddressesMenu *ui;

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -279,10 +279,10 @@ void AddressesWidget::hideEvent(QHideEvent *event){
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
+}
 
-    if(menu != nullptr){
-        menu->hide();
-    }
+void AddressesWidget::hideThisWidget(){
+   this->hide();
 }
 
 // We override the virtual resizeEvent of the QWidget to adjust tables column

--- a/src/qt/veil/addresseswidget.h
+++ b/src/qt/veil/addresseswidget.h
@@ -52,6 +52,7 @@ private Q_SLOTS:
     void onNewAddressClicked();
     void onNewMinerAddressClicked();
     void onButtonChanged();
+    void hideThisWidget();
     void handleAddressClicked(const QModelIndex &index);
     virtual void showEvent(QShowEvent *event) override;
     virtual void hideEvent(QHideEvent *event) override;

--- a/src/qt/veil/addressreceive.cpp
+++ b/src/qt/veil/addressreceive.cpp
@@ -46,7 +46,7 @@ AddressReceive::AddressReceive(QWidget *parent, WalletModel* _walletModel, bool 
     ui->labelTitle->setText(isMinerAddress ? "New Miner Address" : "New Receiving Address");
     generateNewAddress(isMinerAddress);
 
-    connect(ui->btnCopy, SIGNAL(clicked()),this, SLOT(on_btnCopyAddress_clicked()));
+    connect(ui->btnCopy, SIGNAL(clicked()),this, SLOT(onBtnCopyAddressClicked()));
     connect(ui->btnSave, SIGNAL(clicked()),this, SLOT(onBtnSaveClicked()));
 
 }
@@ -63,7 +63,7 @@ void AddressReceive::onBtnSaveClicked(){
     accept();
 }
 
-void AddressReceive::on_btnCopyAddress_clicked() {
+void AddressReceive::onBtnCopyAddressClicked() {
     if(!qAddress.isEmpty()) {
         GUIUtil::setClipboard(qAddress);
         openToastDialog("Address copied", this);

--- a/src/qt/veil/addressreceive.h
+++ b/src/qt/veil/addressreceive.h
@@ -22,7 +22,7 @@ public:
     ~AddressReceive();
 private Q_SLOTS:
     void onEscapeClicked();
-    void on_btnCopyAddress_clicked();
+    void onBtnCopyAddressClicked();
     void onBtnSaveClicked();
 private:
     Ui::AddressReceive *ui;

--- a/src/qt/veil/balance.cpp
+++ b/src/qt/veil/balance.cpp
@@ -47,7 +47,7 @@ Balance::Balance(QWidget *parent, BitcoinGUI* gui) :
     connect(ui->btnBalance, SIGNAL(clicked()), this, SLOT(onBtnBalanceClicked()));
     connect(ui->btnUnconfirmed, SIGNAL(clicked()), this, SLOT(onBtnUnconfirmedClicked()));
     connect(ui->btnImmature, SIGNAL(clicked()), this, SLOT(onBtnImmatureClicked()));
-    connect(ui->copyAddress, SIGNAL(clicked()), this, SLOT(on_btnCopyAddress_clicked()));
+    connect(ui->copyAddress, SIGNAL(clicked()), this, SLOT(onBtnCopyAddressClicked()));
 
 }
 
@@ -69,7 +69,7 @@ void Balance::onBtnImmatureClicked() {
 }
 
 
-void Balance::on_btnCopyAddress_clicked() {
+void Balance::onBtnCopyAddressClicked() {
     GUIUtil::setClipboard(qAddress);
     openToastDialog("Address copied", mainWindow);
 }

--- a/src/qt/veil/balance.h
+++ b/src/qt/veil/balance.h
@@ -36,7 +36,7 @@ public Q_SLOTS:
     void onBtnBalanceClicked();
     void onBtnUnconfirmedClicked();
     void onBtnImmatureClicked();
-    void on_btnCopyAddress_clicked();
+    void onBtnCopyAddressClicked();
 
 private:
     Ui::Balance *ui;

--- a/src/qt/veil/receivewidget.cpp
+++ b/src/qt/veil/receivewidget.cpp
@@ -63,12 +63,12 @@ ReceiveWidget::ReceiveWidget(QWidget *parent, WalletView* walletView) :
 
     ui->labelAddress->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
-    connect(ui->btnCopy, SIGNAL(clicked()), this, SLOT(on_btnCopyAddress_clicked()));
+    connect(ui->btnCopy, SIGNAL(clicked()), this, SLOT(onBtnCopyAddressClicked()));
     connect(ui->btnCreate, SIGNAL(clicked()), this, SLOT(generateNewAddressClicked()));
 
 }
 
-void ReceiveWidget::on_btnCopyAddress_clicked() {
+void ReceiveWidget::onBtnCopyAddressClicked() {
     if(!qAddress.isEmpty()) {
         GUIUtil::setClipboard(qAddress);
         openToastDialog("Address copied", mainWindow->getGUI());

--- a/src/qt/veil/receivewidget.cpp
+++ b/src/qt/veil/receivewidget.cpp
@@ -203,6 +203,10 @@ void ReceiveWidget::hideEvent(QHideEvent *event){
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
+void ReceiveWidget::hideThisWidget(){
+    this->hide();
+}
+
 ReceiveWidget::~ReceiveWidget()
 {
     delete ui;

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -30,6 +30,7 @@ public:
 public Q_SLOTS:
     void on_btnCopyAddress_clicked();
     void generateNewAddressClicked();
+    void hideThisWidget();
 
 private:
     Ui::ReceiveWidget *ui;

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -28,7 +28,7 @@ public:
     void refreshWalletStatus();
 
 public Q_SLOTS:
-    void on_btnCopyAddress_clicked();
+    void onBtnCopyAddressClicked();
     void generateNewAddressClicked();
     void hideThisWidget();
 

--- a/src/qt/veil/settings/settingswidget.cpp
+++ b/src/qt/veil/settings/settingswidget.cpp
@@ -276,6 +276,10 @@ void SettingsWidget::hideEvent(QHideEvent *event){
     connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
+void SettingsWidget::hideThisWidget(){
+    this->hide();
+}
+
 void SettingsWidget::setWalletModel(WalletModel *model){
     this->walletModel = model;
 

--- a/src/qt/veil/settings/settingswidget.h
+++ b/src/qt/veil/settings/settingswidget.h
@@ -40,6 +40,7 @@ private Q_SLOTS:
     void onAdvanceClicked();
     void onCheckStakingClicked(bool res);
     void onLabelStakingClicked();
+    void hideThisWidget();
 private:
     Ui::SettingsWidget *ui;
     WalletView *mainWindow;


### PR DESCRIPTION
### Problem
Clicking on an address in the Address Book page to pull up the Copy|Edit menu generates "No matching signal" errors in debug.log the first time you use the menu.

### Root Cause
The Qt MetaObject `connectSlotsByName` searches for `connect()` code with slot objects that conform to the format `on_<object-name>_<signal-name>`.  Since the signals for that pulldown (`on_btnCopyAddress_clicked()`, `on_btnEditAddress_clicked()` and `on_btnDeleteAddress_clicked()`) conformed to that format; connectSlotsByName picked them up when they shouldn't have been.

### Solution
Rename these slots in the format `on<Object-name>Clicked` to avoid moc from picking them up inadvertently.

### Additional Scope Included
Several other instances of the same issue were found and corrected in this PR.

_Also included in this PR:_ (https://github.com/Veil-Project/veil/commit/ed31991faf0acddd65e48fe1e22ab06730a5ff5b)
**Problem**
Clicking away from certain pages in the QT wallet generates a "no such slot[...]hideThisWidget()" error in the log file.

**Root Cause**
The fade out logic added to the Settings, Receive and Address Book pages was found on the internet, and the comment of "now implement a slot called hideThisWidget()" was removed and not implemented.   In one instance, an additional "->hide()" call was added. 

**Solution**
Rather than remove the connect for the finish signal, `hideThisWidget()` was implemented in each of the three cases to implicitly hide the widget on the finish signal; and thus provides the infrastructure for further effects to be added in the future if desired.

### Bounty PR
#541 

### Bounty Payment Address
`sv1qqpj9l2f883k7ucs88xdzrcuus8wr6jzrnk85quv3p2u90zwyy6d5tqpq0fl2ksmvlsf5hfddf8ezqnph5q6zf05cmac28g6ytafdzp8aufsuqqqwk9ep3`

### Unit Testing Results
**With v1.0.3 Qt Wallet**
1. Start QT Wallet
2. observe during startup, near the end of loading" connect slots by name errors for the copy address button and the address book button.
```
2019-08-11T14:43:38Z CleanBlockIndexGarbage: Erasing 37481 irrelivant indexes
2019-08-11T14:43:40Z GUI: QMetaObject::connectSlotsByName: No matching signal for on_btnCopyAddress_clicked()
2019-08-11T14:43:40Z GUI: QMetaObject::connectSlotsByName: No matching signal for on_addressBookButton_clicked()
2019-08-11T14:43:48Z New outbound peer connected: version: 70024, blocks=310408, peer=4
```
3. click to the "receive" page
4. click to the "address book" page
5. Observe "no such slot" error when leaving the "receive" page
```
2019-08-11T14:44:42Z GUI: QObject::connect: No such slot ReceiveWidget::hideThisWidget() in qt/veil/receivewidget.cpp:207
2019-08-11T14:44:42Z GUI: QObject::connect:  (receiver name: 'ReceiveWidget')
```
6. click on an address in the address book
7. Observe 3 "no matching signal" errors when the "copy/edit" menu pops up (one for copy, one for edit, and one for delete)
```
2019-08-11T14:45:25Z GUI: QMetaObject::connectSlotsByName: No matching signal for on_btnCopyAddress_clicked()
2019-08-11T14:45:25Z GUI: QMetaObject::connectSlotsByName: No matching signal for on_btnEditAddress_clicked()
2019-08-11T14:45:25Z GUI: QMetaObject::connectSlotsByName: No matching signal for on_btnDeleteAddress_clicked()
```
8. click to the "settings" page
9. Observe "no such slot" error when leaving the "address book" page
```
2019-08-11T14:48:00Z GUI: QObject::connect: No such slot AddressesWidget::hideThisWidget() in qt/veil/addresseswidget.cpp:285
2019-08-11T14:48:00Z GUI: QObject::connect:  (receiver name: 'AddressesWidget')
```
10. click away from the "settings" page
11. Observe "no such slot" error when leaving the "settings" page
```
2019-08-11T14:48:25Z GUI: QObject::connect: No such slot SettingsWidget::hideThisWidget() in qt/veil/settings/settingswidget.cpp:276
2019-08-11T14:48:25Z GUI: QObject::connect:  (receiver name: 'SettingsWidget')
```

** With PR code loaded**
Restart wallet and repeat 1-11 above; observe none of the errors are seen.