### PR TITLE
[Trivial][RPC] Fix typo in rescanringctwallet

### DIFF
--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2017-2019 The Particl Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -170,7 +171,7 @@ static UniValue rescanringctwallet(const JSONRPCRequest &request)
 
     if (request.fHelp || !request.params.empty())
         throw std::runtime_error(
-                "rescanringctwallet()\n"
+                "rescanringctwallet\n"
                 "Rescans all transactions in the RingCT & CT Wallets."
                 + HelpRequiringPassphrase(wallet.get()) +
                 "\nExamples:\n"


### PR DESCRIPTION
### Problem
The `rescanringctwallet` command states `rescanringctwallet()` when you look at the help output:

```
~$ veil-cli help rescanringctwallet
rescanringctwallet()
Rescans all transactions in the RingCT & CT Wallets.
Examples:
> veil-cli rescanringctwallet
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "rescanringctwallet", "params": [] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/
```

### Root Cause
It's just plain wrong.  While this was a known trivial issue, it was very low priority.  However, with the use of the bash completion caused this to start to become annoying:

```
spectre@grape:~$ veil-cli rescan
rescanblockchain      rescanringctwallet()  rescanzerocoinwallet
spectre@grape:~$ veil-cli rescanringctwallet()
```


### Solution
Fix it:
```
spectre@Fortune:~$ veil-cli help rescan
rescanblockchain      rescanringctwallet    rescanzerocoinwallet
spectre@Fortune:~$ veil-cli help rescanringctwallet
rescanringctwallet
Rescans all transactions in the RingCT & CT Wallets.
Examples:
> veil-cli rescanringctwallet
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "rescanringctwallet", "params": [] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/
```

### Testing ###
Testing is obvious.  However, to understand the bash completion routines; these are found in `/contrib/veil-cli.bash-completion`  (there is also one for veild and veil-tx).  To install:
1. Copy to a directory on your linux machine.
2. Add a line `~/.bashrc`  `source <file>`, with the location and filename where you copied it to.
3. log back in or `source ~/.bashrc` to load it
4. use <tab> to complete commands.  i.e. `veil-cli rescan<tab><tab>r<tab>`

```
spectre@Fortune:~$ tail ~/.bashrc
source /home/spectre/git-repos/veil/contrib/veil-cli.bash-completion
source /home/spectre/git-repos/veil/contrib/veild.bash-completion
```