### PR TITLE
[Chain][Performance] Rework orphan pruning

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The PIVX developers
-// Copyright (c) 2019 The Veil developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -3542,6 +3542,80 @@ static void NotifyHeaderTip() LOCKS_EXCLUDED(cs_main) {
     }
 }
 
+bool IsAncestor(const CBlockIndex* pindexChain, const CBlockIndex* pindexCheck)
+{
+    if (!pindexChain || !pindexCheck)
+        return false;
+    if (pindexChain->nHeight <= pindexCheck->nHeight)
+        return false;
+
+    return pindexChain->GetAncestor(pindexCheck->nHeight)->GetBlockHash() == pindexCheck->GetBlockHash();
+}
+
+static const unsigned int PRUNE_DEPTH = 120;
+static const unsigned int PRUNE_COUNT = 12;
+
+/*
+** Periodically scan the block index map for stale tips and clean them up.  Note that both
+** chainActive.Contains and IsAncestor are expensive as the block index grows, so we want
+** to take special care to not spend a lot of extra time doing useless work.
+*/
+void PruneStaleBlockIndexes()
+{
+    static int64_t lastPrunedHeight = 0;
+
+    // This isn't going to change while we're processing, so just leave and try again later.
+    if (!pindexBestHeader) return;
+
+    // If mapBlockIndex isn't bloated, don't bother taking the time.
+    if (chainActive.Height() > (mapBlockIndex.size() - PRUNE_COUNT)) {
+        return;
+    }
+
+    LogPrintf("%s: Checking for stale indexes. Block index size=%d; Chain height=%d\n",
+              __func__, mapBlockIndex.size(), chainActive.Height());
+
+    uint32_t irrelevantIndexes = 0;
+    int64_t lowestPrunedHeight = lastPrunedHeight;
+    std::set<uint256> setDelete;
+
+    for (const auto& p : mapBlockIndex) {
+        const CBlockIndex* pindex = p.second;
+        // If we've already checked to this height, don't waste time
+
+        if (pindex->nHeight < lastPrunedHeight)
+            continue;
+
+        // If it's not in the active chain, and not in our best header ancestor list.
+        if (!chainActive.Contains(pindex) && (!IsAncestor(pindexBestHeader, pindex))) {
+            irrelevantIndexes++;
+
+            // if it's also old enough, add it to the prune list.
+            if (pindex->nHeight + PRUNE_DEPTH < chainActive.Height()) {
+                setDelete.emplace(p.first);
+
+                // save the lowest height that we're purging
+                if ((pindex->nHeight < lowestPrunedHeight) || (lowestPrunedHeight <= lastPrunedHeight)) {
+                    lowestPrunedHeight = pindex->nHeight;
+                }
+            }
+        }
+    }
+
+    if (irrelevantIndexes > 0) {
+         LogPrintf("%s: Erasing %d of %d irrelevant indexes.  LastPrunedHeight now %d.\n",
+                   __func__, setDelete.size(), irrelevantIndexes, lowestPrunedHeight);
+
+         // Purge the ones we flagged
+         for (const uint256& hash : setDelete) {
+             mapBlockIndex.erase(hash);
+         }
+
+         // Step back a little for safety
+         lastPrunedHeight = lowestPrunedHeight;
+    }
+}
+
 /**
  * Make the best chain active, in multiple steps. The result is either failure
  * or an activated best chain. pblock is either nullptr or a pointer to a block
@@ -3647,6 +3721,8 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
     if (!FlushStateToDisk(chainparams, state, FlushStateMode::PERIODIC)) {
         return false;
     }
+
+    PruneStaleBlockIndexes();
 
     return true;
 }
@@ -4590,42 +4666,12 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     return true;
 }
 
-bool IsAncestor(const CBlockIndex* pindexChain, const CBlockIndex* pindexCheck)
-{
-    if (!pindexChain || !pindexCheck)
-        return false;
-    if (pindexChain->nHeight <= pindexCheck->nHeight)
-        return false;
-
-    return pindexChain->GetAncestor(pindexCheck->nHeight)->GetBlockHash() == pindexCheck->GetBlockHash();
-}
-
-// If there are too many loose block indexes, then delete the extras.
-void CleanBlockIndexGarbage()
-{
-    std::set<uint256> setDelete;
-    for (const auto& p : mapBlockIndex) {
-        const CBlockIndex* pindex = p.second;
-        if (pindexBestHeader && !chainActive.Contains(pindex) && (!IsAncestor(pindexBestHeader, pindex)))
-            setDelete.emplace(p.first);
-    }
-
-    if (setDelete.size() > 1000) {
-        LogPrintf("%s: Erasing %d irrelevant indexes\n", __func__, setDelete.size());
-        for (const uint256& hash : setDelete) {
-            mapBlockIndex.erase(hash);
-        }
-    }
-}
-
 // Exposed wrapper for AcceptBlockHeader
 bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex, CBlockHeader *first_invalid)
 {
     if (first_invalid != nullptr) first_invalid->SetNull();
     {
         LOCK(cs_main);
-        if (!IsInitialBlockDownload())
-            CleanBlockIndexGarbage();
         int nHeightMaxNonPoW = chainActive.Height() + Params().MaxHeaderRequestWithoutPoW();
         nHeightMaxNonPoW = std::max(nHeightMaxNonPoW, Checkpoints::GetLastCheckpointHeight(chainparams.Checkpoints()));
 


### PR DESCRIPTION
### Problem
The PoS algorithm has a much greater potential to have several stakers submitting a valid block, even though eventually only one will end up being chosen by the consensus to be the official chain.  All others that submit a block that doesn't end up in the chain will see orphans.  These orphans reside in the memory of the core daemons until they are purged.  As a result, the number of tips (as seen with `veil-cli getchaintips`) will continue to grow until it reaches a threshold of 1000.

The code searches for stale tips frequently, and has an observed cost of about 1.3 seconds at the current block height for each time the search is done.  This would have grown slowly as the chain grows.

### Root Cause
Code was added to Veil to clean up these tips.  Other projects have many tips in their database (one popular coin was observed to have over 16k.  Veil cleaned the tips up when they reached 1000.  This is believed to be wholly inefficient.

Additionally, this added code has efficiency problems.  One change in this PR is an initial pass at an efficiency change to help reduce the burden of this cleanup.

### Solution
Two changes are included in this PR.  The first, which is easily confirmed, is the pruning of these chain tips.  Instead of the pruning occurring when the number of tips exceeds 1000; it now will prune them when the tip has been stale for more than 12 blocks.

Additionally, the order of the tests was changed.  The bulk of the time goes to the checking of the ancestors of a block.   If that block is in the current chain, the ancestor check is unnecessary.  So instead of checking the ancestors for every block in the database, then checking if it's in the current chain (and pruning it if neither occurs), the bulk of the blocks are in the chain, so we will rule that out first (much faster) and only check ancestry if the block is not in the current chain.

### Testing
Testing the first part is very simple.  After running the wallet for a little while, anyone can see numerous tips; many of them dozens, if not hundreds or thousands of blocks behind the current height when executing `getchaintips`.   These are not necessary to be retained.

With this PR, you will not see any chain tips with a height less than 12 from the current height.  You will see the pruning occurring in the debug log file as well:

```
2020-01-02T02:15:58Z CleanBlockIndexGarbage: Erasing 53584 of 53585 irrelevant indexes
2020-01-02T02:16:12Z CleanBlockIndexGarbage: Erasing 0 of 2 irrelevant indexes
2020-01-02T02:16:22Z CleanBlockIndexGarbage: Erasing 1 of 1 irrelevant indexes
2020-01-02T02:18:29Z CleanBlockIndexGarbage: Erasing 0 of 1 irrelevant indexes
2020-01-02T02:18:30Z CleanBlockIndexGarbage: Erasing 0 of 1 irrelevant indexes
2020-01-02T02:18:49Z CleanBlockIndexGarbage: Erasing 0 of 1 irrelevant indexes
```

(side note; why there are 53k sitting in the block database on startup is unknown currently, and will be investigated at a later date; as they are pruned on startup it doesn't have an adverse effect on the running system.  This is the reason that the number of chain tips starts at zero; because the large amount in the block database triggers them to be pruned on startup).

What the log shows is how many tips there were, and how many were pruned.  When you see "Erasing 0 of 2", that means there are two that are believed to be irrelevant, but their height requirement is not to a point where they will be pruned.

The second issue is not something that can be easily tested without adding timing into the code.  putting timers in the routine at hand, and keeping track of the amount of time the routine took, reveals the effect of that code change (about a 92% performance improvement on that section of code, and shaving off about 1.2 seconds of time in a critical section locked by `cs_main` for each block processed)

# Before
```
2020-01-02T01:45:34Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.632087 seconds
2020-01-02T01:46:47Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.253449 seconds
2020-01-02T01:46:50Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.251874 seconds
2020-01-02T01:47:33Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.292188 seconds
2020-01-02T01:47:45Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.321275 seconds
2020-01-02T01:47:51Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.293556 seconds
2020-01-02T01:47:54Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.286087 seconds
2020-01-02T01:48:01Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.360860 seconds
2020-01-02T01:48:48Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.303014 seconds
2020-01-02T01:49:12Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.243704 seconds
2020-01-02T01:49:18Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.251913 seconds
2020-01-02T01:49:33Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.242712 seconds
2020-01-02T01:49:41Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.284505 seconds
2020-01-02T01:49:50Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.301958 seconds
2020-01-02T01:50:10Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.318217 seconds
2020-01-02T01:51:00Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.304591 seconds
2020-01-02T01:51:17Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.272602 seconds
2020-01-02T01:51:34Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.257356 seconds
2020-01-02T01:51:59Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.284783 seconds
2020-01-02T01:52:02Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.265133 seconds
2020-01-02T01:53:00Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.300298 seconds
2020-01-02T01:53:28Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.248319 seconds
2020-01-02T01:54:19Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.294210 seconds
2020-01-02T01:55:28Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.302487 seconds
2020-01-02T01:56:22Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.255330 seconds
2020-01-02T01:57:22Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.268904 seconds
2020-01-02T01:58:11Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.293706 seconds
2020-01-02T01:58:39Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.354431 seconds
2020-01-02T01:58:56Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.291397 seconds
2020-01-02T01:59:03Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.353625 seconds
2020-01-02T02:00:59Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.309790 seconds
2020-01-02T02:01:12Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.246629 seconds
2020-01-02T02:01:15Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.350599 seconds
2020-01-02T02:01:28Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.303686 seconds
2020-01-02T02:01:40Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.303095 seconds
```

# After
```
2020-01-02T03:28:17Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099894 seconds
2020-01-02T03:28:18Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099980 seconds
2020-01-02T03:30:10Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099467 seconds
2020-01-02T03:31:27Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100021 seconds
2020-01-02T03:31:32Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099398 seconds
2020-01-02T03:31:38Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100509 seconds
2020-01-02T03:32:52Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098997 seconds
2020-01-02T03:35:15Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098915 seconds
2020-01-02T03:35:34Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099278 seconds
2020-01-02T03:36:09Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099287 seconds
2020-01-02T03:36:38Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099494 seconds
2020-01-02T03:37:43Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099135 seconds
2020-01-02T03:37:50Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.138882 seconds
2020-01-02T03:39:11Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100209 seconds
2020-01-02T03:39:22Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.125681 seconds
2020-01-02T03:39:23Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099585 seconds
2020-01-02T03:39:33Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100035 seconds
2020-01-02T03:39:48Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099417 seconds
2020-01-02T03:40:47Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100063 seconds
2020-01-02T03:40:47Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099346 seconds
2020-01-02T03:41:16Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.105898 seconds
2020-01-02T03:41:18Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099293 seconds
2020-01-02T03:42:19Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.101253 seconds
2020-01-02T03:42:20Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.138483 seconds
2020-01-02T03:42:24Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100591 seconds
2020-01-02T03:42:34Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100140 seconds
2020-01-02T03:43:10Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.138943 seconds
2020-01-02T03:43:45Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100185 seconds
2020-01-02T03:43:53Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098239 seconds
2020-01-02T03:44:55Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100541 seconds
2020-01-02T03:46:53Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099540 seconds
2020-01-02T03:46:59Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100139 seconds
2020-01-02T03:47:04Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100110 seconds
2020-01-02T03:47:07Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099737 seconds
2020-01-02T03:47:20Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098150 seconds
2020-01-02T03:47:24Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099493 seconds
2020-01-02T03:47:37Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100032 seconds
2020-01-02T03:48:08Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100015 seconds
2020-01-02T03:48:26Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099422 seconds
2020-01-02T03:48:40Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099060 seconds
2020-01-02T03:48:49Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098883 seconds
2020-01-02T03:48:50Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099002 seconds
2020-01-02T03:48:55Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098913 seconds
2020-01-02T03:49:13Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100458 seconds
```
