### PR TITLE
[GUI]: add a small indicator for the last block time in the left panel.

### DIFF
--- a/src/qt/veil/balance.cpp
+++ b/src/qt/veil/balance.cpp
@@ -170,6 +170,8 @@ void Balance::onBtnBalanceClicked(int type){
 
 void Balance::setClientModel(ClientModel *model){
     this->clientModel = model;
+
+    connect(model, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(setNumBlocks(int,QDateTime,double,bool)));
 }
 
 void Balance::setWalletModel(WalletModel *model){
@@ -233,13 +235,14 @@ void Balance::refreshWalletStatus() {
     interfaces::Wallet& wallet = walletModel->wallet();
     std::string strAddress;
     std::vector<interfaces::WalletAddress> addresses = wallet.getLabelAddress("stealth");
+
     if(!addresses.empty()) {
         interfaces::WalletAddress address = addresses[0];
         if (address.dest.type() == typeid(CStealthAddress)){
             bool fBech32 = true;
             strAddress = EncodeDestination(address.dest,true);
         }
-    }else {
+    } else {
         ui->copyAddress->setVisible(true);
         ui->labelReceive->setAlignment(Qt::AlignLeft);
         ui->labelReceive->setText("Receiving address");
@@ -320,4 +323,12 @@ void Balance::refreshWalletStatus() {
 #endif
 }
 
+void Balance::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool header)
+{
+    if (!clientModel)
+        return;
+
+    // Set the informative last block time label.
+    ui->labelLastBlockTime_Content->setText(blockDate.toString());
+}
 

--- a/src/qt/veil/balance.h
+++ b/src/qt/veil/balance.h
@@ -37,6 +37,7 @@ public:
 
 public Q_SLOTS:
     void setBalance(const interfaces::WalletBalances& balances);
+    void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool header);
     void updateDisplayUnit();
     void onBtnBalanceClicked();
     void onBtnUnconfirmedClicked();

--- a/src/qt/veil/forms/balance.ui
+++ b/src/qt/veil/forms/balance.ui
@@ -315,6 +315,32 @@ margin:0 0 20 10;</string>
              </widget>
             </item>
             <item>
+             <widget class="QLabel" name="labelLastBlockTime_Head">
+              <property name="styleSheet">
+               <string notr="true">   background-color: transparent;
+color: #004377;</string>
+              </property>
+              <property name="text">
+               <string> Last block time</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelLastBlockTime_Content">
+              <property name="styleSheet">
+               <string notr="true">background-color: transparent;
+padding-left:5px;
+padding-right:5px;
+padding-bottom:3px;
+font-size:11px;
+color:#707070;</string>
+              </property>
+              <property name="text">
+               <string>N/A</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QFrame" name="horiz">
               <property name="styleSheet">
                <string notr="true">#horiz{


### PR DESCRIPTION
![veil-lastblocktime](https://user-images.githubusercontent.com/5908875/82761091-3c756c00-9df8-11ea-9127-8cb58beda068.png)


**Problem**
A small improvement to the usability: the user often needs to see what the block time is on the current node, and it is very annoying having to open the debug console to extract this information.

**Root Cause**
The value is not visible.

**Solution**
I have added two labels to the main form, and rigged up the signal to update the block time.

**Testing**
Should be straightforward.
Maybe show this around to see what people think.
