### PR TITLE
[Refactor] Rename Veil Labs to Veil Foundation

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -374,8 +374,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vin.resize(1);
     coinbaseTx.vin[0].prevout.SetNull();
 
-    CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment;
-    veil::Budget().GetBlockRewards(nHeight, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment;
+    veil::Budget().GetBlockRewards(nHeight, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     if (nBudgetPayment > 0 && nFounderPayment > 0)
         coinbaseTx.vpout.resize(fProofOfStake ? 3 : 4);
@@ -408,14 +408,14 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         outBudget->nValue = nBudgetPayment;
         coinbaseTx.vpout[fProofOfStake ? 0 : 1] = (std::move(outBudget));
 
-        std::string strLabAddress = veil::Budget().GetLabAddress(chainActive.Height()+1); // KeyID for now
-        CTxDestination destLab = DecodeDestination(strLabAddress);
-        auto labScript = GetScriptForDestination(destLab);
+        std::string strFoundationAddress = veil::Budget().GetFoundationAddress(chainActive.Height()+1); // KeyID for now
+        CTxDestination destFoundation = DecodeDestination(strFoundationAddress);
+        auto foundationScript = GetScriptForDestination(destFoundation);
 
-        OUTPUT_PTR<CTxOutStandard> outLab = MAKE_OUTPUT<CTxOutStandard>();
-        outLab->scriptPubKey = labScript;
-        outLab->nValue = nLabPayment;
-        coinbaseTx.vpout[fProofOfStake ? 1 : 2] = (std::move(outLab));
+        OUTPUT_PTR<CTxOutStandard> outFoundation = MAKE_OUTPUT<CTxOutStandard>();
+        outFoundation->scriptPubKey = foundationScript;
+        outFoundation->nValue = nFoundationPayment;
+        coinbaseTx.vpout[fProofOfStake ? 1 : 2] = (std::move(outFoundation));
 
         std::string strFounderAddress = veil::Budget().GetFounderAddress(); // KeyID for now
         CTxDestination destFounder = DecodeDestination(strFounderAddress);

--- a/src/test/monthly_rewards_tests.cpp
+++ b/src/test/monthly_rewards_tests.cpp
@@ -13,208 +13,208 @@ BOOST_FIXTURE_TEST_SUITE(monthly_rewards_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(testRewardAfterSet)
 {
-    CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment = 0;
+    CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment = 0;
     int nBlocksPerPeriod = 43200;
-    veil::Budget().GetBlockRewards(1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(2, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(2, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(nBlocksPerPeriod, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(nBlocksPerPeriod, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 10 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 10 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 10 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 30 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 40 * COIN);
     BOOST_CHECK(nFounderPayment == 8 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 8 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 8 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 24 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 40 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 30 * COIN);
     BOOST_CHECK(nFounderPayment == 6 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 6 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 6 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 18 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 30 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 20 * COIN);
     BOOST_CHECK(nFounderPayment == 4 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 4 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 4 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 12 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 20 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 2 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 2 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 2 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 6 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 2 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 2 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 8 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod + 1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 }
 
 BOOST_AUTO_TEST_CASE(testRewardAfterSet_testnet)
 {
     SelectParams("test");
-    CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment = 0;
+    CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment = 0;
     int nBlocksPerPeriod = 43200;
-    veil::Budget().GetBlockRewards(1, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(1, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 10 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 10 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 10 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 30 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(2, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(2, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(20000, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(20000, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 10 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 10 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 10 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 30 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(20001, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(20001, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 50 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 40 * COIN);
     BOOST_CHECK(nFounderPayment == 8 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 8 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 8 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 24 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(12 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 40 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 30 * COIN);
     BOOST_CHECK(nFounderPayment == 6 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 6 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 6 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 18 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(24 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 30 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 20 * COIN);
     BOOST_CHECK(nFounderPayment == 4 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 4 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 4 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 12 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(36 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 20 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 2 * nBlocksPerPeriod * COIN);
-    BOOST_CHECK(nLabPayment == 2 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 2 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 6 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(48 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
-    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod + 20000, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 2 * nBlocksPerPeriod * COIN);
+    BOOST_CHECK(nFoundationPayment == 2 * nBlocksPerPeriod * COIN);
     BOOST_CHECK(nBudgetPayment == 8 * nBlocksPerPeriod * COIN);
 
-    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    veil::Budget().GetBlockRewards(60 * nBlocksPerPeriod + 20001, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     BOOST_CHECK(nBlockReward == 10 * COIN);
     BOOST_CHECK(nFounderPayment == 0);
-    BOOST_CHECK(nLabPayment == 0);
+    BOOST_CHECK(nFoundationPayment == 0);
     BOOST_CHECK(nBudgetPayment == 0);
 
 
@@ -227,12 +227,12 @@ BOOST_AUTO_TEST_CASE(testRewardAfterSet_testnet)
 BOOST_AUTO_TEST_CASE(countRwards)
 {
 
-    CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment = 0;
+    CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment = 0;
     int nBlockRewardsCount = 0;
     int nRewardsCount = 0;
 
     for(int i = 0; i <= 518400; i++) {
-        veil::Budget().GetBlockRewards(i, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+        veil::Budget().GetBlockRewards(i, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
         if(nFounderPayment > 0)
             nRewardsCount++;
         if(nBlockReward > 0)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2765,8 +2765,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     pindex->nNetworkRewardReserve -= networkReward;
 
     // The block rewards are stratified based upon the height of the block.
-    CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment = 0;
-    veil::Budget().GetBlockRewards(pindex->nHeight, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment = 0;
+    veil::Budget().GetBlockRewards(pindex->nHeight, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     //Check proof of full node
     if (!fSkipComputation && (block.fProofOfFullNode || block.hashPoFN != uint256())) {
@@ -2780,7 +2780,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     }
 
     // Full nodes are rewarded with the transaction fees in the block
-    CAmount nCreationLimit = networkReward + nBlockReward + nFounderPayment + nBudgetPayment + nLabPayment;
+    CAmount nCreationLimit = networkReward + nBlockReward + nFounderPayment + nBudgetPayment + nFoundationPayment;
     if (block.fProofOfFullNode || pindex->nHeight >= Params().HeightSupplyCreationStop())
         nCreationLimit += nFees;
 
@@ -2820,9 +2820,9 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     }
 
     if (nCreated > nCreationLimit) {
-        LogPrintf("%s : BlockReward=%s Network=%s Founder=%s Budget=%s Lab=%s\n", __func__, FormatMoney(nBlockReward),
+        LogPrintf("%s : BlockReward=%s Network=%s Founder=%s Budget=%s Foundation=%s\n", __func__, FormatMoney(nBlockReward),
                 FormatMoney(networkReward), FormatMoney(nFounderPayment), FormatMoney(nBudgetPayment),
-                FormatMoney(nLabPayment));
+                FormatMoney(nFoundationPayment));
 
         return state.DoS(100, error("ConnectBlock(): coinbase pays too much (actual=%s vs limit=%s)\n %s",
                                     FormatMoney(nCreated), FormatMoney(nCreationLimit), block.vtx[0]->ToString()),

--- a/src/veil/budget.cpp
+++ b/src/veil/budget.cpp
@@ -10,24 +10,24 @@ bool CheckBudgetTransaction(const int nHeight, const CTransaction& tx, CValidati
     if (!BudgetParams::IsSuperBlock(nHeight))
         return true;
 
-    CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment;
-    veil::Budget().GetBlockRewards(nHeight, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+    CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment;
+    veil::Budget().GetBlockRewards(nHeight, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
 
     // Verify that the superblock rewards are being payed out to the correct addresses with the correct amounts
     std::string strBudgetAddress = Budget().GetBudgetAddress(nHeight); // KeyID for now
     CTxDestination dest = DecodeDestination(strBudgetAddress);
     auto budgetScript = GetScriptForDestination(dest);
 
-    std::string strLabAddress = Budget().GetLabAddress(nHeight); // KeyID for now
-    CTxDestination destLab = DecodeDestination(strLabAddress);
-    auto labScript = GetScriptForDestination(destLab);
+    std::string strFoundationAddress = Budget().GetFoundationAddress(nHeight); // KeyID for now
+    CTxDestination destFoundation = DecodeDestination(strFoundationAddress);
+    auto foundationScript = GetScriptForDestination(destFoundation);
 
     std::string strFounderAddress = Budget().GetFounderAddress(); // KeyID for now
     CTxDestination destFounder = DecodeDestination(strFounderAddress);
     auto founderScript = GetScriptForDestination(destFounder);
 
     bool fBudgetPayment = false;
-    bool fLabPayment = false;
+    bool fFoundationPayment = false;
     bool fFounderPayment = !nFounderPayment;
 
     for (auto pOut : tx.vpout) {
@@ -39,9 +39,9 @@ bool CheckBudgetTransaction(const int nHeight, const CTransaction& tx, CValidati
             if (txOut->nValue == nBudgetPayment) {
                 fBudgetPayment = true;
             }
-        } else if (txOut->scriptPubKey == labScript) {
-            if (txOut->nValue == nLabPayment) {
-                fLabPayment = true;
+        } else if (txOut->scriptPubKey == foundationScript) {
+            if (txOut->nValue == nFoundationPayment) {
+                fFoundationPayment = true;
             }
         } else if (txOut->scriptPubKey == founderScript) {
             if (txOut->nValue == nFounderPayment)
@@ -51,12 +51,12 @@ bool CheckBudgetTransaction(const int nHeight, const CTransaction& tx, CValidati
 
     if (!fBudgetPayment)
         LogPrintf("%s: Expected budget payment not found in coinbase transaction\n", __func__);
-    if (!fLabPayment)
-        LogPrintf("%s: Expected lab payment not found in coinbase transaction\n", __func__);
+    if (!fFoundationPayment)
+        LogPrintf("%s: Expected foundation payment not found in coinbase transaction\n", __func__);
     if (!fFounderPayment)
         LogPrintf("%s: Expected founder payment not found in coinbase transaction\n", __func__);
 
-    return fBudgetPayment && fLabPayment && fFounderPayment;
+    return fBudgetPayment && fFoundationPayment && fFounderPayment;
 }
 
 /**
@@ -73,23 +73,23 @@ bool BudgetParams::IsSuperBlock(int nBlockHeight)
 }
 
 void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
-        CAmount& nFounderPayment, CAmount& nLabPayment, CAmount& nBudgetPayment)
+        CAmount& nFounderPayment, CAmount& nFoundationPayment, CAmount& nBudgetPayment)
 {
 
     if (nBlockHeight <= 0 || nBlockHeight > Params().HeightSupplyCreationStop()) { // 43830 is the average size of a month in minutes when including leap years
         nBlockReward = 0;
         nFounderPayment = 0;
-        nLabPayment = 0;
+        nFoundationPayment = 0;
         nBudgetPayment = 0;
     } else if (nBlockHeight >= 1 && nBlockHeight <= 518399) {
 
         nBlockReward = 50;
         if(IsSuperBlock(nBlockHeight)) {
             nFounderPayment = 10 * nBlocksPerPeriod;
-            nLabPayment = 10 * nBlocksPerPeriod;
+            nFoundationPayment = 10 * nBlocksPerPeriod;
             nBudgetPayment = 30 * nBlocksPerPeriod;
         } else {
-            nFounderPayment = nLabPayment = nBudgetPayment = 0;
+            nFounderPayment = nFoundationPayment = nBudgetPayment = 0;
         }
 
     } else if (nBlockHeight >= 518400 && nBlockHeight <= 1036799) {
@@ -99,10 +99,10 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
             nFounderPayment = 8 * nBlocksPerPeriod;
             if (nBlockHeight > 518401)
                 nFounderPayment = 0;
-            nLabPayment = 8 * nBlocksPerPeriod;
+            nFoundationPayment = 8 * nBlocksPerPeriod;
             nBudgetPayment = 24 * nBlocksPerPeriod;
         } else {
-            nFounderPayment = nLabPayment = nBudgetPayment = 0;
+            nFounderPayment = nFoundationPayment = nBudgetPayment = 0;
         }
 
     } else if (nBlockHeight >= 1036800 && nBlockHeight <= 1555199) {
@@ -110,10 +110,10 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
         nBlockReward = 30;
         if(IsSuperBlock(nBlockHeight)) {
             nFounderPayment = 0;
-            nLabPayment = 6 * nBlocksPerPeriod;
+            nFoundationPayment = 6 * nBlocksPerPeriod;
             nBudgetPayment = 18 * nBlocksPerPeriod;
         } else {
-            nFounderPayment = nLabPayment = nBudgetPayment = 0;
+            nFounderPayment = nFoundationPayment = nBudgetPayment = 0;
         }
 
     } else if (nBlockHeight >= 1555200 && nBlockHeight <= 2073599) {
@@ -121,10 +121,10 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
         nBlockReward = 20;
         if(IsSuperBlock(nBlockHeight)) {
             nFounderPayment = 0;
-            nLabPayment = 4 * nBlocksPerPeriod;
+            nFoundationPayment = 4 * nBlocksPerPeriod;
             nBudgetPayment = 12 * nBlocksPerPeriod;
         } else {
-            nFounderPayment = nLabPayment = nBudgetPayment = 0;
+            nFounderPayment = nFoundationPayment = nBudgetPayment = 0;
         }
 
     } else if (nBlockHeight >= 2073600 && nBlockHeight <= 2591999) {
@@ -132,10 +132,10 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
         nBlockReward = 10;
         if(IsSuperBlock(nBlockHeight)) {
             nFounderPayment = 0;
-            nLabPayment = 2 * nBlocksPerPeriod;
+            nFoundationPayment = 2 * nBlocksPerPeriod;
             nBudgetPayment = 6 * nBlocksPerPeriod;
         } else {
-            nFounderPayment = nLabPayment = nBudgetPayment = 0;
+            nFounderPayment = nFoundationPayment = nBudgetPayment = 0;
         }
 
     } else {
@@ -143,10 +143,10 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
         nBlockReward = 10;
         if(IsSuperBlock(nBlockHeight)) {
             nFounderPayment = 0 * nBlocksPerPeriod;
-            nLabPayment = 2 * nBlocksPerPeriod;
+            nFoundationPayment = 2 * nBlocksPerPeriod;
             nBudgetPayment = 8 * nBlocksPerPeriod;
         } else {
-            nFounderPayment = nLabPayment = nBudgetPayment = 0;
+            nFounderPayment = nFoundationPayment = nBudgetPayment = 0;
         }
 
     }
@@ -156,7 +156,7 @@ void BudgetParams::GetBlockRewards(int nBlockHeight, CAmount& nBlockReward,
 
     nBlockReward *= COIN;
     nFounderPayment *= COIN;
-    nLabPayment *= COIN;
+    nFoundationPayment *= COIN;
     nBudgetPayment *= COIN;
 }
 
@@ -168,17 +168,17 @@ BudgetParams::BudgetParams(std::string strNetwork)
         budgetAddress_legacy = "3MvD3sxedwPzGSdLnehegDfBGfxpdMevk2";
         budgetAddress = "3LcNKTQSnxkdeuFkCNHet3XkEcUEyeENMF";
         founderAddress = "bv1qnauaweq25552zjthwqxq0puhz2flqrmhzh24h4";
-        labAddress_legacy = "341PYScHCbq5Y3G3orR14V1pSmhb8qamP5";
-        labAddress = "38J8RGLetRUNEXycBMPg8oZqLt4bB9hCbt";
+        foundationAddress_legacy = "341PYScHCbq5Y3G3orR14V1pSmhb8qamP5";
+        foundationAddress = "38J8RGLetRUNEXycBMPg8oZqLt4bB9hCbt";
 
     } else if (strNetwork == "test") {
         budgetAddress = "mxd3ciTteXZAna4q2as6z69mL6F7EncYjr";
         founderAddress = "mhurm1WXr8QXxMZXzJRH61TSjcaDviKfqY";
-        labAddress = "mw4P7NPXLVdCCZME8EGqTxbD2b4nF8sg1S";
+        foundationAddress = "mw4P7NPXLVdCCZME8EGqTxbD2b4nF8sg1S";
     } else if (strNetwork == "regtest") {
         budgetAddress = "2NCMc2apMAx5vY6wyYM8UyqCmfx2vpFmm1J";
         founderAddress = "2N7WZtWTdoFQjheviiGn4smykiwxNbHYdci";
-        labAddress = "2N2iEAT5o7TY9yrz6Li4j91j5L59sLqdFSf";
+        foundationAddress = "2N2iEAT5o7TY9yrz6Li4j91j5L59sLqdFSf";
     }
 }
 
@@ -194,11 +194,11 @@ std::string BudgetParams::GetFounderAddress() const
     return founderAddress;
 }
 
-std::string BudgetParams::GetLabAddress(int nHeight) const
+std::string BudgetParams::GetFoundationAddress(int nHeight) const
 {
     if (nHeight < nHeightAddressChange)
-        return labAddress_legacy;
-    return  labAddress;
+        return foundationAddress_legacy;
+    return  foundationAddress;
 }
 
 BudgetParams* BudgetParams::Get()

--- a/src/veil/budget.h
+++ b/src/veil/budget.h
@@ -20,8 +20,8 @@ private:
     std::string budgetAddress_legacy;
     std::string budgetAddress;
     std::string founderAddress;
-    std::string labAddress_legacy;
-    std::string labAddress;
+    std::string foundationAddress_legacy;
+    std::string foundationAddress;
     int nHeightAddressChange;
 
 public:
@@ -31,12 +31,12 @@ public:
     static void GetBlockRewards(int nBlockHeight,
                                 CAmount& nBlockReward,
                                 CAmount& nFounderPayment,
-                                CAmount& nLabPayment,
+                                CAmount& nFoundationPayment,
                                 CAmount& nBudgetPayment);
 
     std::string GetBudgetAddress(int nHeight) const;
     std::string GetFounderAddress() const;
-    std::string GetLabAddress(int nHeight) const;
+    std::string GetFoundationAddress(int nHeight) const;
     static const int nBlocksPerPeriod = 43200;
 };
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3806,8 +3806,8 @@ bool CWallet::CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits,
             nCredit += stakeInput->GetValue();
 
             // Calculate reward
-            CAmount nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment;
-            veil::Budget().GetBlockRewards(nHeight, nBlockReward, nFounderPayment, nLabPayment, nBudgetPayment);
+            CAmount nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment;
+            veil::Budget().GetBlockRewards(nHeight, nBlockReward, nFounderPayment, nFoundationPayment, nBudgetPayment);
             nCredit += nBlockReward;
             CBlockIndex* pindexPrev = chainActive.Tip();
             assert(pindexPrev != nullptr);


### PR DESCRIPTION
### Problem
Code still shows veil labs, rather than veil foundation for the budget payment process.

Per @4x13:
> Where it says nLabPayment it should be changed to nFoundationPayment so there aren't any future confusions

### Root Cause
Defunct Labs had not been changed to Foundation

### Solution
Done via script:
```
git grep -lz 'LabPayment'  | xargs -0 sed -i '' -e 's/LabPayment/FoundationPayment/g'
git grep -lz 'strLabAddress'  | xargs -0 sed -i '' -e 's/strLabAddress/strFoundationAddress/g'
git grep -lz 'labScript' | xargs -0 sed -i '' -e 's/labScript/foundationScript/g'
git grep -lz 'outLab'  | xargs -0 sed -i '' -e 's/outLab/outFoundation/g'
git grep -lz 'destLab'  | xargs -0 sed -i '' -e 's/destLab/destFoundation/g'
git grep -lz 'GetLabAddress' | xargs -0 sed -i '' -e 's/GetLabAddress/GetFoundationAddress/g'
git grep -lz 'labAddress' | xargs -0 sed -i '' -e 's/labAddress/foundationAddress/g'
git grep -lz 'Lab=' | xargs -0 sed -i '' -e 's/Lab=/Foundation=/g'
git grep -lz ' lab ' | xargs -0 sed -i '' -e 's/ lab / foundation /g'
```
Pre-inspection appears as though this caught everything intended, and didn't catch anything unintended.   One remaining item is the wording of the README since that will be likely more wording changes then just renaming.

### Testing
The bulk will be code inspection; with basic regression type tests... Unless QA wants to put it through a testnet superblock, although I feel that would be unnecessary.  debug messages should be covered as well in this PR.