### PR TITLE
[Performance] don't check ancestry if block is in the current chain

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4606,12 +4606,12 @@ void CleanBlockIndexGarbage()
     std::set<uint256> setDelete;
     for (const auto& p : mapBlockIndex) {
         const CBlockIndex* pindex = p.second;
-        if (pindexBestHeader && (!IsAncestor(pindexBestHeader, pindex) && !chainActive.Contains(pindex)))
+        if (pindexBestHeader && !chainActive.Contains(pindex) && (!IsAncestor(pindexBestHeader, pindex)))
             setDelete.emplace(p.first);
     }
 
     if (setDelete.size() > 1000) {
-        LogPrintf("%s: Erasing %d irrelivant indexes\n", __func__, setDelete.size());
+        LogPrintf("%s: Erasing %d irrelevant indexes\n", __func__, setDelete.size());
         for (const uint256& hash : setDelete) {
             mapBlockIndex.erase(hash);
         }


### PR DESCRIPTION
(Note: this is also included in #727, but may be faster to merge than the full change)

### Problem
The code to prune stale tips searches frequently (every time `ProcessNewBlockHeaders()` is called). 
 The bulk of the time spent in `CleanBlockIndexGarbage()` is in `IsAncestor()`.  This creates an an observed cost of about 1.3 seconds at the current block height for each time the search is done, while the `cs_main` lock is held.

### Root Cause
The logic of the `if` statement will check `IsAncestor()` before checking if the block is contained in ChainActive.  However that check is not needed if the block is determined to be in ChainActive (due to the "if not and not" logic).   This causes IsAncestor to be run for every block in the map, where the vast majority of them don't need this check (~90% of them on startup, and over 99.8% of them after initial startup).  

Greatly reducing the number of times IsAncestor is called, by reducing it to only be when the block is not in the active chain, significantly reduces the overall time spent in the `CleanBlockIndexGarbage()` call.

### Solution
The order of the tests was changed.  The bulk of the time goes to the checking of the ancestors of a block.   If that block is in the current chain, the ancestor check is unnecessary.  So instead of checking the ancestors for every block in the database, then checking if it's in the current chain (and pruning it if neither occurs), the bulk of the blocks are in the chain, so we will rule that out first (much faster) and only check ancestry if the block is not in the current chain.

### Testing
This not something that can be easily tested without adding timing into the code.  putting timers in the routine at hand, and keeping track of the amount of time the routine took, reveals the effect of that code change (about a 92% performance improvement on that section of code, and shaving off about 1.2 seconds of time in a critical section locked by `cs_main` for each block processed) (these tests were performed with an additional reduction in the number of stale tips; however even with the tips being cleaned every time they reach 1000; the reduction in time should still be similar; as 1000 blocks is still less than 0.2% of the total number of times IsAncestor() was being called prior to this PR.

# Before
```
2020-01-02T01:45:34Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.632087 seconds
2020-01-02T01:46:47Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.253449 seconds
2020-01-02T01:46:50Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.251874 seconds
2020-01-02T01:47:33Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.292188 seconds
2020-01-02T01:47:45Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.321275 seconds
2020-01-02T01:47:51Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.293556 seconds
2020-01-02T01:47:54Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.286087 seconds
2020-01-02T01:48:01Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.360860 seconds
2020-01-02T01:48:48Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.303014 seconds
2020-01-02T01:49:12Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.243704 seconds
2020-01-02T01:49:18Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.251913 seconds
2020-01-02T01:49:33Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.242712 seconds
2020-01-02T01:49:41Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.284505 seconds
2020-01-02T01:49:50Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.301958 seconds
2020-01-02T01:50:10Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.318217 seconds
2020-01-02T01:51:00Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.304591 seconds
2020-01-02T01:51:17Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.272602 seconds
2020-01-02T01:51:34Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.257356 seconds
2020-01-02T01:51:59Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.284783 seconds
2020-01-02T01:52:02Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.265133 seconds
2020-01-02T01:53:00Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.300298 seconds
2020-01-02T01:53:28Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.248319 seconds
2020-01-02T01:54:19Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.294210 seconds
2020-01-02T01:55:28Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.302487 seconds
2020-01-02T01:56:22Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.255330 seconds
2020-01-02T01:57:22Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.268904 seconds
2020-01-02T01:58:11Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.293706 seconds
2020-01-02T01:58:39Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.354431 seconds
2020-01-02T01:58:56Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.291397 seconds
2020-01-02T01:59:03Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.353625 seconds
2020-01-02T02:00:59Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.309790 seconds
2020-01-02T02:01:12Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.246629 seconds
2020-01-02T02:01:15Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.350599 seconds
2020-01-02T02:01:28Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.303686 seconds
2020-01-02T02:01:40Z (debug) validation.cpp:4731 - CleanBlockIndexGarbage took 1.303095 seconds
```

# After
```
2020-01-02T03:28:17Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099894 seconds
2020-01-02T03:28:18Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099980 seconds
2020-01-02T03:30:10Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099467 seconds
2020-01-02T03:31:27Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100021 seconds
2020-01-02T03:31:32Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099398 seconds
2020-01-02T03:31:38Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100509 seconds
2020-01-02T03:32:52Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098997 seconds
2020-01-02T03:35:15Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098915 seconds
2020-01-02T03:35:34Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099278 seconds
2020-01-02T03:36:09Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099287 seconds
2020-01-02T03:36:38Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099494 seconds
2020-01-02T03:37:43Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099135 seconds
2020-01-02T03:37:50Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.138882 seconds
2020-01-02T03:39:11Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100209 seconds
2020-01-02T03:39:22Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.125681 seconds
2020-01-02T03:39:23Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099585 seconds
2020-01-02T03:39:33Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100035 seconds
2020-01-02T03:39:48Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099417 seconds
2020-01-02T03:40:47Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100063 seconds
2020-01-02T03:40:47Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099346 seconds
2020-01-02T03:41:16Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.105898 seconds
2020-01-02T03:41:18Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099293 seconds
2020-01-02T03:42:19Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.101253 seconds
2020-01-02T03:42:20Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.138483 seconds
2020-01-02T03:42:24Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100591 seconds
2020-01-02T03:42:34Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100140 seconds
2020-01-02T03:43:10Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.138943 seconds
2020-01-02T03:43:45Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100185 seconds
2020-01-02T03:43:53Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098239 seconds
2020-01-02T03:44:55Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100541 seconds
2020-01-02T03:46:53Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099540 seconds
2020-01-02T03:46:59Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100139 seconds
2020-01-02T03:47:04Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100110 seconds
2020-01-02T03:47:07Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099737 seconds
2020-01-02T03:47:20Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098150 seconds
2020-01-02T03:47:24Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099493 seconds
2020-01-02T03:47:37Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100032 seconds
2020-01-02T03:48:08Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100015 seconds
2020-01-02T03:48:26Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099422 seconds
2020-01-02T03:48:40Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099060 seconds
2020-01-02T03:48:49Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098883 seconds
2020-01-02T03:48:50Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.099002 seconds
2020-01-02T03:48:55Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.098913 seconds
2020-01-02T03:49:13Z (debug) validation.cpp:4751 - CleanBlockIndexGarbage took 0.100458 seconds
```
