### PR TITLE
[RPC] correct listunspent for ct, ringct and zerocoin

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -433,6 +434,8 @@ public:
 
     CTxOut ToTxOut() const { return CTxOut(nValue, scriptPubKey); }
 };
+
+static const uint32_t EPHEMERAL_PUBKEY_LENGTH = 33;
 
 class CTxOutCT : public CTxOutBase
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -2357,13 +2358,14 @@ UniValue OutputRecordToUniValue(AnonWallet* panonwallet, const COutputRecord* re
         obj.pushKV("have_address", haveAddress);
 
         CKeyID keyID;
+        keyID.SetNull();
         if (dest.type() == typeid(CKeyID)) {
             keyID = boost::get<CKeyID>(dest);
         } else {
             obj.pushKV("is_keyid", false);
         }
 
-        if (haveAddress) {
+        if (haveAddress && !keyID.IsNull()) {
             CStealthAddress sx;
             if (panonwallet->GetStealthAddress(keyID, sx)) {
                 obj.pushKV("stealth_address", sx.ToString(true));
@@ -2582,9 +2584,9 @@ static UniValue gettransaction(const JSONRPCRequest& request)
                     auto mi = pwalletAnon->mapRecords.find(txin.prevout.hash);
                     obj_vin.pushKV("has_tx_rec", bool(mi != pwalletAnon->mapRecords.end()));
                     if (mi != pwalletAnon->mapRecords.end()) {
-                        const COutputRecord *oR = mi->second.GetOutput(txin.prevout.n);
-                        if (oR)
-                            obj_vin.pushKV("output_record", OutputRecordToUniValue(pwalletAnon, oR));
+                        const COutputRecord *outputRecord = mi->second.GetOutput(txin.prevout.n);
+                        if (outputRecord != nullptr)
+                            obj_vin.pushKV("output_record", OutputRecordToUniValue(pwalletAnon, outputRecord));
                     }
                 }
             }
@@ -2618,8 +2620,8 @@ static UniValue gettransaction(const JSONRPCRequest& request)
             CTxOutRingCT* outRingCT = (CTxOutRingCT*)pout.get();
 
             std::vector<uint8_t> vchEphemPK;
-            vchEphemPK.resize(33);
-            memcpy(&vchEphemPK[0], &outRingCT->vData[0], 33);
+            vchEphemPK.resize(EPHEMERAL_PUBKEY_LENGTH);
+            memcpy(&vchEphemPK[0], &outRingCT->vData[0], EPHEMERAL_PUBKEY_LENGTH);
             obj_out.pushKV("ephemeral_pubkey", HexStr(vchEphemPK));
         } else if (pout->GetType() == OUTPUT_DATA) {
             obj_out.pushKV("type", "data");
@@ -2635,9 +2637,9 @@ static UniValue gettransaction(const JSONRPCRequest& request)
         auto mi = pwalletAnon->mapRecords.find(hash);
         obj_out.pushKV("has_tx_rec", bool(mi != pwalletAnon->mapRecords.end()));
         if (mi != pwalletAnon->mapRecords.end()) {
-            const COutputRecord *oR = mi->second.GetOutput(i);
-            if (oR)
-                obj_out.pushKV("output_record", OutputRecordToUniValue(pwalletAnon, oR));
+            const COutputRecord *outputRecord = mi->second.GetOutput(i);
+            if (outputRecord != nullptr)
+                obj_out.pushKV("output_record", OutputRecordToUniValue(pwalletAnon, outputRecord));
         }
         arr_vout.push_back(obj_out);
     }
@@ -3611,7 +3613,8 @@ static UniValue listunspent(const JSONRPCRequest& request)
             "\nResult\n"
             "[                   (array of json object)\n"
             "  {\n"
-            "    \"txid\" : \"txid\",          (string) the transaction id \n"
+            "    \"type\" : \"type\",          (string) the transaction type\n"
+            "    \"txid\" : \"txid\",          (string) the transaction id\n"
             "    \"vout\" : n,               (numeric) the vout value\n"
             "    \"address\" : \"address\",    (string) the veil address\n"
             "    \"label\" : \"label\",        (string) The associated label, or \"\" for the default label\n"
@@ -3705,17 +3708,56 @@ static UniValue listunspent(const JSONRPCRequest& request)
 
     LOCK(pwallet->cs_wallet);
 
+    auto *pwalletAnon = pwallet->GetAnonWallet();
     for (const COutput& out : vecOutputs) {
         CTxDestination address;
         CScript scriptPubKey;
-        if (!out.tx->tx->vpout[out.i]->GetScriptPubKey(scriptPubKey))
-            continue;
+        auto pout = out.tx->tx->vpout[out.i];
+        auto mi = pwalletAnon->mapRecords.find(out.tx->tx->GetHash());
+        const COutputRecord *outputRecord = nullptr;
+        if (mi != pwalletAnon->mapRecords.end())
+            outputRecord = mi->second.GetOutput(out.i);
+
+        const OutputTypes outType = (OutputTypes) pout->GetType();
+        if (!pout->GetScriptPubKey(scriptPubKey)) {
+            bool foundKey = false;
+            // check for anon script
+            if (outType == OUTPUT_RINGCT) {
+                if (outputRecord != nullptr) {
+                    scriptPubKey = outputRecord->scriptPubKey;
+                    foundKey = true;
+                }
+            }
+            if (!foundKey)  {
+                continue;
+            }
+        }
         bool fValidAddress = ExtractDestination(scriptPubKey, address);
 
-        if (destinations.size() && (!fValidAddress || !destinations.count(address)))
+        if (destinations.size() && (!fValidAddress || !destinations.count(address))) {
             continue;
+        }
 
         UniValue entry(UniValue::VOBJ);
+
+        // push a type on so it's not so confusing
+        switch (outType) {
+          case OUTPUT_STANDARD:
+            if (pout->IsZerocoinMint())
+                entry.pushKV("type", "zerocoinmint");
+            else
+                entry.pushKV("type", "basecoin");
+            break;
+          case OUTPUT_RINGCT:
+            entry.pushKV("type", "ringct");
+            break;
+          case OUTPUT_CT:
+            entry.pushKV("type", "ct");
+            break;
+          default:
+            entry.pushKV("type", "unknown");
+        }
+
         entry.pushKV("txid", out.tx->GetHash().GetHex());
         entry.pushKV("vout", out.i);
 
@@ -3723,6 +3765,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
             entry.pushKV("address", EncodeDestination(address));
 
             auto i = pwallet->mapAddressBook.find(address);
+
             if (i != pwallet->mapAddressBook.end()) {
                 entry.pushKV("label", i->second.name);
                 if (IsDeprecatedRPCEnabled("accounts")) {
@@ -3733,14 +3776,66 @@ static UniValue listunspent(const JSONRPCRequest& request)
             if (scriptPubKey.IsPayToScriptHash()) {
                 const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
-                if (pwallet->GetCScript(hash, redeemScript)) {
+                if (pwallet->GetCScript(hash, redeemScript))
                     entry.pushKV("redeemScript", HexStr(redeemScript.begin(), redeemScript.end()));
+            }
+
+            // if not basecoin, get the stealth address (and destination if ct)
+            if ((outputRecord != nullptr) && !outputRecord->IsBasecoin()) {
+                CKeyID keyID;
+                keyID.SetNull();
+                if (address.type() == typeid(CKeyID)) {
+                    keyID = boost::get<CKeyID>(address);
+                }
+
+                if (!keyID.IsNull()) {
+                    CStealthAddress sx;
+                    if (pwalletAnon->GetStealthAddress(keyID, sx)) {
+                        entry.pushKV("stealth_address", sx.ToString(true));
+                    } else {
+                        if (pwalletAnon->GetStealthLinked(keyID, sx)) {
+                            entry.pushKV("stealth_address", sx.ToString(true));
+                            entry.pushKV("stealth_destination", EncodeDestination(address, true));
+                        }
+                    }
                 }
             }
         }
 
         entry.pushKV("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
-        entry.pushKV("amount", ValueFromAmount(out.tx->tx->vpout[out.i]->GetValue()));
+
+        // If RingCT, get the ephemeral pubkey
+        if (outType == OUTPUT_RINGCT) {
+            CTxOutRingCT * outRingCT = (CTxOutRingCT *)pout.get();
+            std::vector<uint8_t> vchEphemPK;
+            vchEphemPK.resize(EPHEMERAL_PUBKEY_LENGTH);
+            memcpy(&vchEphemPK[0], &outRingCT->vData[0], EPHEMERAL_PUBKEY_LENGTH);
+            entry.pushKV("ephemeral_pubkey", HexStr(vchEphemPK));
+        }
+
+        // If zerocoin, add hash fields
+        if (pout->IsZerocoinMint()) {
+            libzerocoin::PublicCoin pubcoin(Params().Zerocoin_Params());
+            if (OutputToPublicCoin(pout.get(), pubcoin)) {
+                uint256 hashPubcoin = GetPubCoinHash(pubcoin.getValue());
+                entry.pushKV("pubcoinhash", hashPubcoin.GetHex());
+                if (pwallet->IsMyMint(pubcoin.getValue())) {
+                    CMintMeta meta;
+                    if (pwallet->GetMintMeta(hashPubcoin, meta)) {
+                        entry.pushKV("serialhash", meta.hashSerial.GetHex());
+                    }
+                }
+            }
+        }
+
+        // For CT and RingCT, need to get the amount differently.
+        if ((outType == OUTPUT_RINGCT) || (outType == OUTPUT_CT)) {
+            if (outputRecord != nullptr)
+                entry.pushKV("amount", ValueFromAmount(outputRecord->GetAmount()));
+        } else {
+            entry.pushKV("amount", ValueFromAmount(out.tx->tx->vpout[out.i]->GetValue()));
+        }
+
         entry.pushKV("confirmations", out.nDepth);
         entry.pushKV("spendable", out.fSpendable);
         entry.pushKV("solvable", out.fSolvable);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3703,7 +3703,10 @@ static UniValue listunspent(const JSONRPCRequest& request)
     std::vector<COutput> vecOutputs;
     {
         LOCK2(cs_main, pwallet->cs_wallet);
-        pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
+        pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount,
+                                nMaximumAmount, nMinimumSumAmount, nMaximumCount,
+                                nMinDepth, nMaxDepth, true,
+                                FILTER_BASECOIN|FILTER_ZEROCOIN|FILTER_CT|FILTER_RINGCT);
     }
 
     LOCK(pwallet->cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -540,7 +541,6 @@ public:
     // Get the marginal bytes if spending the specified output from this transaction
     int GetSpendSize(unsigned int out, bool use_max_sig = false) const
     {
-        assert(tx->vpout[out]->IsStandardOutput());
         CTxOut txout;
         txout.nValue = tx->vpout[out]->GetValue();
         txout.scriptPubKey = *tx->vpout[out]->GetPScriptPubKey();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -77,6 +77,12 @@ static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 
+//! mask bits for coin type
+static const uint8_t FILTER_BASECOIN = 0x01;
+static const uint8_t FILTER_ZEROCOIN = 0x02;
+static const uint8_t FILTER_CT       = 0x04;
+static const uint8_t FILTER_RINGCT   = 0x08;
+
 typedef std::vector<std::pair<uint32_t, bool> > BIP32Path;
 typedef std::map<libzerocoin::CoinDenomination, CAmount> ZerocoinSpread;
 typedef std::tuple<CWalletTx, std::vector<CDeterministicMint>, std::vector<CZerocoinMint>> CommitData;
@@ -945,7 +951,11 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999, bool fIncludeImmature=false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr,
+                        const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY,
+                        const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0,
+                        const int nMinDepth = 0, const int nMaxDepth = 9999999, bool fIncludeImmature=false,
+                        const uint8_t filterType = FILTER_BASECOIN) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.


### PR DESCRIPTION
### Problem
`listunspent` only returns basecoin results

### Root Cause
`listunspent` specifically skipped anything that wasn't a standard transaction (skipping CT and RingCT) and skipped zerocoin transactions.

### Solution
Add support for CT, RingCT and zerocoin into `listunspent`.

### Release Notes
- [RPC] listunspent now returns the list of all unspent transactions, rather than just basecoin.
- [RPC] listunspent now properly functions when specifying value based query options.
- [RPC] listunspent now returns unspent immature transactions, not just mature transactions.

### Developer Notes
A few different places in the code use `AvailableCoins()` to collect the unspent list of basecoins, and use other methods to collect the list of other coin  types.  To handle this, a parameter was added with a bitmask to select what coin types you would like `AvailableCoins()` to collect.  During refactoring efforts, these alternate methods of collecting the coin lists should be migrated to use `AvailableCoins()`.  For now the default for the bitmask is `FILTER_BASECOIN`, so that the other callers aside of `listunspent` function as they have been.

### Known Issues
- Codewise: a few places should eventually have the base code updated to handle zerocoin and stealth transactions.  Things like "isSpent" and "GetValue", etc.   This work can be done as a later refractoring PR.
- The help documentation for `listunspent` needs some work, including the additional fields added.  This also isn't high priority at the moment, and there's a lot of other RPC commands that need revisions to their help documentation.  That can be rolled into a separate PR as well.

### Fixes of note
A couple issues were uncovered with this work.  
- First, the value calculations used for the query_options were limited to a signed 32 bit number; and as such likely don't work when the value of the unspent transaction is greater than 22 veil.  Likewise; values that would wrap and fall into a negative number would be skipped by the default filter (0 to 300m).
- Secondly; a parameter was missing in the creation of the COutput object; thus effecting when watched outputs are being used.

### Issue
Part of #682 

### Unit Testing Results
Rather than blasting with a ton of outputs; some things to note:
1) watch only addresses were not tested
2) zerocoin spends had to be handled specifically.  It has been tested, but could probably use more.
3) spent ringct transactions also had to be handled specifically; likewise tested.
4) AvailableCoins is used several different places, like selecting the outputs for spending, as well as some places where it collects the wallet value.  Aside of a full regression test, some of these functions should be checked as well.

Some techniques used
1) filtering by block and comparing with `gettransaction` for that block
2) insuring zerocoin has the proper `pubcoinhash` and `serialhash`, and accurately reflects `listmintedzerocoins`
3) insuring ringct and ct have the proper `stealth_address` and ct has `stealth_destination`.
4) comparing the amounts of each type to `getamounts`

Some of the linux commands used
`./veil-cli listunspent | grep -B 1 -A 12 \"ct`
`./veil-cli listunspent | grep -B 1 -A 12 \"ringct | grep -e lth_ad -e amount`
`./veil-cli listunspent | grep -B 1 -A 12 \"zero | grep serial | sort`
` ./veil-cli listunspent 0 999999 [] true '{ "maximumAmount": 0.05 }' | grep -B 1 -A 12 \"ringct | grep -e stealth_address -e amou`
`./veil-cli listunspent 0 100 | grep txid`
