### PR TITLE
Rework exceptions where reference is missing.

### DIFF
--- a/src/qt/veil/settings/settingswidget.cpp
+++ b/src/qt/veil/settings/settingswidget.cpp
@@ -118,7 +118,7 @@ void SettingsWidget::onCheckStakingClicked(bool res) {
                 error = true;
             }
         }
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
         error = true;
     }
@@ -140,7 +140,7 @@ void SettingsWidget::onLockWalletClicked(){
         mainWindow->getGUI()->showHide(true);
         UnlockPasswordDialog *dialog = new UnlockPasswordDialog(/*fUnlockForStakingOnly*/false, mainWindow->getWalletModel(), mainWindow->getGUI());
         openDialogWithOpaqueBackground(dialog, mainWindow->getGUI(), 4);
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }
@@ -150,7 +150,7 @@ void SettingsWidget::onFaqClicked(){
         mainWindow->getGUI()->showHide(true);
         SettingsFaq *dialog = new SettingsFaq(mainWindow->getGUI());
         openDialogWithOpaqueBackgroundFullScreen(dialog, mainWindow->getGUI());
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 
@@ -159,7 +159,7 @@ void SettingsWidget::onFaqClicked(){
 void SettingsWidget::onAdvanceClicked(){
     try {
         mainWindow->getGUI()->showDebugWindow();
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 
@@ -170,7 +170,7 @@ void SettingsWidget::onResetOptionClicked(){
 
         //SendControlDialog *dialog = new SendControlDialog(mainWindow);
         //openDialogFullScreen(mainWindow, dialog);
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 
@@ -182,7 +182,7 @@ void SettingsWidget::onPreferenceClicked(){
         //mainWindow->getGUI()->showHide(true);
         //SettingsPreferences *dialog = new SettingsPreferences();
         //openDialogWithOpaqueBackground(dialog, mainWindow->getGUI());
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }
@@ -193,7 +193,7 @@ void SettingsWidget::onBackupClicked(){
         //mainWindow->getGUI()->showHide(true);
         //SettingsBackup *dialog = new SettingsBackup(mainWindow->getGUI());
         //openDialogWithOpaqueBackground(dialog, mainWindow->getGUI());
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }
@@ -209,7 +209,7 @@ void SettingsWidget::onRestoreClicked(){
         }
         SettingsRestore *dialog = new SettingsRestore(wordList, mainWindow->getGUI());
         openDialogWithOpaqueBackgroundFullScreen(dialog, mainWindow->getGUI());
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }
@@ -220,7 +220,7 @@ void SettingsWidget::onMintingClicked(){
         mainWindow->getGUI()->showHide(true);
         SettingsMinting *dialog = new SettingsMinting(mainWindow->getGUI(), mainWindow , this->walletModel);
         openDialogWithOpaqueBackgroundFullScreen(dialog, mainWindow->getGUI());
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }
@@ -230,7 +230,7 @@ void SettingsWidget::onNetworkClicked(){
         mainWindow->getGUI()->showHide(true);
         SettingsNetwork *dialog = new SettingsNetwork(mainWindow->getGUI());
         openDialogWithOpaqueBackground(dialog, mainWindow->getGUI());
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }
@@ -238,7 +238,7 @@ void SettingsWidget::onNetworkClicked(){
 void SettingsWidget::onChangePasswordClicked(){
     try {
         mainWindow->changePassphrase();
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         qDebug() << e.what();
     }
 }


### PR DESCRIPTION
**Problem**

In C++ the way exceptions are used is to throw by value, and to catch by reference.
In the base there are a few instances of catch by value, which is incorrect.

**Solution**

The correct fix is to simply catch by reference.

**Testing.**
I don't expect any special testing needs to be done for this item.