### PR TITLE
[DOC] Corrected TravisCI badge, added release version and date badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Veil integration/staging tree
 =============================
 
-[![Build Status](https://travis-ci.org/Veil-Project/veil.svg?branch=master)](https://travis-ci.org/Veil-Project/veil)
+[![Build Status](https://travis-ci.com/Veil-Project/veil.svg?branch=master)](https://travis-ci.com/Veil-Project/veil?branch=master)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/veil-project/veil?color=%23001e58&cacheSeconds=3600)](https://github.com/Veil-Project/veil/releases)
+[![GitHub Release Date](https://img.shields.io/github/release-date/veil-project/veil?color=%23001e58&cacheSeconds=3600)](https://github.com/Veil-Project/veil/releases)
 
 https://veil-project.com
 


### PR DESCRIPTION
### Problem ###
The build indicator badge on the project repo page doesn't report the correct TravisCI build status.

### Root Cause ###
The badge URL is incorrect. 

### Solution ###
Corrected the badge URL.

### Additions ###
Added badges to display the last release version and date. 

### Unit Testing Results ###
Clicking the build badge will open https://travis-ci.com/Veil-Project/veil?branch=master
Clicking either release badge will open https://github.com/Veil-Project/veil/releases