### PR TITLE
[QT] Correct "view in explorer" tooltip style

### DIFF
--- a/src/qt/veil/forms/transactiondetaildialog.ui
+++ b/src/qt/veil/forms/transactiondetaildialog.ui
@@ -189,11 +189,12 @@
                                             <cursorShape>PointingHandCursor</cursorShape>
                                         </property>
                                         <property name="styleSheet">
-                                            <string notr="true">background-color:transparent;
-                                                color:rgb(106,148,255);
-                                                border:0;
-                                                background-repeat:no-repeat;
-                                                background-position:center;
+                                            <string notr="true">QPushButton {
+                                                    border:  none;
+                                                    background-color:#ffffff;
+                                                    color: #707070;
+                                                    font-size: 14px;
+                                                }
                                             </string>
                                         </property>
                                         <property name="text">

--- a/src/qt/veil/transactiondetaildialog.cpp
+++ b/src/qt/veil/transactiondetaildialog.cpp
@@ -22,6 +22,8 @@ TransactionDetailDialog::TransactionDetailDialog(QWidget *parent, TransactionRec
     ui(new Ui::TransactionDetailDialog)
 {
     ui->setupUi(this);
+    this->setStyleSheet(GUIUtil::loadStyleSheet());
+    
     // Titles
     ui->title->setProperty("cssClass" , "title");
     ui->labelAmount->setProperty("cssClass" , "label-detail");


### PR DESCRIPTION
### Problem ###
The view in explorer button on the transaction detail modal had tooltip style that didn't mastch the rest of the wallet. Depending on the OS the tooltip background would be black or transparent

### Root Cause ###
The tooltip styling on the modal was overriding the QT style sheet.

### Solution ###
Removed the custom tooltip style. Set the QT style sheet.

### Unit Testing Results ###
1. Navigate to the transaction listing.
2. Open a transaction 
3. Hover your mouse over the eye icon.
4. Verify the View in Explorer tooltip is displayed on a blue background with white text.

Before:
![image](https://user-images.githubusercontent.com/46700212/69159035-ede3bf80-0aac-11ea-9162-3c42b1996419.png)

After:
![image](https://user-images.githubusercontent.com/46700212/69159585-c3463680-0aad-11ea-8c54-25bf931989d4.png)

fixed #685 

More information about the QT bug can be found here: #515 