### PR TITLE
[script][RPC] Properly parse and display zerocoin opcodes

### DIFF
--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -138,6 +139,10 @@ const char* GetOpName(opcodetype opcode)
     case OP_NOP8                   : return "OP_NOP8";
     case OP_NOP9                   : return "OP_NOP9";
     case OP_NOP10                  : return "OP_NOP10";
+
+    // zerocoin
+    case OP_ZEROCOINMINT           : return "OP_ZEROCOINMINT";
+    case OP_ZEROCOINSPEND          : return "OP_ZEROCOINSPEND";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -190,7 +190,7 @@ enum opcodetype
 };
 
 // Maximum value that an opcode can be
-static const unsigned int MAX_OPCODE = OP_NOP10;
+static const unsigned int MAX_OPCODE = OP_ZEROCOINSPEND;
 
 const char* GetOpName(opcodetype opcode);
 


### PR DESCRIPTION
### Problem
The scriptsig outputs from decoded RPC transactions show `OP_UNKNOWN` when displaying zerocoin transaction scripts.

### Root Cause
The opcodes were defined in script.h (0xc1 & 0xc2 respectively) but a corresponding mapping for decoding scriptsig did not have the proper mappings.

```
      "scriptSig": {
        "asm": "OP_UNKNOWN 453 822223105 OP_ROLL 9 OP_NUMEQUALVERIFY 628cde83026d23fd5dcb02bc9da72c344679b3aff034739897e80446304402200d12f9f7ff0af09db1e6eeed30497222ffe535c6 OP_CODESEPARATOR OP_MAX OP_UNKNOWN OP_UNKNOWN OP_UNKNOWN 57b1c8b9f103022042d1304dc0309ff8d5295846f3a7a8099794c9a2bab9559eff OP_DEPTH OP_NOP8 OP_SWAP OP_UNKNOWN 658fe803000000000000327acd580a5604bc6244d70ee681cf506e2edf4b95 b51600fc1465d8469519b64165c8c618a0c4751891b0875c1afae3554fe43a25b5f5c3cc52e4171ae1215a59c373fb55c10dc6c1a39622d50261d59837e1e9422db7227acdb4dd4443fb0000000000000000000000000000000000000000000000000000000000000000000000000000000000000280d7d60678bba434ffb5eaf16045c7b14b9047e789739f94c82957bac927bac8a0ccf4442a1b298163c8a0212922e919df899c2871d710265e5c83e1e5b15e6300b30fc67e53950ac313c5bb69affb827b3b6a4e59adb67143fd6d2aa92099010838e4958fded64ec568aeb27a8825ceeb8ae0ffae 62b880c0bbe08a15c9214020043b2035987a8726ad03004d556aabd5464995d8ff9269154145 -1 OP_2DROP OP_GREATERTHANOREQUAL [error]",
        "hex": "c202c50104012102317a599d34628cde83026d23fd5dcb02bc9da72c344679b3aff034739897e80446304402200d12f9f7ff0af09db1e6eeed30497222ffe535c6aba4c4d8f82157b1c8b9f103022042d1304dc0309ff8d5295846f3a7a8099794c9a2bab9559eff74b77cc71f658fe803000000000000327acd580a5604bc6244d70ee681cf506e2edf4b954ceab51600fc1465d8469519b64165c8c618a0c4751891b0875c1afae3554fe43a25b5f5c3cc52e4171ae1215a59c373fb55c10dc6c1a39622d50261d59837e1e9422db7227acdb4dd4443fb0000000000000000000000000000000000000000000000000000000000000000000000000000000000000280d7d60678bba434ffb5eaf16045c7b14b9047e789739f94c82957bac927bac8a0ccf4442a1b298163c8a0212922e919df899c2871d710265e5c83e1e5b15e6300b30fc67e53950ac313c5bb69affb827b3b6a4e59adb67143fd6d2aa92099010838e4958fded64ec568aeb27a8825ceeb8ae0ffae2662b880c0bbe08a15c9214020043b2035987a8726ad03004d556aabd5464995d8ff92691541454f6da238ef6582c72aba8d8f100ed9e7cbad216df3c0d6327fb993c45c0d3cb7755b758e258c01000000"
```

### Solution
Extend the MAX_OPCODE value to include the zerocoin opcodes; and include them in the `GetOpName()` mapping.

This was observed when evaluating RPC Commands, and since the decoding of zerocoin transactions will be necessary for chain history, it should be corrected.

This will be rebased to one commit when I get back to my linux machine.

### Unit Testing Results
1. look at a zerocoin transaction in the explorer and look at the raw data, you will see "OP_UNKNOWN" in the script-sig asm field in places.  
2. getrawtransaction followed by decoderawtransaction of the transaction in question; observe they now show the zerocoin opcodes.