### PR TITLE
[GUI] Do not use Qt's debugging information in the log handler.

### DIFF
--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -146,16 +146,19 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
 /* qDebug() message handler --> debug.log */
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
-#ifndef QT_MESSAGELOGCONTEXT
-   Q_UNUSED(context);
+//#ifndef QT_MESSAGELOGCONTEXT
+// ^ Do not use this except in debugging environments as some OSs don't handle it properly
+ 
+    Q_UNUSED(context);
     if (type == QtDebugMsg) {
         LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
     } else {
         LogPrintf("GUI: %s\n", msg.toStdString());
     }
-#else // QT_MESSAGELOGCONTEXT needs to be added to the DEFS line of the Makefile
-    LogPrintf("GUI: %s:%d %s\n", context.file, context.line, msg.toStdString());
-#endif
+
+//#else // QT_MESSAGELOGCONTEXT needs to be added to the DEFS line of the Makefile
+//    LogPrintf("GUI: %s:%d %s\n", context.file, context.line, msg.toStdString());
+//#endif
 }
 
 /** Class encapsulating Bitcoin Core startup and shutdown.


### PR DESCRIPTION
(Commit cherry picked from #766 for fast tracking)
### Problem ###
CaveSpectre and mimir (others?) have reported a crash on recent macOS builds.
The crash is a segmentation fault in a debug handler named DebugMessageHandler(),
at runtime, before the slash screen, or main window, is shown.

### Root Cause ###
The issue has been tracked down to incorrect usage of the debug.log message handler override.
This is a part of Qt that allows us to log to debug.log, using a bypassed message handler
in the form of a callback function.

The issue is that we should not access some of the “context” information, passed in the form of
a QmessageLogContext.

If we peruse the Qt documentation:

Note: By default, this information is recorded only in debug builds. You can overwrite this explicitly by defining QT_MESSAGELOGCONTEXT or QT_NO_MESSAGELOGCONTEXT.

### Solution ###
The correct way to fix this is to not make use of any of the potentially unavailable debugging information.

### Unit Testing Results ###
Build on a relatively recent version of macOS, and see if: 

1)  The build is successful.
2)  The user succeeds in launching the application to the main window.