### PR TITLE
Add an include file for Travis build to pass.

### DIFF
--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -10,6 +10,7 @@
 #include "veil-config.h"
 #endif
 
+#include <limits.h>
 #include <stdexcept>
 #include <vector>
 #if defined(USE_NUM_GMP)


### PR DESCRIPTION
This fixes an issue we have with Travis not building because of a missing include file.