### PR TITLE
Fix formatting of ztracker remove pending

### DIFF
--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -365,6 +365,7 @@ void CzTracker::RemovePending(const uint256& txid)
 
 bool CzTracker::UpdateStatusInternal(const std::set<uint256>& setMempool, const std::map<uint256, uint256>& mapMempoolSerials, CMintMeta& mint)
 {
+    LOCK(cs_update_status);
     //! Check whether this mint has been spent and is considered 'pending' or 'confirmed'
     // If there is not a record of the block height, then look it up and assign it
     uint256 txidMint;

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -348,16 +348,19 @@ void CzTracker::SetPubcoinNotUsed(const PubCoinHash& hashPubcoin)
 void CzTracker::RemovePending(const uint256& txid)
 {
     arith_uint256 hashSerial;
-    for (auto it : mapPendingSpends) {
+    SerialHash hashToRemove;
+    for (auto const& it : mapPendingSpends) {
         if (it.second == txid) {
             hashSerial = UintToArith256(it.first);
+            hashToRemove = it.first;
             break;
         }
     }
 
-
     if (hashSerial > arith_uint256())
-        mapPendingSpends.erase(ArithToUint256(hashSerial));
+        if (mapPendingSpends.count(hashToRemove))
+            mapPendingSpends.erase(hashToRemove);
+
 }
 
 bool CzTracker::UpdateStatusInternal(const std::set<uint256>& setMempool, const std::map<uint256, uint256>& mapMempoolSerials, CMintMeta& mint)

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -57,7 +57,7 @@ public:
     void Clear();
     mutable CCriticalSection cs_modify_lock;
     mutable CCriticalSection cs_readlock;
-    mutable CCriticalSection cs_update_status;
+    mutable CCriticalSection cs_remove_pending;
     bool HasSpendCache(const uint256& hashSerial) EXCLUSIVE_LOCKS_REQUIRED(cs_readlock);
     CoinWitnessData* CreateSpendCache(const uint256& hashSerial) EXCLUSIVE_LOCKS_REQUIRED(cs_modify_lock);
     CoinWitnessData* GetSpendCache(const uint256& hashSerial) EXCLUSIVE_LOCKS_REQUIRED(cs_readlock);

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -57,6 +57,7 @@ public:
     void Clear();
     mutable CCriticalSection cs_modify_lock;
     mutable CCriticalSection cs_readlock;
+    mutable CCriticalSection cs_update_status;
     bool HasSpendCache(const uint256& hashSerial) EXCLUSIVE_LOCKS_REQUIRED(cs_readlock);
     CoinWitnessData* CreateSpendCache(const uint256& hashSerial) EXCLUSIVE_LOCKS_REQUIRED(cs_modify_lock);
     CoinWitnessData* GetSpendCache(const uint256& hashSerial) EXCLUSIVE_LOCKS_REQUIRED(cs_readlock);


### PR DESCRIPTION
The following segfault occurred on a node running veil. This is a potential fix to this segfault


```
[Thread 0x7ffef37fe700 (LWP 36705) exited]
[New Thread 0x7ffef37fe700 (LWP 36914)]
[Thread 0x7ffef37fe700 (LWP 36914) exited]
[New Thread 0x7ffef37fe700 (LWP 37562)]
[Thread 0x7ffef37fe700 (LWP 37562) exited]
[New Thread 0x7ffef37fe700 (LWP 38217)]
[Thread 0x7ffef37fe700 (LWP 38217) exited]
double free or corruption (fasttop)

Thread 26 "veil-httpworker" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fff98ff9700 (LWP 45833)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51        ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) backtrace
#0  0x00007ffff2f22e97 in __GI_raise (sig=sig@entry=6)
    at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff2f24801 in __GI_abort () at abort.c:79
#2  0x00007ffff2f6d897 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff309ab9a "%s\n") at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007ffff2f7490a in malloc_printerr (str=str@entry=0x7ffff309c828 "double free or corruption (fasttop)") at malloc.c:5350
#4  0x00007ffff2f7c004 in _int_free (have_lock=0, p=0x7ffef8155530, av=0x7ffef8000020) at malloc.c:4230
#5  0x00007ffff2f7c004 in __GI___libc_free (mem=0x7ffef8155540)
    at malloc.c:3124
#6  0x000055555597b93b in __gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<uint256 const, uint256> > >::deallocate(std::_Rb_tree_node<std::pair<uint256 const, uint256> >*, unsigned long) (this=<optimized out>, __p=0x7ffef8155540)
    at /usr/include/c++/7/ext/new_allocator.h:125
#7  0x000055555597b93b in std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<uint256 const, uint256> > > >::deallocate(std::allocator<std::_Rb_tree_node<std::pair<uint256 const, uint256> > >&, std::_Rb_tree_node<std::pair<uint256 const, uint256> >*, unsigned long) (__a=..., __n=1, __p=0x7ffef8155540)
    at /usr/include/c++/7/bits/alloc_traits.h:462

#8  0x000055555597b93b in std::_Rb_tree<uint256, std::pair<uint256 const, uint256>, std::_Select1st<std::pair<uint256 const, uint256> >, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::_M_put_node(std::_Rb_tree_nod---Type <return> to continue, or q <return> to quit---
e<std::pair<uint256 const, uint256> >*) (this=0x555556c0c728, __p=0x7ffef8155540) at /usr/include/c++/7/bits/stl_tree.h:592
#9  0x000055555597b93b in std::_Rb_tree<uint256, std::pair<uint256 const, uint256>, std::_Select1st<std::pair<uint256 const, uint256> >, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::_M_drop_node(std::_Rb_tree_node<std::pair<uint256 const, uint256> >*) (this=0x555556c0c728, __p=0x7ffef8155540) at /usr/include/c++/7/bits/stl_tree.h:659
#10 0x000055555597b93b in std::_Rb_tree<uint256, std::pair<uint256 const, uint256>, std::_Select1st<std::pair<uint256 const, uint256> >, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::_M_erase(std::_Rb_tree_node<std::pair<uint256 const, uint256> >*) (this=this@entry=0x555556c0c728, __x=0x7ffef8155540) at /usr/include/c++/7/bits/stl_tree.h:1858
#11 0x0000555555baeef5 in std::_Rb_tree<uint256, std::pair<uint256 const, uint256>, std::_Select1st<std::pair<uint256 const, uint256> >, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::clear() (this=0x555556c0c728) at /usr/include/c++/7/bits/stl_tree.h:1171

#12 0x0000555555baeef5 in std::_Rb_tree<uint256, std::pair<uint256 const, uint256>, std::_Select1st<std::pair<uint256 const, uint256> >, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::_M_erase_aux(std::_Rb_tree_const_iterator<std::pair<uint256 const, uint256> >, std::_Rb_tree_const_iterator<std::pair<uint256 const, uint256> >) (__last=
      {first = {<base_blob<256>> = {static WIDTH = 32, data = '\000' <repeats 25 times>, "\247\356\071\377\177\000"}, <No data fields>}, second = {<base_blob<25---Type <return> to continue, or q <return> to quit---
6>> = {static WIDTH = 32, data = "p\b\337\071\377\177\000\000\000\365\372\071\377\177\000\000\267\017", '\000' <repeats 13 times>}, <No data fields>}}, __first={first = {<base_blob<256>> = {static WIDTH = 32, data = "\005\371\254|\260/\220\353ed# \221\221\025\210\365_Y\216\367i=\352\231\006\016\202`ٜ"}, <No data fields>}, second = {<base_blob<256>> = {static WIDTH = 32, data = "ŏ9c\204\210\274\060C{\337k\357bۉ\033\026\347\001z\030\200\240\256!\275\251\316\002", <incomplete sequence \347>}, <No data fields>}}, this=0x555556c0c728)
    at /usr/include/c++/7/bits/stl_tree.h:2488
#13 0x0000555555baeef5 in std::_Rb_tree<uint256, std::pair<uint256 const, uint256>, std::_Select1st<std::pair<uint256 const, uint256> >, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::erase(uint256 const&) (this=this@entry=0x555556c0c728, __x=...) at /usr/include/c++/7/bits/stl_tree.h:2502
#14 0x0000555555ba86dd in std::map<uint256, uint256, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > >::erase(uint256 const&) (__x=..., this=0x555556c0c728) at /usr/include/c++/7/bits/stl_map.h:1062
#15 0x0000555555ba86dd in CzTracker::RemovePending(uint256 const&) (this=this@entry=0x555556c0c6e0, txid=...) at veil/zerocoin/ztracker.cpp:360
#16 0x0000555555ba933f in CzTracker::UpdateStatusInternal(std::set<uint256, std::less<uint256>, std::allocator<uint256> > const&, std::map<uint256, uint256, std::less<uint256>, std::allocator<std::pair<uint256 const, uint256> > > const&, CMintMeta&) (this=this@entry=0x555556c0c6e0, setMempool=std::set with 2 elements = {...}, mapMempoolSerials=std::map with 0 elements, mint=...)
    at veil/zerocoin/ztracker.cpp:386
---Type <return> to continue, or q <return> to quit---
#17 0x0000555555bacaf6 in CzTracker::ListMints(bool, bool, bool) (this=0x555556c0c6e0, fUnusedOnly=fUnusedOnly@entry=false, fMatureOnly=fMatureOnly@entry=false, fUpdateStatus=fUpdateStatus@entry=true) at veil/zerocoin/ztracker.cpp:503
#18 0x0000555555b132ee in CWallet::ListMints(bool, bool, bool) (this=this@entry=0x7fff3e6b18f0, fUnusedOnly=fUnusedOnly@entry=false, fMatureOnly=fMatureOnly@entry=false, fUpdateStatus=fUpdateStatus@entry=true) at wallet/wallet.cpp:2661
#19 0x0000555555b02b44 in ResetMints(CWallet*) (pwallet=pwallet@entry=0x7fff3e6b18f0) at wallet/rpczerocoin.cpp:789
#20 0x0000555555b05afa in rescanzerocoinwallet(JSONRPCRequest const&) (request=...) at wallet/rpczerocoin.cpp:905
#21 0x000055555592de67 in CRPCTable::execute(JSONRPCRequest const&) const (this=<optimized out>, request=...) at rpc/server.cpp:496
#22 0x0000555555a381ef in HTTPReq_JSONRPC(HTTPRequest*, std::__cxx11::string const&) (req=0x7ffee4766b50) at httprpc.cpp:194
#23 0x0000555555a3abdc in std::function<bool (HTTPRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(HTTPRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (__args#1="", __args#0=<optimized out>, this=0x7ffee59abaa0) at /usr/include/c++/7/bits/std_function.h:706
#24 0x0000555555a3abdc in HTTPWorkItem::operator()() (this=0x7ffee59aba70)
    at httpserver.cpp:54
#25 0x0000555555a3abdc in WorkQueue<HTTPClosure>::Run() (this=0x7fffbc001b00)
    at httpserver.cpp:113
---Type <return> to continue, or q <return> to quit---
#26 0x0000555555a3abdc in HTTPWorkQueueRun(WorkQueue<HTTPClosure>*) (queue=0x7fffbc001b00) at httpserver.cpp:334
#27 0x00007ffff394866f in  () at /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#28 0x00007ffff4d646db in start_thread (arg=0x7fff98ff9700)
    at pthread_create.c:463
#29 0x00007ffff300588f in clone ()
    at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) 

```