### PR TITLE
[GUI] Explicitly disable Dark Mode appearance on macOS

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -99,6 +99,9 @@
 
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
+
+  <key>NSRequiresAquaSystemAppearance</key>
+    <string>True</string>
   
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>


### PR DESCRIPTION
### Problem ###
Bitcoin Core's gui is pretty broken for a someone using macOS in "Dark Mode"; the biggest issue being lots of white text on a white background, leaving most inputs, the rpc console etc unusable.

This is likely something we'll have to wait for Qt to fix/support, so it's probably easiest to just disable for now, rather than provide a broken UI; 

### Root Cause ###
Apple documentation on "Opting out of Dark Mode" is here.

>    If you need extra time to work on your app's Dark Mode support, you can temporarily opt out by including the NSRequiresAquaSystemAppearance key (with a value of true) in your app’s Info.plist file. Setting this key to true causes the system to ignore the user's preference and always apply a light appearance to your app.

### Solution ###
Disable dark mode

### Testing ###
1. Enable dark mode
2. Launch and use the wallet
3. Verify text is visible

fixes: #270  