### PR TITLE
[GUI] Fix coin control crashes

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -436,7 +437,8 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
             coinControl()->nCoinType = CoinControlDialog::nCurrentCoinTypeSelected;
             coinControl()->fZerocoinSelected = CoinControlDialog::fSpendingZerocoin;
 
-            CAmount nValue = AmountFromValue(item->text(COLUMN_AMOUNT).toStdString());
+            CAmount nValue;
+            BitcoinUnits::parse(BitcoinUnits::VEIL, item->text(COLUMN_AMOUNT), &nValue);
 
             if (CoinControlDialog::fSpendingZerocoin)
                 coinControl()->Select(serialHash, nValue);

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -16,15 +17,17 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Space) // press spacebar -> select checkbox
     {
         event->ignore();
+        int COLUMN_CHECKBOX = 0;
         if (this->currentItem()) {
-            int COLUMN_CHECKBOX = 0;
-            this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+            this->currentItem()->setCheckState(COLUMN_CHECKBOX,
+               ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
         }
     }
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
     {
         event->ignore();
-        CoinControlDialog *coinControlDialog = static_cast<CoinControlDialog*>(this->parentWidget());
+        CoinControlDialog *coinControlDialog;
+        coinControlDialog = static_cast<CoinControlDialog*>(this->parentWidget()->parentWidget());
         coinControlDialog->done(QDialog::Accepted);
     }
     else


### PR DESCRIPTION
### Problem
GUI Coin Control crashes in a couple instances:
- When on the list of utxos (either by clicking on the line or checking the box) and then escaping, wallet crashes (Issue #660).
- When checking a UTXO 10,000 veil or larger will crash the wallet (Issue #661)

### Root Cause
First issue, the `Key_Escape` catch in `CoinControlTreeWidget::keyPressEvent` was getting the wrong object to close.

Second issue, the Coin Control display used the `BitcoinUnits::format` method for the value; which puts whitespace in values greater than 10,000.  This was not being accounted for when converting the value of the selection to a `CAmount`.

### Solution
Fix both issues.  The first by addressing the proper object; the second by using the `BitcoinUnits::parse` method to convert the amount column back to a `CAmount`.

### Testing ###
Ideally, test against a UTXO that is greater than 10000 and not a zerocoin; but also test against zerocoins.  Also make sure to click around the coin control page before hitting escape.

### QA ###
There may be other instances of this type of thing.  Anywhere you find a veil amount in excess of 10000, test around it to see if there's places where it's not converted properly.  Likewise; hit escapes in places to see if there's other areas where it is improperly escaped.  These would be separate issues.  Note that the receive page, and the debug window are the only other two places that catch keyboard input.