### PR TITLE
[Network] Update seed nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -256,9 +257,22 @@ public:
         assert(genesis.hashMerkleRoot == uint256S("0xa6d192b185dc382a8d7e7dbb5f7a212a54cb93b94e6b9e08869d9169c04993b0"));
         assert(genesis.hashVeilData == uint256S("0x8b7f273daa09d2d0fa6abeb27a2a87a4ee6c947ac04931f4f3b6b83f1cf7ad3f"));
 
-        vSeeds.emplace_back("veilseed.presstab.pw");
-        vSeeds.emplace_back("veil.seed.fuzzbawls.pw"); // Fuzzbawls seeder - supports x1, x5, x9
-        vSeeds.emplace_back("veil.seed2.fuzzbawls.pw"); // Fuzzbawls seeder - supports x1, x5, x9
+        vSeeds.emplace_back("node01.veil-project.com");
+        vSeeds.emplace_back("node02.veil-project.com");
+        vSeeds.emplace_back("node03.veil-project.com");
+        vSeeds.emplace_back("node04.veil-project.com");
+        vSeeds.emplace_back("node05.veil-project.com");
+        vSeeds.emplace_back("node06.veil-project.com");
+        vSeeds.emplace_back("node07.veil-project.com");
+        vSeeds.emplace_back("node08.veil-project.com");
+        vSeeds.emplace_back("node09.veil-project.com"); // Mimir seeder
+        vSeeds.emplace_back("node10.veil-project.com"); // Codeofalltrades seeder
+        vSeeds.emplace_back("node11.veil-project.com"); // CaveSpectre seeder
+        // single point DNS failure backups
+        vSeeds.emplace_back("seed.veil.rune.network");             // Mimir seeder
+        vSeeds.emplace_back("veilseed.codeofalltrades.com");       // Codeofalltrades seeder
+        vSeeds.emplace_back("veilseed.veil-stats.com");            // Codeofalltrades seeder
+        vSeeds.emplace_back("veil-seed.pontificatingnobody.com");  // CaveSpectre seeder
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,70);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
@@ -418,11 +432,19 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
 
-        vSeeds.emplace_back("veilseedtestnet.presstab.pw");
-        vSeeds.emplace_back("veil-testnet.seed.fuzzbawls.pw"); // Fuzzbawls seeder - supports x1, x5, x9
-        vSeeds.emplace_back("veil-testnet.seed2.fuzzbawls.pw"); // Fuzzbawls seeder - supports x1, x5, x9
-        vSeeds.emplace_back("veilseedtestnet.veil-stats.com"); // Codeofalltrades seeder
-        vSeeds.emplace_back("veil-testnet-seed.asoftwaresolution.com");
+        vSeeds.emplace_back("testnode01.veil-project.com");
+        vSeeds.emplace_back("testnode02.veil-project.com");
+        vSeeds.emplace_back("testnode03.veil-project.com");
+        vSeeds.emplace_back("testnode04.veil-project.com");
+        vSeeds.emplace_back("testnode05.veil-project.com");
+        vSeeds.emplace_back("testnode06.veil-project.com");
+        vSeeds.emplace_back("testnode07.veil-project.com"); // Mimir seeder
+        vSeeds.emplace_back("testnode08.veil-project.com"); // Codeofalltrades seeder
+        vSeeds.emplace_back("testnode09.veil-project.com"); // CaveSpectre seeder
+        // single point DNS failure backups
+        vSeeds.emplace_back("seedtest.veil.rune.network");              // Mimir seeder
+        vSeeds.emplace_back("veilseedtestnet.codeofalltrades.com");     // Codeofalltrades seeder
+        vSeeds.emplace_back("veil-seed-test.pontificatingnobody.com");  // CaveSpectre seeder
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
### Problem
Users can't synch to the network without an existing peers.dat file, or using addnodes.

### Root Cause
The hardcoded seed nodes in the core code have all gone offline, and needed to be refreshed.

### Solution
The solution is multi-fold.  The bulk was re-porting bitcoin-seeder to veil, and making a number of improvements and fixes to the code.  We have taken that on and have a new repo to manage the Veil-DNS-Seeder; which will evolve over time.  That can be found https://github.com/Veil-Project/Veil-DNS-Seeder

The DNS Seeder is a lightweight nameserver that also talks on the veil p2p network to scrape the existing nodes, and curate them before serving them out as responses to a DNS query for the seeder name.    In the core code, both trusted full nodes, and dns seeders can serve as the seeder nodes; since the design will lookup the IP address of the node, and connect to it for synching; regardless of if the name ties to a full node ip address, or the name is a random list of ip addresses that the seeders have found.

The design for the core code is to have a full list of nodes managed by the project DNS, with a few backups duplicated to external names (like @mimirmim, @codeofalltrades and my personal domains); to protect in the event of a DNS failure for veil-project.com.

### Unit Testing Results
The DNS changes still need to be propagated through the net to get everything functional, but shortly this should be functional.  You can test any of these nodes by telnetting (not ssh) to nodexx.veil-project.com 58810.  If it connects, then it's running a veil node.

The response from a seeder node via DNS looks like:
```
~/veil-seeder $ nslookup veil-seed.pontificatingnobody.com.
Server:         108.61.10.10
Address:        108.61.10.10#53

Non-authoritative answer:
Name:   veil-seed.pontificatingnobody.com
Address: 199.247.20.46

root@199.247.20.46 ~/veil-seeder $ nslookup veil-seed.pontificatingnobody.com. 127.0.0.1 -port=5053
Server:         127.0.0.1
Address:        127.0.0.1#5053

Name:   veil-seed.pontificatingnobody.com
Address: 159.69.20.168
Name:   veil-seed.pontificatingnobody.com
Address: 51.91.94.23
Name:   veil-seed.pontificatingnobody.com
Address: 79.134.225.59
Name:   veil-seed.pontificatingnobody.com
Address: 62.14.46.140
Name:   veil-seed.pontificatingnobody.com
Address: 31.201.2.151
Name:   veil-seed.pontificatingnobody.com
Address: 95.216.161.75
Name:   veil-seed.pontificatingnobody.com
Address: 89.25.168.21
Name:   veil-seed.pontificatingnobody.com
Address: 119.194.83.150
Name:   veil-seed.pontificatingnobody.com
Address: 91.241.32.110
Name:   veil-seed.pontificatingnobody.com
Address: 151.230.70.111
Name:   veil-seed.pontificatingnobody.com
Address: 94.67.38.36
Name:   veil-seed.pontificatingnobody.com
Address: 94.130.185.98
Name:   veil-seed.pontificatingnobody.com
Address: 118.211.137.169
Name:   veil-seed.pontificatingnobody.com
Address: 94.191.50.112
Name:   veil-seed.pontificatingnobody.com
Address: 95.216.196.198
Name:   veil-seed.pontificatingnobody.com
Address: 96.9.80.109
Name:   veil-seed.pontificatingnobody.com
Address: 104.196.219.29
Name:   veil-seed.pontificatingnobody.com
Address: 109.195.131.81
Name:   veil-seed.pontificatingnobody.com
Address: 116.203.70.203
Name:   veil-seed.pontificatingnobody.com
Address: 116.203.96.115
Name:   veil-seed.pontificatingnobody.com
Address: 192.99.62.161
Name:   veil-seed.pontificatingnobody.com
Address: 165.227.216.124
Name:   veil-seed.pontificatingnobody.com
Address: 94.65.10.248
```