### PR TITLE
[RPC] Update getblockchaininfo - Add a difficulty value for each algo type

### DIFF
--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -17,6 +17,8 @@ class uint256;
 
 static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
 
+static const unsigned int DEFAULT_CHECK_DIFFICULTY_BLOCK_COUNT = 1440; // ~1 day
+
 extern std::map<std::string, CBlock> mapProgPowTemplates;
 
 /**


### PR DESCRIPTION
### Problem ###
The RPC command `getblockchaininfo` only contains two values for difficulty, one for PoS and one for PoW. With the change to 3 PoW algos we need to return a difficulty value for each algo.

### Solution ###
`getblockchaininfo` was updated to return
```
"difficulty_pow": 0,
"difficulty_randomx": 0,
"difficulty_progpow": 0,
"difficulty_sha256d": 0,
"difficulty_pos": 0,
```

### Logic ### 
Search from the chaintip backward. For each block determine the algo type and if a difficulty value > 0 have already been saved for that type. Exit the difficulty lookup once a difficultly for each block type has been found or after checking the last 1440 blocks.

### Testing ###
Run the `getblockchaininfo` cmd via rpc or the console. Verify each difficulty matches the block explorer. You can also check the difficulty of each block with `getblock(getblockhash(180795))`
```
"proof_type": "Proof-of-Stake",
"difficulty": 2426835.587045338,
```
