### PR TITLE
[QT] Fix address creation on Receive tab

### DIFF
--- a/src/qt/veil/receivewidget.cpp
+++ b/src/qt/veil/receivewidget.cpp
@@ -81,17 +81,17 @@ void ReceiveWidget::on_btnCopyAddress_clicked() {
 }
 
 void ReceiveWidget::generateNewAddressClicked(){
-    if(generateNewAddress()) openToastDialog("Address generated", mainWindow->getGUI());
+    if(generateNewAddress(true)) openToastDialog("Address generated", mainWindow->getGUI());
     else openToastDialog("Wallet Encrypted, please unlock it first", mainWindow->getGUI());
 }
 
-bool ReceiveWidget::generateNewAddress(){
+bool ReceiveWidget::generateNewAddress(bool isOnDemand){
     // Address
     interfaces::Wallet& wallet = walletModel->wallet();
 
     std::string strAddress;
     std::vector<interfaces::WalletAddress> addresses = wallet.getLabelAddress("stealth");
-    if(!addresses.empty()) {
+    if(!isOnDemand && !addresses.empty()) {
         interfaces::WalletAddress address = addresses[0];
         if (address.dest.type() == typeid(CStealthAddress)){
             bool fBech32 = true;

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -44,7 +44,7 @@ private:
     CPubKey newKey;
     QString qAddress;
 
-    bool generateNewAddress();
+    bool generateNewAddress(bool isOnDemand = false);
 };
 
 #endif // RECEIVEWIDGET_H


### PR DESCRIPTION
### Problem
Clicking the "Generate Address" circle arrow icon in the bottom left of the Receive screen shows a pop up for "address generated" but doesn't generate a new address.

### Root Cause
`ReceiveWidget::generateNewAddress()` has multiple uses.  It's called by `setWalletModel()`, `refreshWalletStatus()`, and when you click on the "Generate Address" icon.  The first use is to generate a new address if you don't already have one.  The second is to get the label of your initial address.  These two uses required the original `generateNewAddress()` to need a change; so that it wouldn't create a new address every time you started the wallet.

That fix introduced the issue in question.  Because the fix was made by not generating a new address if an address already exists.  Since the nature of having the wallet up and running means you have an address; a new address wasn't created.

### Solution
Add a parameter to the function, `bOnDemand`, that defaults to false so that the other two cases don't have to change their call.  For the click action, add the "true" parameter; and conditionalize the address existence check.  Now the other two uses will pass through the same code it had before; but the on clicked address creation will go down the path intended.

### Bounty PR
#509 

### Bounty Payment Address
`sv1qqpj9l2f883k7ucs88xdzrcuus8wr6jzrnk85quv3p2u90zwyy6d5tqpq0fl2ksmvlsf5hfddf8ezqnph5q6zf05cmac28g6ytafdzp8aufsuqqqwk9ep3`

### Unit Testing Results
Very simple
1. Click the generate address icon on the Receive tab
2. Observe the "Address generated" result
3. Observe the QR code and address change.
3. Change to the Address Book tab to confirm the newly created address has been added.