### PR TITLE
[ReIndex] Skip RingCT TX computation during resynching

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2679,7 +2679,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                 CTxOutRingCT *txout = (CTxOutRingCT*)tx.vpout[k].get();
 
                 int64_t nTestExists;
-                if (!fVerifyingDB && pblocktree->ReadRCTOutputLink(txout->pk, nTestExists)) {
+                if (!fSkipComputation && !fVerifyingDB && pblocktree->ReadRCTOutputLink(txout->pk, nTestExists)) {
                     control.Wait();
 
                     if (nTestExists > pindex->pprev->nAnonOutputs) {
@@ -2694,7 +2694,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     return error("%s: Duplicate anon-output (db) %s, index %d.", __func__, HexStr(txout->pk.begin(), txout->pk.end()), nTestExists);
                 }
 
-                if (!fVerifyingDB && view.ReadRCTOutputLink(txout->pk, nTestExists)) {
+                if (!fSkipComputation && !fVerifyingDB && view.ReadRCTOutputLink(txout->pk, nTestExists)) {
                     control.Wait();
                     return error("%s: Duplicate anon-output (view) %s, index %d.", __func__, HexStr(txout->pk.begin(), txout->pk.end()), nTestExists);
                 }


### PR DESCRIPTION
### Problem
**_Every other_** reindex fails when processing RingCT transactions.  (Issue #784 )

### Root Cause
When reindexing, the existing RingCT transactions still exist in the wallet; therefore when you compare a RingCT transaction against the list, it's found and generates an error.  The code then rolls back and clears the transaction record, so the next reindex is successful since the record doesn't exist anymore.

### Solution
As in other areas of the reindex process, some calculations are skipped since it's not a new block, but rather reindexing an existing block... so you already have some information on it.  This now skips the existence test of ringct transactions on a reindex.

### Testing
It is important that you run any test twice; as the first test may not have the records in them (from being deleted on a previous reindex).  Initial tests were done with `-reindex-chainstate -stopatheight=1600` as the first RingCT is in block 1529.  One pass will fail at block 1529, the other will successfully pass it.  The failing test appears as:
```
2020-05-09T17:37:10Z UpdateTip: new best=c97704555f8d49cd66fd198162803004139cbca84724c90600c319ae1b2b34c4 height=1528 type=PoS version=0x20000000 tx=5744 date='2019-01-04T02:12:18Z' cache=0.8MiB(4579txo)
2020-05-09T17:37:10Z Attempting to repair anon index.
2020-05-09T17:37:10Z ERROR: ConnectTip(): ConnectBlock 3494732d196280247c924bc7fa50372af3d01d2e2a57a0d9cc3b8ace407940dd failed
```