### PR TITLE
[RingCT] Increase max inputs to 50

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,7 +9,6 @@
 #include <policy/policy.h>
 
 #include <consensus/validation.h>
-#include <validation.h>
 #include <coins.h>
 #include <tinyformat.h>
 #include <util.h>
@@ -276,11 +276,11 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         if (tx.vin[i].IsAnonInput())
         {
             size_t sizeWitnessStack = tx.vin[i].scriptWitness.stack.size();
-            if (sizeWitnessStack > 3)
+            if (sizeWitnessStack > maxStandardRingctStackItems())
                 return false;
             for (unsigned int j = 0; j < sizeWitnessStack; j++)
             {
-                if (tx.vin[i].scriptWitness.stack[j].size() > 4096)
+                if (tx.vin[i].scriptWitness.stack[j].size() > maxStandardRingctStackItemSize())
                     return error("%s: witness is larger than max size", __func__);
             }
             continue;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,6 +8,7 @@
 #define BITCOIN_POLICY_POLICY_H
 
 #include <consensus/consensus.h>
+#include <validation.h>
 #include <policy/feerate.h>
 #include <script/interpreter.h>
 #include <script/standard.h>
@@ -39,8 +41,16 @@ static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 /** The maximum number of witness stack items in a standard P2WSH script */
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS = 100;
+/** The maximum number of witness stack items in a RingCT script */
+static const unsigned int MAX_STANDARD_RINGCT_STACK_ITEMS = 3;
+static unsigned int maxStandardRingctStackItems() { return MAX_STANDARD_RINGCT_STACK_ITEMS; }
 /** The maximum size of each witness stack item in a standard P2WSH script */
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE = 80;
+/** The maximum size of each witness stack item in a RingCT script */
+static const unsigned int MAX_STANDARD_RINGCT_STACK_ITEM_SIZE = 384 + (50 * 352); // 50 inputs
+static const unsigned int MAX_STANDARD_RINGCT_STACK_ITEM_SIZE_OLD = 4096;
+static unsigned int maxStandardRingctStackItemSize() {
+    return (isPowTimeStampActive() ? MAX_STANDARD_RINGCT_STACK_ITEM_SIZE : MAX_STANDARD_RINGCT_STACK_ITEM_SIZE_OLD); }
 /** The maximum size of a standard witnessScript */
 static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
 /** Min feerate for defining dust. Historically this has been based on the

--- a/src/validation.h
+++ b/src/validation.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -533,6 +534,8 @@ extern std::unique_ptr<Precompute> pprecompute;
  * This is also true for mempool checks.
  */
 int GetSpendHeight(const CCoinsViewCache& inputs);
+
+static bool isPowTimeStampActive() { return (chainActive.Tip()->nTime >= nPowTimeStampActive); }
 
 extern VersionBitsCache versionbitscache;
 


### PR DESCRIPTION
### Problem
Sending ringct transactions with more than 10 inputs results in a failure.
`Transaction commit failed: bad-witness-nonstandard (code 64)`

### Root Cause
The maximum witness stack item size was coded to 4096.  Particl changed theirs to 8192.  That number is actually 384 + 352 per input.  So 10 inputs == 3904; where 11 is 4256; which exceeds the 4096 and creates the error.

### Solution
Increase the number in a set way.  Instead of using magic numbers in the code, defines have been made to define them in policy.h.  The limit is changed to include 50 input transactions.  The error message cleanup will be done as a separate PR.

### Testing
This will need to be tested on the v1.1 branch as it requires consensus on both sides to allow for the larger witness stack.  Testing can be done with coin control (might need to merge in #758, #757 and #755) by selecting over 10 ringct inputs (ideally see 51 fail and 50 succeed).  Need to verify that this transaction goes through into a block on the PoW devnet with everyone upgraded.