### PR TITLE
[ringct] Fix IsSpent check

### DIFF
--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -6145,6 +6145,18 @@ bool AnonWallet::IsSpent(const uint256& hash, unsigned int n) const
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
     range = mapTxSpends.equal_range(outpoint);
 
+    if (range.first == range.second) {
+        // the outpoint was not in the Tx Spends map.  check it directly
+        MapRecords_t::const_iterator mi = mapRecords.find(hash);
+        if (mi != mapRecords.end()) {
+            const COutputRecord *outputRecord = mi->second.GetOutput(n);
+            if (outputRecord != nullptr)
+                return outputRecord->IsSpent();
+        }
+        // If we got this far, assume it's spent
+        return true;
+    }
+
     for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
         const uint256 &wtxid = it->second;
 


### PR DESCRIPTION
### Problem
Occasionally wallets with a lot of ringCT transactions will start getting `GetAnonBalance: value out of range (code -1)` errors when trying to send ringct transactions.

### Root Cause
The algorithm that counted up the total coins available used the ringct anonwallet `isSpent()` to check if a UTXO was spent.  If it didn't think it was spent, it would count it.  This ended up drastically inflating the total coins that there were believed to be; and eventually surpassed the total supply, and thus generate the error.

The `IsSpent()` code had an error.  It pulled the outpoint from the TxSpends map, and then processed the range results to determine if it was spent, or abandoned; and would consider it not spent if it got through that whole section of code.  However, the code did not properly check the hash transaction if it wasn't actually in the TxSpends map.  

### Solution
If the outpoint isn't in the TxSpends map, check it directly to see if it's spent or not.

### Testing ###
Testing will be a challenge given the nature of the problem, and the lack of visibility into the inner workings to see if the count is incorrect or not.  As such, @4x13 is listed as a reviewer so that he can test it.  Otherwise, I highly recommend using regtest; move the premine to ringct and then do a significant number of ringct transactions until the problem starts to occur.  Then load the wallet with the new code and see if the issue clears up.

Also need to do doublechecks on other coin balances to make sure everything still looks okay.

### Additional Work ###

1. There are still a number of places in the code where `!MoneyRange()` calls are commented out.  Likely these were due to this same problem.  They will all need to be reviewed as a separate issue.
2. Ideally all the different `IsSpent()` methods can be properly designed so that a parent coin object has an IsSpent() method that is used, or overridden by different coin type objects.
3. The question of why the spent transactions aren't in the TxSpends map, which may be a further root cause that should be investigated to determine if there is a better way of fixing this problem, and if these outpoints not being in the TxSpends manifests as other symptoms as well.