### PR TITLE
Correct incorrect usage of string arithmetic.

### DIFF
--- a/src/libzerocoin/Bulletproofs.cpp
+++ b/src/libzerocoin/Bulletproofs.cpp
@@ -188,7 +188,7 @@ CBN_matrix Bulletproofs::splitIntoSets(const CBN_matrix ck_inner_g, const int s)
         return g_sets;
     }
 
-    else throw std::runtime_error("wrong s inside splitIntoSets: " + s);
+    else throw std::runtime_error("wrong s inside splitIntoSets: " + std::to_string(s));
 }
 
 // Function for reduction when mu > 1
@@ -297,7 +297,7 @@ CBN_matrix Bulletproofs::get_new_gs_hs(const CBN_matrix g_sets, const int sign,
             new_g = (g_sets[0][j].pow_mod(xn,p)).mul_mod(
                     g_sets[1][j].pow_mod(x,p),p);
         else
-            throw std::runtime_error("wrong sign inside get_new_gs_hs: " + sign);
+            throw std::runtime_error("wrong sign inside get_new_gs_hs: " + std::to_string(sign));
 
         new_gs[0].push_back(new_g);
     }
@@ -323,7 +323,7 @@ CBN_matrix Bulletproofs::get_new_as_bs(const CBN_matrix a_sets, const int sign,
         else if (sign < 0)
             aj = (a_sets[0][j].mul_mod(xn,q) + a_sets[1][j].mul_mod(x, q)) % q;
         else
-            throw std::runtime_error("wrong sign inside get_new_as_bs: " + sign);
+            throw std::runtime_error("wrong sign inside get_new_as_bs: " + std::to_string(sign));
 
         a2[0][j] = aj;
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1024,7 +1024,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
             "The third optional argument (may be null) is an array of base58-encoded private\n"
             "keys that, if given, will be the only keys used to sign the transaction.\n"
 #ifdef ENABLE_WALLET
-            + (!gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) ? HelpRequiringPassphrase(pwallet) + "\n" : ""
+            + HelpRequiringPassphrase(pwallet) + "\n"
 #endif
             "\nArguments:\n"
             "1. \"hexstring\"     (string, required) The transaction hex string\n"


### PR DESCRIPTION
**Problem**

It is not acceptable to add an int to a string. This will result in completely different behaviour than what is intended.

**Solution**

The simple way to fix this is std::to_string() invocation to create a string object and then the plus works as intended.

Furthermore, this fixes a bug where the ? Operator has a lower priority as +.

**Testing.**


~Check that the signrawtransaction rpc command’s help message is okay.~

Open to ideas on how to test Bulletproofs::splitIntoSets.

The basic idea is sound, demonstrated by the following snipped:

```c++
#include <stdexcept> 
  
int main() 
{ 
   int s = 10; 
    (A)  throw std::runtime_error("wrong number " + s); 
    (B)  throw std::runtime_error("wrong number " + std::to_string(s)); 

   return 0; 
}

```
-----
(A)
```bash
phil@crn ~/projects/tmp $ clang++ runerr.cpp  
runerr.cpp:6:46: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int] 
   throw std::runtime_error("wrong number " + s); 
                            ~~~~~~~~~~~~~~~~^~~ 
runerr.cpp:6:46: note: use array indexing to silence this warning 
   throw std::runtime_error("wrong number " + s); 
                                            ^ 
                            &               [  ] 
1 warning generated. 
phil@crn ~/projects/tmp $ ./a.out  
terminate called after throwing an instance of 'std::runtime_error' 
 what():  er  
Aborted
```

-----
(B)
```c++
.phil@crn ~/projects/tmp $ ./a.out 
terminate called after throwing an instance of 'std::runtime_error'
  what():  wrong number 10
Aborted
```