### PR TITLE
[RPC] Help user out if RPC return is Null.

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -382,6 +382,10 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                 strResult = lastResult.get_str();
             else
                 strResult = lastResult.write(2);
+
+            if (lastResult.isNull())
+                strResult.append(" (is not necessarily indicative of a fatal error)");
+
         case STATE_ARGUMENT:
         case STATE_EATING_SPACES:
             return true;


### PR DESCRIPTION
### Problem ###
For the sake of lowering confusion with users, requests used in console that return 'null' should be accompanied with a short text description of what's been achieved. This will solve many cases of users believing something has gone wrong when entering a command in console and getting null as a return.


### Root Cause ###
Not all RPC calls return a value.

### Solution ###
In case of a Qt context.
If the RPC’s call return value is a Null object, then we append a string to help the user out.
Otherwise, the command-line RPC behaviour remains unmodified.

### Unit Testing Results ###
Run various RPC commands and see if the returned value is helpful. 

`clearmempool` returns Null, you can test with this command.
Other such commands (not exhaustive):
`savemempool`
`syncwithvalidationinterfacequeue`