### PR TITLE
🚀9% less memory:  make SaltedOutputHasher noexcept. 

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -121,8 +121,16 @@ public:
      * This *must* return size_t. With Boost 1.46 on 32-bit systems the
      * unordered_map will behave unpredictably if the custom hasher returns a
      * uint64_t, resulting in failures when syncing the chain (#4634).
+     *
+     * Having the hash noexcept allows libstdc++'s unordered_map to recalculate
+     * the hash during rehash, so it does not have to cache the value. This
+     * reduces node's memory by sizeof(size_t). The required recalculation has
+     * a slight performance penalty (around 1.6%), but this is compensated by
+     * memory savings of about 9% which allow for a larger dbcache setting.
+     *
+     * @see https://gcc.gnu.org/onlinedocs/gcc-9.2.0/libstdc++/manual/manual/unordered_associative.html
      */
-    size_t operator()(const COutPoint& id) const {
+    size_t operator()(const COutPoint& id) const noexcept {
         return SipHashUint256Extra(k0, k1, id.hash, id.n);
     }
 };


### PR DESCRIPTION
**Problem**
`If the hash is not noexcept, unorderd_map has to assume that it can throw an exception. Thus when rehashing care needs to be taken. libstdc++ solves this by simply caching the hash value, which increases memory of each node by 8 bytes. Adding noexcept prevents this caching. In my experiments with -reindex-chainstate -stopatheight=594000, memory usage (maximum resident set size) has decreased by 9.4% while runtime has increased by 1.6% due to additional hashing. Additionally, memusage::DynamicUsage() is now more accurate and does not underestimate.`
For credits and additional discussion, see [the original](https://github.com/bitcoin/bitcoin/pull/16957)

**Root Cause**
Assumptions in libstdc++.

**Solution**
Indicate that libstdc++ doesn't need to cache values.
This results in an overall reduction in memory usage of ~9%.

**Unit Testing Results**
The build is successful.
Test the wallet, make sure nothing hangs.
Is the behaviour acceptable?