### PR TITLE
Fix Stake Miner Segfaults. Add checks for too many zcmints in tx/block.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -339,6 +339,8 @@ public:
         nHeightLightZerocoin = 335975;
         nValueBlacklist = (282125 + 60540) * COIN;
         nHeightEnforceBlacklist = 336413;
+        nPreferredMintsPerBlock = 70; //Miner will not include more than this many mints per block
+        nPreferredMintsPerTx = 15; //Do not consider a transaction as standard that includes more than this many mints
 
         /** RingCT/Stealth **/
         nDefaultRingSize = 11;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -124,6 +124,8 @@ public:
     int Zerocoin_RequiredStakeDepthV2() const { return nZerocoinRequiredStakeDepthV2; }
     int Zerocoin_OverSpendAdjustment(libzerocoin::CoinDenomination denom) const;
     CAmount ValueBlacklisted() const { return nValueBlacklist; }
+    int Zerocoin_PreferredMintsPerBlock() const { return nPreferredMintsPerBlock; }
+    int Zerocoin_PreferredMintsPerTransaction() const { return nPreferredMintsPerTx; }
 
     /** RingCT and Stealth **/
     int DefaultRingSize() const { return nDefaultRingSize; }
@@ -180,6 +182,8 @@ protected:
     int nRequiredAccumulation;
     int nDefaultSecurityLevel;
     CAmount nValueBlacklist;
+    int nPreferredMintsPerBlock;
+    int nPreferredMintsPerTx;
 
     //RingCT/Stealth
     int nDefaultRingSize;

--- a/src/miner.h
+++ b/src/miner.h
@@ -23,12 +23,21 @@ namespace Consensus { struct Params; };
 
 static const bool DEFAULT_PRINTPRIORITY = false;
 
+enum TemplateFlags
+{
+    TF_FAIL = 0,
+    TF_SUCCESS = (1 << 0),
+    TF_STAILTIP = (1 << 1),
+    TF_MEMPOOLFAIL = (1 << 2),
+};
+
 struct CBlockTemplate
 {
     CBlock block;
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOpsCost;
     std::vector<unsigned char> vchCoinbaseCommitment;
+    uint8_t nFlags;
 };
 
 // Container for tracking updates to ancestor feerate as we include (parent)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4866,7 +4866,8 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot)
 {
     AssertLockHeld(cs_main);
-    assert(pindexPrev && pindexPrev == chainActive.Tip());
+    if (!pindexPrev || pindexPrev != chainActive.Tip())
+        return error("%s: new block added to chain before staked block was fully packaged.", __func__);
     CCoinsViewCache viewNew(pcoinsTip.get());
     uint256 block_hash(block.GetHash());
     CBlockIndex indexDummy(block);

--- a/src/veil/proofofstake/kernel.cpp
+++ b/src/veil/proofofstake/kernel.cpp
@@ -78,7 +78,7 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
 
     //grab stake modifier
     uint64_t nStakeModifier = 0;
-    if (!stakeInput->GetModifier(nStakeModifier, chainActive.Tip()))
+    if (!stakeInput->GetModifier(nStakeModifier, pindexBest))
         return error("failed to get kernel stake modifier");
 
     bool fSuccess = false;

--- a/src/veil/proofofstake/stakeinput.cpp
+++ b/src/veil/proofofstake/stakeinput.cpp
@@ -140,7 +140,7 @@ int GetSampleBits(int nSampleCount)
 bool ZerocoinStake::GetModifier(uint64_t& nStakeModifier, const CBlockIndex* pindexChainPrev)
 {
     CBlockIndex* pindex = GetIndexFrom();
-    if (!pindex)
+    if (!pindex || !pindexChainPrev)
         return false;
 
     uint256 hashModifier;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -26,7 +26,7 @@
 //
 // WalletBatch
 //
-
+CCriticalSection cs_walletdb;
 bool WalletBatch::WriteName(const std::string& strAddress, const std::string& strName)
 {
     return WriteIC(std::make_pair(std::string("name"), strAddress), strName);
@@ -459,6 +459,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     DBErrors result = DBErrors::LOAD_OK;
 
     LOCK(pwallet->cs_wallet);
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -560,7 +561,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx)
 {
     DBErrors result = DBErrors::LOAD_OK;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -953,7 +954,7 @@ bool WalletBatch::WriteMintPoolPair(const CKeyID& hashMasterSeed, const uint256&
 std::map<CKeyID, std::vector<std::pair<uint256, uint32_t> > > WalletBatch::MapMintPool()
 {
     std::map<CKeyID, std::vector<std::pair<uint256, uint32_t> > > mapPool;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -1018,7 +1019,7 @@ std::map<CKeyID, std::vector<std::pair<uint256, uint32_t> > > WalletBatch::MapMi
 std::list<CDeterministicMint> WalletBatch::ListDeterministicMints()
 {
     std::list<CDeterministicMint> listMints;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -1072,7 +1073,7 @@ std::list<CDeterministicMint> WalletBatch::ListDeterministicMints()
 std::list<CZerocoinMint> WalletBatch::ListMintedCoins()
 {
     std::list<CZerocoinMint> listPubCoin;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -1126,7 +1127,7 @@ std::list<CZerocoinMint> WalletBatch::ListMintedCoins()
 std::list<CZerocoinSpend> WalletBatch::ListSpentCoins()
 {
     std::list<CZerocoinSpend> listCoinSpend;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -1191,7 +1192,7 @@ std::list<CBigNum> WalletBatch::ListSpentCoinsSerial()
 std::list<CZerocoinMint> WalletBatch::ListArchivedZerocoins()
 {
     std::list<CZerocoinMint> listMints;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
@@ -1244,7 +1245,7 @@ std::list<CZerocoinMint> WalletBatch::ListArchivedZerocoins()
 std::list<CDeterministicMint> WalletBatch::ListArchivedDeterministicMints()
 {
     std::list<CDeterministicMint> listMints;
-
+    LOCK(cs_walletdb);
     try {
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -160,6 +160,7 @@ protected:
     template <typename K, typename T>
     bool WriteIC(const K& key, const T& value, bool fOverwrite = true)
     {
+        LOCK(cs_walletdb);
         if (!m_batch.Write(key, value, fOverwrite)) {
             return false;
         }
@@ -170,6 +171,7 @@ protected:
     template <typename K>
     bool EraseIC(const K& key)
     {
+        LOCK(cs_walletdb);
         if (!m_batch.Erase(key)) {
             return false;
         }
@@ -289,6 +291,7 @@ public:
 protected:
     BerkeleyBatch m_batch;
     WalletDatabase& m_database;
+    CCriticalSection cs_walletdb;
 };
 
 //! Compacts BDB state so that wallet.dat is self-contained (if there are changes)


### PR DESCRIPTION
- Fix a few segfaults, mostly related to PoS.
- Lock the walletdb anytime it reads or modifies. There were a few cases of multithreaded access that caused a double free to be thrown.
- Consider any tx with more than 15 zerocoin mints as nonstandard.
- Don't include more than 70 zerocoinmints per block. This is still a very large amount of mints, it may be able to be reduced further in the future, or have a user configurable setting.
- Add some fail flags to the mining process. These do not do anything at the moment, but can help in the future if the miner should respond to certain failures in different ways.