### PR TITLE
[Qt] Remove hide() on hideEvents

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -569,5 +569,4 @@ void OverviewPage::hideEvent(QHideEvent *event){
     a->setEndValue(0);
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
-    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -1051,7 +1051,6 @@ void SendCoinsDialog::showEvent(QShowEvent *event){
     a->setEndValue(0);
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
-    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
 }
 
 SendConfirmationDialog::SendConfirmationDialog(const QString &title, const QString &text, int _secDelay,

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -281,11 +281,6 @@ void AddressesWidget::hideEvent(QHideEvent *event){
     a->setEndValue(0);
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
-    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
-}
-
-void AddressesWidget::hideThisWidget(){
-   this->hide();
 }
 
 // We override the virtual resizeEvent of the QWidget to adjust tables column

--- a/src/qt/veil/addresseswidget.h
+++ b/src/qt/veil/addresseswidget.h
@@ -56,7 +56,6 @@ private Q_SLOTS:
     void onNewAddressClicked();
     void onNewMinerAddressClicked();
     void onButtonChanged();
-    void hideThisWidget();
     void handleAddressClicked(const QModelIndex &index);
     virtual void showEvent(QShowEvent *event) override;
     virtual void hideEvent(QHideEvent *event) override;

--- a/src/qt/veil/receivewidget.cpp
+++ b/src/qt/veil/receivewidget.cpp
@@ -203,11 +203,6 @@ void ReceiveWidget::hideEvent(QHideEvent *event){
     a->setEndValue(0);
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
-    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
-}
-
-void ReceiveWidget::hideThisWidget(){
-    this->hide();
 }
 
 ReceiveWidget::~ReceiveWidget()

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -34,7 +34,6 @@ public:
 public Q_SLOTS:
     void onBtnCopyAddressClicked();
     void generateNewAddressClicked();
-    void hideThisWidget();
 
 private:
     Ui::ReceiveWidget *ui;

--- a/src/qt/veil/settings/settingswidget.cpp
+++ b/src/qt/veil/settings/settingswidget.cpp
@@ -273,11 +273,6 @@ void SettingsWidget::hideEvent(QHideEvent *event){
     a->setEndValue(0);
     a->setEasingCurve(QEasingCurve::OutBack);
     a->start(QPropertyAnimation::DeleteWhenStopped);
-    connect(a,SIGNAL(finished()),this,SLOT(hideThisWidget()));
-}
-
-void SettingsWidget::hideThisWidget(){
-    this->hide();
 }
 
 void SettingsWidget::setWalletModel(WalletModel *model){

--- a/src/qt/veil/settings/settingswidget.h
+++ b/src/qt/veil/settings/settingswidget.h
@@ -40,7 +40,6 @@ private Q_SLOTS:
     void onAdvanceClicked();
     void onCheckStakingClicked(bool res);
     void onLabelStakingClicked();
-    void hideThisWidget();
 private:
     Ui::SettingsWidget *ui;
     WalletView *mainWindow;


### PR DESCRIPTION
### Problem
When restoring the wallet from a minimized state, or when completely covered by other windows; the receive, addresses, and settings tabs don't redraw.

### Root Cause
This problem was introduced with PR #651 in response to Issue #541, where "no such slot" errors were generated when switching between windows.  The problem with the errors was a missing hideThisWidget() call.  That routine traditionally calls hide() to hide the widget.  However, when a widget is hidden on minimize, the showEvent() handler doesn't get called on restoration; so it didn't automatically redraw the widget.  One had to click away and back to get the showEvent() to trigger.

### Solution
After some research, it seems that hiding the widget isn't really necessary; so instead of putting conditions to prevent the hide when minimizing (and then dealing with all the other corner cases) the slot has been removed.  This was done to prevent the problem introduced with #651, and to also fix the same problem (no such slot) for the Overview and Send Coins tabs as well.

### Unit Testing Results
**With v1.0.4.7 Qt Wallet**
1. Start QT Wallet
2. Minimize wallet when on the Overview tab
3. observe "No such slot" errors in the log file.
4. restore focus to the window.
5. click to the "receive" tab
6. minimize and then restore the window
7. observe the screen is now blank
8. repeat for "addresses" and "settings" tabs.

**With PR code loaded**
Restart wallet and repeat 1-8 above; observe none of the errors and issues are seen.

closes #671 