### PR TITLE
[Qt][Build] Fix Mint Zerocoin amount

### DIFF
--- a/src/qt/locale/veil_en.ts
+++ b/src/qt/locale/veil_en.ts
@@ -4052,7 +4052,7 @@ to have automatically minted by automint</source>
     </message>
     <message>
         <location line="+108"/>
-        <source>Mint Zerocoin veil</source>
+        <source>Mint Zerocoin Veil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/veil/settings/settingsminting.cpp
+++ b/src/qt/veil/settings/settingsminting.cpp
@@ -7,7 +7,7 @@
 #include <qt/walletmodel.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
-#include <QIntValidator>
+#include <QRegExpValidator>
 
 #include <QSettings>
 #include <QStandardPaths>
@@ -29,7 +29,7 @@ SettingsMinting::SettingsMinting(QWidget *parent, WalletView *mainWindow, Wallet
 
     ui->btnEsc->setProperty("cssClass" , "btn-text-primary-inactive");
 
-    ui->editAmount->setPlaceholderText("Enter amount here");
+    ui->editAmount->setPlaceholderText("Enter amount here (multiple of 10)");
     ui->editAmount->setAttribute(Qt::WA_MacShowFocusRect, 0);
     ui->editAmount->setProperty("cssClass" , "edit-primary");
 
@@ -71,10 +71,12 @@ SettingsMinting::SettingsMinting(QWidget *parent, WalletView *mainWindow, Wallet
             break;
     }
 
-    //
     ui->errorMessage->setVisible(false);
 
-    ui->editAmount->setValidator(new QIntValidator(0, 100000000000, this) );
+    // one digit between 1 and 9 followed by 0 to 10 digits followed by a zero (as it must
+    // be a multiple of 10
+    QRegExp rx("[1-9]\\d{1,11}");
+    ui->editAmount->setValidator(new QRegExpValidator(rx, this) );
 
     connect(ui->btnEsc,SIGNAL(clicked()),this, SLOT(close()));
     connect(ui->btnSendMint,SIGNAL(clicked()),this, SLOT(btnMint()));


### PR DESCRIPTION
### Problem
Build generates overflow warning in `SettingsMinting`
```
qt/veil/settings/settingsminting.cpp: In constructor ‘SettingsMinting::SettingsMinting(QWidget*, WalletView*, WalletModel*)’:
qt/veil/settings/settingsminting.cpp:77:73: warning: overflow in implicit constant conversion [-Woverflow]
     ui->editAmount->setValidator(new QIntValidator(0, 100000000000, this) );
                                                                         ^
```

### Root Cause
The validator value (100000000000) is greater than an integer; so it only allows an integer value to be placed.

### Solution
The simple solution was to reduce the integer value to something that fits into a 32 bit integer; but that will also allow a negative number to be input.  Instead, this fix sets it to a regular expression that will require a positive digit followed by 1 to 11 other digits (allowing for the size that was allowed before).  Since it technically should only be a multiple of 10, two digits are required and the edit window was changed to mention it needs to be a multiple of 10.  This way they don't enter a number and then are warned that it's not a multiple of 10.

Settings->Zerocoin Minting
![image](https://user-images.githubusercontent.com/36988814/70963100-84c47d00-2055-11ea-9098-306ba3cb50bb.png)

While there's a lot of other work that could be done on the page; the intent was to remove the warning on the build, so other things on the page were skipped as the page is now only temporary.