### PR TITLE
Disable Dark Mode on recent versions of macOS.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -171,7 +171,8 @@ QT_MOC_CPP = \
 
 BITCOIN_MM = \
   qt/macdockiconhandler.mm \
-  qt/macnotificationhandler.mm
+  qt/macnotificationhandler.mm \
+  qt/macdarkmode.mm
 
 QT_MOC = \
   qt/veil.moc \
@@ -211,6 +212,7 @@ BITCOIN_QT_H = \
   qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
+  qt/macdarkmode.h \
   qt/modaloverlay.h \
   qt/networkstyle.h \
   qt/notificator.h \

--- a/src/qt/macdarkmode.h
+++ b/src/qt/macdarkmode.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include <stdbool.h>
+
+bool isDarkMode();
+void disableDarkMode();
+

--- a/src/qt/macdarkmode.mm
+++ b/src/qt/macdarkmode.mm
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "macdarkmode.h"
+
+#include <AppKit/AppKit.h>
+#include <objc/runtime.h>
+
+bool isDarkMode()
+{
+    NSString *interfaceStyle = [NSUserDefaults.standardUserDefaults valueForKey:@"AppleInterfaceStyle"];
+    return [interfaceStyle isEqualToString:@"Dark"];
+}
+
+
+// This is a work around for our not having as yet any "Dark Mode" compatible
+// stylesheets.  Enforce the use of known-good Aqua style on systems that support
+// the NSAppearance property.
+//
+// That is to say, the interface is only available on 10.14+.
+@interface NSApplication (NSAppearanceCustomization) <NSAppearanceCustomization>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wavailability"
+@property (nullable, strong) NSAppearance *appearance;
+@property (readonly, strong) NSAppearance *effectiveAppearance;
+#pragma clang diagnostic pop
+@end
+
+void disableDarkMode()
+{
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,14,0}])
+    {
+        NSApp.appearance = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
+    }
+}
+

--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -22,6 +22,7 @@
 #include <qt/platformstyle.h>
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
+#include <qt/macdarkmode.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/paymentserver.h>
@@ -314,6 +315,13 @@ BitcoinApplication::BitcoinApplication(interfaces::Node& node, int &argc, char *
 
 void BitcoinApplication::setupPlatformStyle()
 {
+#if defined(Q_OS_MAC)
+    // This is a work around for our not having as yet any "Dark Mode" compatible
+    // stylesheets.  Enforce the use of known-good Aqua style on systems that support
+    // the NSAppearance property.
+    disableDarkMode();
+#endif
+
     // UI per-platform customization
     // This must be done inside the BitcoinApplication constructor, or after it, because
     // PlatformStyle::instantiate requires a QApplication


### PR DESCRIPTION
### Problem ###
Recent macOS releases have introduced a so-called “Dark Mode” feature meant to give mac users an alternative theme for their operating system.
As of this time, the stylesheets we have in the Qt application do not work well with this change of colours.

In other words:
![dmode wrong](https://user-images.githubusercontent.com/5908875/78070263-c88c8980-739b-11ea-8855-8e797b9f5701.png)


### Root Cause ###
The root cause is a change in the Qt styling system on macOS, broadly speaking the problem was introduced by Apple Inc.

### Solution ###
The way I fix this is by just enforcing the known-good Aqua style.

In other words:
![dmode right](https://user-images.githubusercontent.com/5908875/78070297-d2ae8800-739b-11ea-8a32-4c90b4742958.png)

### Unit Testing Results ###
Build on a relatively recent version of macOS, and see if: 

1)  The build is successful.
2)  The user succeeds in launching the application to the main window.
3)  The main window is visible and usable.

Versions to test :  10.14, 10.13.   The former introduced the problem, check for regression on later.