### PR TITLE
[WIP][Build] Fix travis build issues with randomx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 os: linux
 language: minimal
 cache:

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,23 @@ AC_CONFIG_HEADERS([src/config/veil-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 
+dnl Add config links for asm includes for RandomX
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_epilogue_linux.inc:src/crypto/randomx/asm/program_epilogue_linux.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_epilogue_store.inc:src/crypto/randomx/asm/program_epilogue_store.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_epilogue_win64.inc:src/crypto/randomx/asm/program_epilogue_win64.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_loop_load.inc:src/crypto/randomx/asm/program_loop_load.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_loop_store.inc:src/crypto/randomx/asm/program_loop_store.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_prologue_linux.inc:src/crypto/randomx/asm/program_prologue_linux.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_prologue_win64.inc:src/crypto/randomx/asm/program_prologue_win64.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_read_dataset.inc:src/crypto/randomx/asm/program_read_dataset.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_read_dataset_sshash_fin.inc:src/crypto/randomx/asm/program_read_dataset_sshash_fin.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_read_dataset_sshash_init.inc:src/crypto/randomx/asm/program_read_dataset_sshash_init.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_sshash_constants.inc:src/crypto/randomx/asm/program_sshash_constants.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_sshash_load.inc:src/crypto/randomx/asm/program_sshash_load.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_sshash_prefetch.inc:src/crypto/randomx/asm/program_sshash_prefetch.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/program_xmm_constants.inc:src/crypto/randomx/asm/program_xmm_constants.inc])
+AC_CONFIG_LINKS([src/crypto/randomx/asm/randomx_reciprocal.inc:src/crypto/randomx/asm/randomx_reciprocal.inc])
+
 BITCOIN_DAEMON_NAME=veild
 BITCOIN_GUI_NAME=veil-qt
 BITCOIN_CLI_NAME=veil-cli

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -518,6 +518,17 @@ crypto_libbitcoin_crypto_base_a_SOURCES = \
   crypto/randomx/asm/configuration.asm \
   crypto/randomx/asm/program_prologue_linux.inc \
   crypto/randomx/asm/program_xmm_constants.inc \
+  crypto/randomx/asm/program_loop_load.inc \
+  crypto/randomx/asm/program_read_dataset.inc \
+  crypto/randomx/asm/program_read_dataset_sshash_init.inc \
+  crypto/randomx/asm/program_read_dataset_sshash_fin.inc \
+  crypto/randomx/asm/program_loop_store.inc \
+  crypto/randomx/asm/program_epilogue_store.inc \
+  crypto/randomx/asm/program_epilogue_linux.inc \
+  crypto/randomx/asm/program_sshash_load.inc \
+  crypto/randomx/asm/program_sshash_prefetch.inc \
+  crypto/randomx/asm/program_sshash_constants.inc \
+  crypto/randomx/asm/randomx_reciprocal.inc \
   crypto/c_threads.h \
   crypto/hash-ops.h \
   crypto/rx-slow-hash.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -516,6 +516,8 @@ crypto_libbitcoin_crypto_base_a_SOURCES = \
   crypto/randomx/blake2/blamka-round-ssse3.h \
   crypto/randomx/blake2/endian.h \
   crypto/randomx/asm/configuration.asm \
+  crypto/randomx/asm/program_prologue_linux.inc \
+  crypto/randomx/asm/program_xmm_constants.inc \
   crypto/c_threads.h \
   crypto/hash-ops.h \
   crypto/rx-slow-hash.c


### PR DESCRIPTION
**_Note this is a WIP to test if the solution is complete_**

### Problem
Travis fails when building `jit_compiler_x86_static.S`  when it can't find certain asm include files.

### Root Cause
They're needed in the Makefile

### Solution
Add them

### Testing
Travis script will handle it

Thanks to @akshaynexus for figuring this out!