### PR TITLE
[Testnet] Update testnet params and fix amount

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -422,7 +422,7 @@ public:
         vSeeds.emplace_back("veil-testnet.seed.fuzzbawls.pw"); // Fuzzbawls seeder - supports x1, x5, x9
         vSeeds.emplace_back("veil-testnet.seed2.fuzzbawls.pw"); // Fuzzbawls seeder - supports x1, x5, x9
         vSeeds.emplace_back("veilseedtestnet.veil-stats.com"); // Codeofalltrades seeder
-        vSeeds.emplace_back("138.68.236.164", "138.68.236.164"); // blondfrogs single IP
+        vSeeds.emplace_back("veil-testnet-seed.asoftwaresolution.com");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);

--- a/src/veil/budget.cpp
+++ b/src/veil/budget.cpp
@@ -152,7 +152,7 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
     }
 
     if (nBlockHeight == 1 && Params().NetworkIDString() != CBaseChainParams::MAIN)
-        nBlockReward += 15000000 * COIN;
+        nBlockReward += 15000000;
 
     nBlockReward *= COIN;
     nFounderPayment *= COIN;


### PR DESCRIPTION
When syncing with the latest code. Nodes were rejecting the block at height 1. This was because of a miss calculation on the amount. This PR fixes that, as well as adds another seed node for testnet