### PR TITLE
[Tests] Fix some tests and use CAmount for SetValue Calls

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -25,7 +25,7 @@ public:
     /** Fee rate of 0 satoshis per kB */
     CFeeRate() : nSatoshisPerK(0) { }
     template<typename I>
-    CFeeRate(const I _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) {
+    explicit CFeeRate(const I _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) {
         // We've previously had bugs creep in from silent double->int conversion...
         static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
     }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -43,7 +43,7 @@ std::string CTxIn::ToString() const
     return str;
 }
 
-void CTxOutBase::SetValue(int64_t value)
+void CTxOutBase::SetValue(const CAmount& value)
 {
     // convenience function intended for use with CTxOutStandard only
     if (nVersion != OUTPUT_STANDARD) return;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -348,7 +348,7 @@ public:
 
     virtual bool IsEmpty() const { return false;}
 
-    void SetValue(CAmount value);
+    void SetValue(const CAmount& value);
     void AddToValue(const CAmount& nValue);
     virtual bool SetScriptPubKey(const CScript& scriptPubKey) { return false; }
 

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(bip173_testvectors_invalid)
         " 1nwldj5",
         "\x7f""1axkwrx",
         "\x80""1eym55h",
-        "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+        "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvxandsomecharstonotmatchveillimit",
         "pzry9x0s0muk",
         "1pzry9x0s0muk",
         "x1b4n0q5v",

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -135,7 +135,7 @@ static void RunTest(const TestVector &test) {
 
         CDataStream ssPriv(SER_DISK, CLIENT_VERSION);
         ssPriv << keyNew;
-        BOOST_CHECK(ssPriv.size() == 75);
+        BOOST_CHECK(ssPriv.size() == 74);
 
         CExtPubKey pubCheck;
         CExtKey privCheck;

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -5,7 +5,7 @@
 #include <policy/policy.h>
 #include <txmempool.h>
 #include <util.h>
-
+#include <validation.h>
 #include <test/test_veil.h>
 
 #include <boost/test/unit_test.hpp>
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 
 
     CTxMemPool testPool;
-    LOCK(testPool.cs);
+    LOCK2(cs_main, testPool.cs);
 
     // Nothing in pool, remove should do nothing:
     unsigned int poolSize = testPool.size();


### PR DESCRIPTION
This PR Fixes the mempool_tests,bech32_tests,bip32_tests and sets the value arg for SetValue calls to CTxOutBase to const CAmount& to match the header func.

There is a segfault on SetValue in blockencoding_tests.cpp that will need more investigation to be fixed.