### PR TITLE
[Build] Qt duplicate name warnings corrected

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -69,7 +69,7 @@
  background-color:white;
 }</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <layout class="QVBoxLayout" name="verticalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -86,7 +86,7 @@
          <number>0</number>
         </property>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -200,7 +200,7 @@
               <property name="frameShadow">
                <enum>QFrame::Raised</enum>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout" stretch="2,0,0,0,1,0,3">
+              <layout class="QVBoxLayout" name="verticalLayout_3" stretch="2,0,0,0,1,0,3">
                <property name="sizeConstraint">
                 <enum>QLayout::SetDefaultConstraint</enum>
                </property>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -36,7 +36,7 @@ background-color:white;</string>
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="frame">
+    <widget class="QFrame" name="frame_1">
      <property name="styleSheet">
       <string notr="true">background-color:white;
 border:none;</string>
@@ -412,7 +412,7 @@ margin:0px;</string>
        </widget>
       </item>
       <item>
-       <widget class="QFrame" name="frame">
+       <widget class="QFrame" name="frame_2">
         <property name="styleSheet">
          <string notr="true">QToolTip {
     color: #ffffff;

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -46,7 +46,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QFrame" name="frame">
+     <widget class="QFrame" name="frame_1">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
         <horstretch>0</horstretch>
@@ -299,7 +299,7 @@ padding:0px;</string>
      </widget>
     </item>
     <item>
-     <widget class="QFrame" name="frame">
+     <widget class="QFrame" name="frame_3">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
         <horstretch>0</horstretch>

--- a/src/qt/veil/forms/sendconfirmation.ui
+++ b/src/qt/veil/forms/sendconfirmation.ui
@@ -112,7 +112,7 @@
           <number>9</number>
          </property>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_1" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelSend">
              <property name="maximumSize">
@@ -158,7 +158,7 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelAmount">
              <property name="maximumSize">
@@ -201,7 +201,7 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelFee">
              <property name="maximumSize">
@@ -244,7 +244,7 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">

--- a/src/qt/veil/forms/settingsadvanceinformation.ui
+++ b/src/qt/veil/forms/settingsadvanceinformation.ui
@@ -44,7 +44,7 @@
          <number>12</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="label_1">
           <property name="styleSheet">
            <string notr="true">color:#707070;
 font-size:18px;
@@ -56,12 +56,12 @@ font-weight:bold;</string>
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_1">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_10">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -85,7 +85,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_11">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -103,7 +103,7 @@ font-size:18px;</string>
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_12">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -127,7 +127,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_13">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -140,12 +140,12 @@ font-size:18px;</string>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_14">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -169,7 +169,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_15">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -182,12 +182,12 @@ font-size:18px;</string>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_16">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -211,7 +211,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_17">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -224,12 +224,12 @@ font-size:18px;</string>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_18">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -253,7 +253,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_19">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -294,12 +294,12 @@ font-weight:bold;</string>
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_21">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -323,7 +323,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_22">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -336,12 +336,12 @@ font-size:18px;</string>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_23">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -365,7 +365,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_24">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -394,7 +394,7 @@ font-size:18px;</string>
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="label_3">
           <property name="styleSheet">
            <string notr="true">color:#707070;
 font-size:18px;
@@ -406,12 +406,12 @@ font-weight:bold;</string>
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_31">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -435,7 +435,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_32">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -448,12 +448,12 @@ font-size:18px;</string>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_33">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -477,7 +477,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_34">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -506,7 +506,7 @@ font-size:18px;</string>
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="label_4">
           <property name="styleSheet">
            <string notr="true">color:#707070;
 font-size:18px;
@@ -518,12 +518,12 @@ font-weight:bold;</string>
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_10">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_41">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -547,7 +547,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_42">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>
@@ -560,12 +560,12 @@ font-size:18px;</string>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_11">
           <property name="spacing">
            <number>20</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_43">
             <property name="minimumSize">
              <size>
               <width>290</width>
@@ -589,7 +589,7 @@ font-weight:200;</string>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_44">
             <property name="styleSheet">
              <string notr="true">color:#707070;
 font-size:18px;</string>

--- a/src/qt/veil/forms/settingsadvancenetwork.ui
+++ b/src/qt/veil/forms/settingsadvancenetwork.ui
@@ -46,7 +46,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <property name="spacing">
          <number>10</number>
         </property>
@@ -160,7 +160,7 @@ color:#707070;</string>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="amountRecevied">
+         <widget class="QLabel" name="amountReceived">
           <property name="layoutDirection">
            <enum>Qt::RightToLeft</enum>
           </property>
@@ -179,12 +179,12 @@ color:#707070;</string>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
         <property name="spacing">
          <number>10</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="label_4">
           <property name="maximumSize">
            <size>
             <width>30</width>
@@ -200,7 +200,7 @@ color:#707070;</string>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="label_5">
           <property name="styleSheet">
            <string notr="true">font-size:18px;
 color:#707070;</string>

--- a/src/qt/veil/forms/settingsfaq02.ui
+++ b/src/qt/veil/forms/settingsfaq02.ui
@@ -22,7 +22,7 @@ color:#707070;</string>
     <number>60</number>
    </property>
    <item>
-    <spacer name="verticalSpacer_5">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -38,7 +38,7 @@ color:#707070;</string>
     </spacer>
    </item>
    <item alignment="Qt::AlignTop">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -60,7 +60,7 @@ color:#707070;</string>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_2">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -76,7 +76,7 @@ color:#707070;</string>
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_1">
      <property name="maximumSize">
       <size>
        <width>16777215</width>
@@ -92,7 +92,7 @@ color:#707070;</string>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_3">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -141,7 +141,7 @@ color:#707070;</string>
       </widget>
      </item>
      <item alignment="Qt::AlignTop">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="label_11">
        <property name="styleSheet">
         <string notr="true">padding-top:10px;</string>
        </property>
@@ -157,7 +157,7 @@ color:#707070;</string>
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_2">
      <property name="maximumSize">
       <size>
        <width>16777215</width>
@@ -189,7 +189,7 @@ color:#707070;</string>
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout_1" stretch="0,1">
      <property name="spacing">
       <number>20</number>
      </property>
@@ -222,7 +222,7 @@ color:#707070;</string>
       </widget>
      </item>
      <item alignment="Qt::AlignTop">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="label_21">
        <property name="styleSheet">
         <string notr="true">padding-top:10px;</string>
        </property>
@@ -240,7 +240,7 @@ Trading fee: 0.25%.
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_3">
      <property name="maximumSize">
       <size>
        <width>16777215</width>
@@ -256,7 +256,7 @@ Trading fee: 0.25%.
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_3">
+    <spacer name="verticalSpacer_4">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -272,7 +272,7 @@ Trading fee: 0.25%.
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
      <property name="spacing">
       <number>20</number>
      </property>
@@ -305,7 +305,7 @@ Trading fee: 0.25%.
       </widget>
      </item>
      <item alignment="Qt::AlignTop">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="label_31">
        <property name="styleSheet">
         <string notr="true">padding-top:10px;</string>
        </property>
@@ -323,7 +323,7 @@ Trading fee: 0.25%.
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacer_4">
+    <spacer name="verticalSpacer_5">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -339,7 +339,7 @@ Trading fee: 0.25%.
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_4">
      <property name="maximumSize">
       <size>
        <width>16777215</width>
@@ -371,7 +371,7 @@ Trading fee: 0.25%.
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="label_4">
+    <widget class="QLabel" name="label_5">
      <property name="styleSheet">
       <string notr="true">font-weight:200;</string>
      </property>
@@ -384,7 +384,7 @@ Trading fee: 0.25%.
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_7">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/src/qt/veil/forms/settingsfaq03.ui
+++ b/src/qt/veil/forms/settingsfaq03.ui
@@ -22,7 +22,7 @@ color:#707070;</string>
     <number>60</number>
    </property>
    <item>
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="label">
      <property name="styleSheet">
       <string notr="true">color:#105aef;</string>
      </property>
@@ -32,7 +32,7 @@ color:#707070;</string>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_5">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -48,7 +48,7 @@ color:#707070;</string>
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_1">
      <property name="styleSheet">
       <string notr="true">font-weight:bold;
 font-size:16px;</string>
@@ -59,7 +59,7 @@ font-size:16px;</string>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_2">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -102,7 +102,7 @@ For security reasons, it is strongly recommended not to make a digital backup of
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_3">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -128,6 +128,33 @@ For security reasons, it is strongly recommended not to make a digital backup of
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;
+font-size:16px;</string>
+     </property>
+     <property name="text">
+      <string>Go to Settings&gt;Restore wallet.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer_4">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -143,35 +170,8 @@ For security reasons, it is strongly recommended not to make a digital backup of
      </property>
     </spacer>
    </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold;
-font-size:16px;</string>
-     </property>
-     <property name="text">
-      <string>Go to Settings&gt;Restore wallet.</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item alignment="Qt::AlignLeft|Qt::AlignTop">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label_5">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -196,7 +196,7 @@ When restoring up with recovery seed phrase, please enter words one at a time in
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_5">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/src/qt/veil/forms/settingsminting.ui
+++ b/src/qt/veil/forms/settingsminting.ui
@@ -96,7 +96,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QFrame" name="frame">
+          <widget class="QFrame" name="frame_1">
            <property name="styleSheet">
             <string notr="true">#groupBox {
   border:0;
@@ -437,7 +437,7 @@ border:0;
              <number>0</number>
             </property>
             <item alignment="Qt::AlignHCenter">
-             <widget class="QFrame" name="frame">
+             <widget class="QFrame" name="frame_31">
               <property name="minimumSize">
                <size>
                 <width>300</width>
@@ -468,7 +468,7 @@ border:0;
                 </spacer>
                </item>
                <item>
-                <widget class="QFrame" name="frame">
+                <widget class="QFrame" name="frame_311">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -607,7 +607,7 @@ padding-bottom:3px;</string>
                 </widget>
                </item>
                <item alignment="Qt::AlignTop">
-                <widget class="QFrame" name="frame">
+                <widget class="QFrame" name="frame_312">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -728,7 +728,7 @@ padding-bottom:3px;</string>
                 </widget>
                </item>
                <item>
-                <widget class="QFrame" name="frame_4">
+                <widget class="QFrame" name="frame_313">
                  <layout class="QVBoxLayout" name="verticalLayout_8">
                   <property name="leftMargin">
                    <number>1</number>


### PR DESCRIPTION
### Problem
v1.0.4.7 build generates several QT warnings relating to duplicate names.

### Root Cause
The names are duplicate; for example:
```
qt/forms/overviewpage.ui: Warning: The name 'verticalLayout_3' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_31'.
qt/forms/sendcoinsdialog.ui: Warning: The name 'frame' (QFrame) is already in use, defaulting to 'frame1'.
qt/forms/sendcoinsentry.ui: Warning: The name 'frame' (QFrame) is already in use, defaulting to 'frame1'.
qt/veil/forms/settingsadvancenetwork.ui: Warning: The name 'horizontalLayout_2' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_21'.
qt/veil/forms/settingsadvancenetwork.ui: Warning: The name 'label_2' (QLabel) is already in use, defaulting to 'label_21'.
qt/veil/forms/settingsadvancenetwork.ui: Warning: The name 'label_3' (QLabel) is already in use, defaulting to 'label_31'.
qt/veil/forms/settingsfaq03.ui: Warning: The name 'label_3' (QLabel) is already in use, defaulting to 'label_31'.
qt/veil/forms/settingsfaq03.ui: Warning: The name 'label' (QLabel) is already in use, defaulting to 'label1'.
qt/veil/forms/settingsfaq03.ui: Warning: The name 'verticalSpacer_2' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_21'.
qt/veil/forms/settingsfaq03.ui: Warning: The name 'label_2' (QLabel) is already in use, defaulting to 'label_21'.
```
### Solution
Fix 'em.
