### PR TITLE
[GUI] Fix sending page crashes

### DIFF
--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -48,7 +48,7 @@
       <item alignment="Qt::AlignHCenter">
        <widget class="QLabel" name="labelTitle">
         <property name="text">
-         <string>Encrypt Wallet</string>
+         <string>Encrypt wallet</string>
         </property>
        </widget>
       </item>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Send Veil</string>
+   <string>Send veil</string>
   </property>
   <property name="styleSheet">
    <string notr="true">border:none;
@@ -59,7 +59,7 @@ border:none;</string>
            <string notr="true">padding:10 0 10 0;</string>
           </property>
           <property name="text">
-           <string>Send Veil </string>
+           <string>Send veil</string>
           </property>
          </widget>
         </item>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -121,7 +122,7 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent)
     //widget->setFont(fixedPitchFont());
     // We don't want translators to use own addresses in translations
     // and this is the only place, where this address is supplied.
-    widget->setPlaceholderText(QObject::tr("Enter a Veil address (e.g. %1)").arg(
+    widget->setPlaceholderText(QObject::tr("Enter a Veil stealth address (e.g. %1)").arg(
         QString::fromStdString(DummyAddress(Params()))));
     widget->setValidator(new BitcoinAddressEntryValidator(parent));
     widget->setCheckValidator(new BitcoinAddressCheckValidator(parent));

--- a/src/qt/locale/veil_en.ts
+++ b/src/qt/locale/veil_en.ts
@@ -2102,7 +2102,7 @@ and blockchain data.</source>
     </message>
     <message>
         <location filename="../guiutil.cpp" line="+124"/>
-        <source>Enter a Veil address (e.g. %1)</source>
+        <source>Enter a Veil stealth address (e.g. %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/res/css/main.css
+++ b/src/qt/res/css/main.css
@@ -1,3 +1,9 @@
+/*
+// Copyright (c) 2019-2020 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+*/
+
 #centralWidget{
     border: none;
     padding: 0em 0em;
@@ -88,7 +94,7 @@ QToolBar > QToolButton:checked {
 background-image: url(":/icons/ic_nav_active") ;
 background-position: left center;
 background-repeat:no-repeat;
-background-size: 11px 18px;
+font-size: 11px 18px;
 }
 
 /* QToolBar > QToolButton:hover:!selected { */

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -478,13 +479,8 @@ void SendCoinsDialog::on_sendButton_clicked()
         }
     }
 
-    if(!valid){
-        openToastDialog(QString::fromStdString("Invalid data\n" + error), this);
-        return;
-    }
-
-    if(recipients.isEmpty()){
-        openToastDialog("No recipients", this);
+    if (!valid) {
+        openToastDialog(QString::fromStdString("Invalid data\n" + error), this->mainWindow->getGUI());
         return;
     }
 

--- a/src/qt/splashscreenveil.cpp
+++ b/src/qt/splashscreenveil.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2020 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <qt/splashscreenveil.h>
 #include <qt/forms/ui_splashscreenveil.h>
 #include <QPixmap>
@@ -24,7 +28,6 @@
 
 #include <QApplication>
 #include <QCloseEvent>
-#include <QPainter>
 #include <QRadialGradient>
 #include <QScreen>
 

--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -145,12 +146,16 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
 /* qDebug() message handler --> debug.log */
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
-    Q_UNUSED(context);
+#ifndef QT_MESSAGELOGCONTEXT
+   Q_UNUSED(context);
     if (type == QtDebugMsg) {
         LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
     } else {
         LogPrintf("GUI: %s\n", msg.toStdString());
     }
+#else // QT_MESSAGELOGCONTEXT needs to be added to the DEFS line of the Makefile
+    LogPrintf("GUI: %s:%d %s\n", context.file, context.line, msg.toStdString());
+#endif
 }
 
 /** Class encapsulating Bitcoin Core startup and shutdown.

--- a/src/qt/veil/forms/addressesmenu.ui
+++ b/src/qt/veil/forms/addressesmenu.ui
@@ -20,7 +20,7 @@
    <string>Form</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">backgruond-color:transparent;
+   <string notr="true">background-color:transparent;
 border:none;
 color:#bababa;</string>
   </property>

--- a/src/qt/veil/forms/addresseswidget.ui
+++ b/src/qt/veil/forms/addresseswidget.ui
@@ -92,7 +92,6 @@ border:none;
 QPushButton:checked {
     background-image: url(&quot;:/icons/ic-title&quot;) ;
     background-repeat:no-repeat;
-    background-size:6px;
     background-position: center bottom;
     color: #105aef;
 }

--- a/src/qt/veil/forms/balance.ui
+++ b/src/qt/veil/forms/balance.ui
@@ -100,7 +100,7 @@ padding-right:10px;
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="styleSheet">
-           <string notr="true">background-colot:transparent;
+           <string notr="true">background-color:transparent;
 border:none;</string>
           </property>
           <property name="text">

--- a/src/qt/veil/mainwindow.cpp
+++ b/src/qt/veil/mainwindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Veil developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -29,7 +29,6 @@
 #include <qt/walletmodel.h>
 
 #include <QAbstractItemDelegate>
-#include <QPainter>
 
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 5

--- a/src/qt/veil/settings/settingswidget.cpp
+++ b/src/qt/veil/settings/settingswidget.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2020 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <qt/veil/settings/settingswidget.h>
 
 //#include "transactiondetaildialog.h"
@@ -290,11 +294,11 @@ void SettingsWidget::setWalletModel(WalletModel *model){
 
 void SettingsWidget::updateStakingCheckboxStatus(){
     if(walletModel->getEncryptionStatus() == WalletModel::Unencrypted){
-        ui->labelStacking->setText("Encrypt Wallet");
+        ui->labelStacking->setText("Encrypt wallet");
         ui->labelStacking->setProperty("cssClass" , "btn-text-settings");
         ui->checkBoxStaking->setVisible(false);
     }else{
-        ui->labelStacking->setText("Unlock Wallet for Staking");
+        ui->labelStacking->setText("Unlock wallet for staking");
         ui->checkBoxStaking->setVisible(true);
     }
 }


### PR DESCRIPTION
### Problem
As seen in issue #684 and #697; the GUI crashes when you do things it's not expecting in the send screen.

### Root Cause
The error path in the GUI send screen tried to write the error message to the wrong object; which triggered the crash.  A number of other things were found while it was being investigated; the code to check for no recipients wasn't proper; it would never execute since the previous error catch would catch those as well.  Many things would cause the crash:  no recipient address, no value, a basecoin recipient address...

### Solution
Please note this is not a deep dive into all the problems in the send code; but was a means to enable reproduction of a different problem being investigated.  More work will go into this code when the time comes.  For now, a few improvements:

- Send page now notifies you what is wrong with your send; "Amount can't be zero", "only stealth addresses accepted", etc.
- Send Page now states "Enter a Veil stealth address" to help the user understand before they start that they can't send to a basecoin address.
- Several typos in properties were revealed when debugging was enabled
- As debugging revealed the crash was related to duplicate painter objects, investigation into that revealed several locations where QPainter was included and not necessary.

Ideally this should be done as two separate PRs; one to clean up the little stuff, and one for the crash.  However since it's a means to an end fix, for something more pressing; I'm pushing it as one.