### PR TITLE
[Build] Fix timing issue in Travis between depends and build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - set -o errexit; source .travis/test_05_before_script.sh
 script:
   - if [ $SECONDS -gt 1200 ]; then set +o errexit; echo "Travis early exit to cache current state"; false; else set -o errexit; source .travis/test_06_script_a.sh; fi
-  - if [ $SECONDS -gt 1800 ]; then set +o errexit; echo "Travis early exit to cache current state"; false; else set -o errexit; source .travis/test_06_script_b.sh; fi
+  - if [ $SECONDS -gt 1200 ]; then set +o errexit; echo "Travis early exit to cache current state"; false; else set -o errexit; source .travis/test_06_script_b.sh; fi
 after_script:
   - echo $TRAVIS_COMMIT_RANGE
   - echo $TRAVIS_COMMIT_LOG


### PR DESCRIPTION
### Problem
Travis fails step 6 b of the test suite and can't get past it.

### Root Cause
Travis scripts  have a few timer checks; to make sure there is enough time to get through the remaining tests.  The intent of these checks is to cache the progress up through test step 6, generally the build of the depends files; and have them done when the tests are restarted.  This insures there is enough time for the full build and all the tests to run.

These time checks happen at the end of step 5, and at the end of step 6a.  The first makes sure that it didn't take over 20 minutes to get up through step 5; the second makes sure that it didn't take over 30 minutes to get through step 6a.  This leaves 20 minutes to finish all testing from that point on.

The problem, however, is when the script through step 5 is > 1200 seconds (20 minutes) but <= 1800 seconds (30 minutes).  In that situation, step 6a is skipped, but step 6b is not; and step 6b depends on things that were done in step 6a.  So the build ends up failing during step 6b, and therefore doesn't cache it.

### Solution
Unfortunately checking to see if step 6a was run is not as easy as checking to see if errexit is set:
`if [[ "$SHELLOPTS" =~ "errexit" ]] || [ $SECONDS -gt 1800 ] ; then`.  This check doesn't actually work for some reason.

Rather than continuing down that path; we can just abort at either point if the time is greater than 1800 seconds.  This way if it doesn't run 6a, it won't run 6b; and will cache the progress to that point for the next pass.

### QA ###
As this is a build system issue; no QA will be needed.  The true test will be after merging when we run against all the failed PRs.