### PR TITLE
[WIP][RingCT] Increase max inputs to 50

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -270,17 +271,18 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     {
         // We don't care if witness for this input is empty, since it must not be bloated.
         // If the script is invalid without witness, it would be caught sooner or later during validation.
-        if (tx.vin[i].scriptWitness.IsNull())
+        if (tx.vin[i].scriptWitness.IsNull()) {
             continue;
+        }
 
         if (tx.vin[i].IsAnonInput())
         {
             size_t sizeWitnessStack = tx.vin[i].scriptWitness.stack.size();
-            if (sizeWitnessStack > 3)
+            if (sizeWitnessStack > MAX_STANDARD_RINGCT_STACK_ITEMS)
                 return false;
             for (unsigned int j = 0; j < sizeWitnessStack; j++)
             {
-                if (tx.vin[i].scriptWitness.stack[j].size() > 4096)
+                if (tx.vin[i].scriptWitness.stack[j].size() > MAX_STANDARD_RINGCT_STACK_ITEM_SIZE)
                     return error("%s: witness is larger than max size", __func__);
             }
             continue;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -39,8 +40,12 @@ static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 /** The maximum number of witness stack items in a standard P2WSH script */
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS = 100;
+/** The maximum number of witness stack items in a RingCT script */
+static const unsigned int MAX_STANDARD_RINGCT_STACK_ITEMS = 3;
 /** The maximum size of each witness stack item in a standard P2WSH script */
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE = 80;
+/** The maximum size of each witness stack item in a RingCT script */
+static const unsigned int MAX_STANDARD_RINGCT_STACK_ITEM_SIZE = 384 + (50 * 352); // 50 inputs
 /** The maximum size of a standard witnessScript */
 static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
 /** Min feerate for defining dust. Historically this has been based on the


### PR DESCRIPTION
### Problem
Sending ringct transactions with more than 10 inputs results in a failure.
`Transaction commit failed: bad-witness-nonstandard (code 64)`

### Root Cause
The maximum witness stack item size was coded to 4096.  Particl changed theirs to 8192.  That number is actually 384 + 352 per input.  So 10 inputs == 3904; where 11 is 4256; which exceeds the 4096 and creates the error.

### Solution
Increase the number in a set way.  Instead of using magic numbers in the code, defines have been made to define them in policy.h.  The limit is changed to include 50 input transactions.  The error message cleanup will be done as a separate PR.