### PR TITLE
Add P2P version tracker & update warnings

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil Developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -16,6 +17,16 @@ static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 /** Default for BIP61 (sending reject messages) */
 static constexpr bool DEFAULT_ENABLE_BIP61 = true;
+
+extern bool fUpdateCheck;
+extern int nHigherVerPeers;
+extern int nCurrentVerPeers;
+extern int nLowerVerPeers;
+extern bool fShouldUpgrade;
+
+int CheckForUpdates(std::string addr, std::string ver);
+std::vector<int> ParseVersion(const std::string);
+void replaceAll(std::string& str, const std::string& from, const std::string& to);
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil Developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -108,6 +109,7 @@ void ClientModel::updateTimer()
 void ClientModel::updateNumConnections(int numConnections)
 {
     Q_EMIT numConnectionsChanged(numConnections);
+    Q_EMIT alertsChanged(getStatusBarWarnings());
 }
 
 void ClientModel::updateNetworkActive(bool networkActive)

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil Developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +11,7 @@
 
 CCriticalSection cs_warnings;
 std::string strMiscWarning GUARDED_BY(cs_warnings);
+bool fUpdateFound GUARDED_BY(cs_warnings) = false;
 bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
 bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
 
@@ -17,6 +19,12 @@ void SetMiscWarning(const std::string& strWarning)
 {
     LOCK(cs_warnings);
     strMiscWarning = strWarning;
+}
+
+void SetfUpdateFound(bool flag)
+{
+    LOCK(cs_warnings);
+    fUpdateFound = flag;
 }
 
 void SetfLargeWorkForkFound(bool flag)
@@ -55,6 +63,12 @@ std::string GetWarnings(const std::string& strFor)
     {
         strStatusBar = strMiscWarning;
         strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
+    }
+
+    if (fUpdateFound)
+    {
+        strStatusBar = "Over 50% of our peers are running a newer wallet version than yours. An update may be available.";
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Over 50% of our peers are running a newer wallet version than yours. An update may be available.");
     }
 
     if (fLargeWorkForkFound)

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil Developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +11,7 @@
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);
+void SetfUpdateFound(bool flag);
 void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);


### PR DESCRIPTION
This PR closes #404 by adding a check onto every new connection that measures and saves the connection's peer subversion, this can then be used to measure the average network version, and figure out if the client is "behind", "forward" or "current" in version integers, if the client is behind, the check will trigger a message in warnings.cpp which displays a warning of `"Over 50% of our peers are running a newer wallet version than yours. An update may be available."`

The update tracker is relatively simple, but the functions of it must be known clearly, so that it doesn't get abused by malicious actors, and doesn't false-positive on specific version integers.

- Atleast 50% of historical peers, must be a higher version before an update warning is triggered.
- Atleast 2 historical peers minimum must be a higher version before an update is considered.

This means at minimum, if you have 4 connections, two are older or matching wallets, two are new wallets higher than our own, the update warning **WILL** fire.

If you connect to only 1 peer, and they are a higher version, the update warning will **NOT** fire, due to the minimum requirement of 2 higher-ver peers, to help prevent false-positives.

No arbitrary data can be inserted into the update tracker, it will not display a URL or version text when an update triggers, it will just purely notify that an update may be possible, due to >50% of peers having higher subversions.

*This is a rebase and upgrade to the closed #627 PR which had two vulnerabilities. The new code removes the possibility to abuse such parsing bugs.*