### PR TITLE
[Qt] Align text in the center of the progress bar.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1413,6 +1413,9 @@ void BitcoinGUI::showProgress(const QString &title, int nProgress)
     if (nProgress == 0)
     {
         progressDialog = new QProgressDialog(title, "", 0, 100);
+        QProgressBar* bar = new QProgressBar(progressDialog);
+        bar->setObjectName("progressDialogBar");
+        progressDialog->setBar(bar);
         progressDialog->setWindowModality(Qt::ApplicationModal);
         progressDialog->setMinimumDuration(0);
         progressDialog->setCancelButton(0);

--- a/src/qt/res/css/main.css
+++ b/src/qt/res/css/main.css
@@ -190,6 +190,10 @@ QProgressBar {
     qproperty-alignment: AlignBottom AlignRight;
 }
 
+#progressDialogBar {
+    qproperty-alignment: AlignCenter;
+}
+
 #progressBar {
     border: 1px solid black;
     text-align: top;


### PR DESCRIPTION
fixes #577 

This gives the progress bar that is called in the small progress dialog its own styling for text alignment.