### PR TITLE
Add missing header.

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -14,6 +14,7 @@
 #include <ui_interface.h>
 
 #include <memory>
+#include <deque>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This is required for building with GCC 9.2.