### PR TITLE
Refactor + fix mutex locking in wallet and ztracker.

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -234,12 +234,14 @@ WalletTx MakeWalletTx(CHDWallet& wallet, MapRecords_t::const_iterator irtx)
 }
 */
 //! Construct wallet tx status struct.
-WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
+WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     WalletTxStatus result;
     auto mi = ::mapBlockIndex.find(wtx.hashBlock);
+
     CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max());
+
     result.blocks_to_maturity = wtx.GetBlocksToMaturity();
     result.depth_in_main_chain = wtx.GetDepthInMainChain();
     result.time_received = wtx.nTimeReceived;
@@ -252,7 +254,7 @@ WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
     return result;
 }
 
-WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, const CTransactionRecord &rtx)
+WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, const CTransactionRecord &rtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     WalletTxStatus result;
     auto mi = ::mapBlockIndex.find(rtx.blockHash);
@@ -260,7 +262,7 @@ WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, 
     CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max()),
 
-            result.blocks_to_maturity = 0;
+    result.blocks_to_maturity = 0;
     result.depth_in_main_chain = pAnonWallet->GetDepthInMainChain(rtx.blockHash, rtx.nIndex);
     result.time_received = rtx.nTimeReceived;
     result.lock_time = 0; // TODO
@@ -273,7 +275,10 @@ WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, 
 }
 
 //! Construct wallet TxOut struct.
-WalletTxOut MakeWalletTxOut(CWallet& wallet, const CWalletTx& wtx, int n, int depth)
+WalletTxOut MakeWalletTxOut(CWallet& wallet,
+        const CWalletTx& wtx,
+        int n,
+        int depth) EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet.cs_wallet)
 {
     WalletTxOut result;
     result.pout = wtx.tx->vpout[n];
@@ -449,6 +454,7 @@ public:
     }
     std::vector<std::string> getDestValues(const std::string& prefix) override
     {
+        LOCK(m_wallet.cs_wallet);
         return m_wallet.GetDestValues(prefix);
     }
     void lockCoin(const COutPoint& output) override

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -473,7 +473,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     if(fProofOfFullNode && !fProofOfStake)
         LogPrint(BCLog::BLOCKCREATION, "%s: A block can not be proof of full node and proof of work.\n", __func__);
     else if(fProofOfFullNode && fProofOfStake) {
-        LOCK(cs_main);
         pblock->hashPoFN = veil::GetFullNodeHash(*pblock, pindexPrev);
     }
 

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -4518,7 +4518,7 @@ bool AnonWallet::AddStealthDestinationMeta(const CKeyID& idStealth, const CKeyID
     return db.WriteStealthDestinationMeta(idStealthDestination, vchEphemPK);
 }
 
-bool AnonWallet::AddKeyToParent(const CKey& keySharedSecret)
+bool AnonWallet::AddKeyToParent(const CKey& keySharedSecret) EXCLUSIVE_LOCKS_REQUIRED(pwalletParent->cs_wallet)
 {
     //Since the new key is not derived through Ext, for now keep it in CWallet keystore
     bool fSuccess = true;

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -19,10 +19,11 @@ typedef uint256 PubCoinHash;
 class CzTracker
 {
 private:
+
     bool fInitialized;
     std::shared_ptr<WalletDatabase> walletDatabase;
     std::map<SerialHash, CMintMeta> mapSerialHashes;
-    std::map<SerialHash, uint256> mapPendingSpends; //serialhash, txid of spend
+    std::map<SerialHash, uint256> mapPendingSpends GUARDED_BY(cs_remove_pending); //serialhash, txid of spend
     std::map<PubCoinHash, SerialHash> mapHashPubCoin;
     bool UpdateStatusInternal(const std::set<uint256>& setMempoolTx, const std::map<uint256, uint256>& mapMempoolSerials, CMintMeta& mint);
 public:

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -66,7 +66,7 @@ static std::string DecodeDumpString(const std::string &str) {
     return ret.str();
 }
 
-static bool GetWalletAddressesForKey(CWallet * const pwallet, const CKeyID &keyid, std::string &strAddr, std::string &strLabel)
+static bool GetWalletAddressesForKey(CWallet * const pwallet, const CKeyID &keyid, std::string &strAddr, std::string &strLabel) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     bool fLabelFound = false;
     CKey key;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1665,6 +1665,7 @@ struct tallyitem
 };
 
 static UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool by_label)
+    EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     // Minimum confirmations
     int nMinDepth = 1;
@@ -1933,7 +1934,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
  * @param  ret        The UniValue into which the result is stored.
  * @param  filter     The "is mine" filter bool.
  */
-static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwallet->cs_wallet)
 {
     CAmount nFee;
     std::string dummy_account;
@@ -4967,7 +4968,7 @@ bool ParseHDKeypath(std::string keypath_str, std::vector<uint32_t>& keypath)
     return true;
 }
 
-void AddKeypathToMap(const CWallet* pwallet, const CKeyID& keyID, std::map<CPubKey, std::vector<uint32_t>>& hd_keypaths)
+void AddKeypathToMap(const CWallet* pwallet, const CKeyID& keyID, std::map<CPubKey, std::vector<uint32_t>>& hd_keypaths) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     CPubKey vchPubKey;
     if (!pwallet->GetPubKey(keyID, vchPubKey)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1448,7 +1448,7 @@ void CWallet::BlockUntilSyncedToCurrentChain() {
         // We could also take cs_wallet here, and call m_last_block_processed
         // protected by cs_wallet instead of cs_main, but as long as we need
         // cs_main here anyway, it's easier to just call it cs_main-protected.
-        LOCK(cs_main);
+        LOCK2(cs_main, cs_wallet);
         const CBlockIndex* initialChainTip = chainActive.Tip();
 
         if (m_last_block_processed && m_last_block_processed->GetAncestor(initialChainTip->nHeight) == initialChainTip) {
@@ -2310,6 +2310,8 @@ CAmount CWalletTx::GetDebit(const isminefilter& filter) const
 
 CAmount CWalletTx::GetCredit(const isminefilter& filter, bool fResetCache) const
 {
+    LOCK(cs_main);
+
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
         return 0;
@@ -2345,6 +2347,8 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter, bool fResetCache) const
 
 CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
 {
+    LOCK(cs_main);
+
     if (IsCoinBase() && GetBlocksToMaturity() > 0 && IsInMainChain())
     {
         if (fUseCache && fImmatureCreditCached)
@@ -2408,6 +2412,8 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter
 
 CAmount CWalletTx::GetImmatureWatchOnlyCredit(const bool fUseCache) const
 {
+    LOCK(cs_main);
+
     if (IsCoinBase() && GetBlocksToMaturity() > 0 && IsInMainChain())
     {
         if (fUseCache && fImmatureWatchCreditCached)
@@ -4491,7 +4497,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
     std::map<CTxDestination, CAmount> balances;
 
     {
-        LOCK(cs_wallet);
+        LOCK2(cs_main, cs_wallet);
         for (const auto& walletEntry : mapWallet)
         {
             const CWalletTx *pcoin = &walletEntry.second;
@@ -4899,7 +4905,6 @@ bool CWallet::GetDestData(const CTxDestination &dest, const std::string &key, st
 
 std::vector<std::string> CWallet::GetDestValues(const std::string& prefix) const
 {
-    LOCK(cs_wallet);
     std::vector<std::string> values;
     for (const auto& address : mapAddressBook) {
         for (const auto& data : address.second.destdata) {
@@ -5198,8 +5203,12 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
             return nullptr;
         }
     }
-
-    int prev_version = walletInstance->nWalletVersion;
+    
+    int prev_version;
+    { // XXX => GetVersion();
+        LOCK(walletInstance->cs_wallet);
+        prev_version = walletInstance->nWalletVersion;
+    }
     if (gArgs.GetBoolArg("-upgradewallet", fFirstRun))
     {
         int nMaxVersion = gArgs.GetArg("-upgradewallet", 0);
@@ -5385,7 +5394,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    LOCK(cs_main);
+    LOCK2(cs_main, walletInstance->cs_wallet);
 
     CBlockIndex *pindexRescan = chainActive.Genesis();
     if (!gArgs.GetBoolArg("-rescan", false))
@@ -5495,7 +5504,6 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     walletInstance->SetBroadcastTransactions(gArgs.GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
 
     {
-        LOCK(walletInstance->cs_wallet);
         walletInstance->WalletLogPrintf("setKeyPool.size() = %u\n",      walletInstance->GetKeyPoolSize());
         walletInstance->WalletLogPrintf("mapWallet.size() = %u\n",       walletInstance->mapWallet.size());
         walletInstance->WalletLogPrintf("mapAddressBook.size() = %u\n",  walletInstance->mapAddressBook.size());


### PR DESCRIPTION


**Problem**
We are having trouble with locking issues.

**Root Cause**
Locking is used to protect information from getting corrupted when multiple threads access it at the same time. The issue is that locking must be done in the correct order, and it's pretty tricky.

**Solution**
I use Clang's static analysis features to find a few places where locking is done twice, incorrectly. I found a few inconsistencies in the locking paths using Clang's tools.
Finally, by perusing the bitcoin sources, I added in correct locking annotations to a bunch of critical wallet functions.
This solution is part of a greater incremental push to fix locking issues. The locking issues are admittedly hairy, this patch is meant as a small improvement over the current situation.

The patch's description is as follows.


* Correct missing mutex locks.

* Correct paths where the mutex is locked twice.

* Add mutex annotations to some declarations, prototypes.


**Unit Testing Results**
Testing on all platforms.

1) The build is successful.
2) The user succeeds in launching the application to the main window.
3) This patch touches a lot of core components like the wallet, and mining, and so on.. For this patch it is requested that tests with transactions be done, what we are looking for is hard crashes, and performance issues.
