### PR TITLE
gui: Fix leak in CoinControlDialog::updateView

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -766,8 +766,7 @@ void CoinControlDialog::updateView(int nCoinType)
 
     if (nCoinType == OUTPUT_STANDARD && !CoinControlDialog::fSpendingZerocoin) {
         for (const auto &coins : model->wallet().listCoins()) {
-            CCoinControlWidgetItem *itemWalletAddress = new CCoinControlWidgetItem();
-            itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+            CCoinControlWidgetItem *itemWalletAddress{nullptr};
             QString sWalletAddress = QString::fromStdString(EncodeDestination(coins.first));
             QString sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
             if (sWalletLabel.isEmpty())
@@ -775,7 +774,7 @@ void CoinControlDialog::updateView(int nCoinType)
 
             if (treeMode) {
                 // wallet address
-                ui->treeWidget->addTopLevelItem(itemWalletAddress);
+                itemWalletAddress = new CCoinControlWidgetItem(ui->treeWidget);
 
                 itemWalletAddress->setFlags(flgTristate);
                 itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);


### PR DESCRIPTION
**problem**

This is admittedly a small issue, but nonetheless there's a leak in the CoinControl view update when the tree mode is not enabled. As you see the CCoinControlWidgetItem gets created when there's no need for it.

I think this right, please check that I didn't miss other logic there.

**how to solve**

Move the `new CCoinControlWidgetItem` a bit further down in the proper `if (treeMode)` area.

**how to test.**

You want to go into the Wallet ->  Send ->   Coin Control at the bottom.   Toggle knobs, play with the options, nothing should crash or behave strangely.

