### PR TITLE
Fix proof of stake veil data hash error

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -396,9 +396,9 @@ public:
         return *phashBlock;
     }
 
-    uint256 GetBlockPoWHash() const
+    uint256 GetX16RTPoWHash(bool fSetVeilDataHashNull = false) const
     {
-        return GetBlockHeader().GetX16RTPoWHash();
+        return GetBlockHeader().GetX16RTPoWHash(fSetVeilDataHashNull);
     }
 
     uint256 GetProgPowHash(uint256& mix_hash) const;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -195,7 +195,7 @@ public:
     }
 
     uint256 GetHash() const;
-    uint256 GetX16RTPoWHash() const;
+    uint256 GetX16RTPoWHash(bool fSetVeilDataHashNull = false) const;
     uint256 GetSha256DPoWHash() const;
 
     uint256 GetProgPowHeaderHash() const;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -155,7 +155,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     else if (blockindex->IsSha256DProofOfWork() && blockindex->nTime >= Params().PowUpdateTimestamp())
         result.pushKV("sha256dproofofworkhash", blockindex->GetSha256DPowHash().GetHex());
     else
-        result.pushKV("proofofworkhash", blockindex->GetBlockPoWHash().GetHex());
+        result.pushKV("proofofworkhash", blockindex->GetX16RTPoWHash().GetHex());
     result.pushKV("version", block.nVersion);
     result.pushKV("versionHex", strprintf("%08x", block.nVersion));
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4833,8 +4833,9 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
         uint256 hashProofOfStake = uint256();
         std::unique_ptr<CStakeInput> stake;
 
-        if (!CheckProofOfStake(pindex, block.vtx[1], block.nBits, block.nTime, hashProofOfStake, stake))
+        if (!CheckProofOfStake(pindex, block.vtx[1], block.nBits, block.nTime, hashProofOfStake, stake)) {
             return state.DoS(100, error("%s: proof of stake check failed", __func__));
+        }
 
         if (!stake)
             return error("%s: null stake ptr", __func__);

--- a/src/veil/proofofstake/stakeinput.cpp
+++ b/src/veil/proofofstake/stakeinput.cpp
@@ -94,8 +94,16 @@ int ZerocoinStake::HeightToModifierHeight(int nHeight)
 // Use the PoW hash or the PoS hash
 uint256 GetHashFromIndex(const CBlockIndex* pindexSample)
 {
-    if (pindexSample->IsProofOfWork())
-        return pindexSample->GetBlockPoWHash();
+    if (pindexSample->IsProofOfWork()) {
+        // By using the pindex time and checking it against the PoWUpdateTimestamp we can tell the code to either
+        // set the veildatahash to all zeros if True is passed, or to do nothing if False is passed.
+        // When mining to the local wallet aggressively we have found that occassionaly the memory of the pindex block data
+        // shows that the veildatahash is not zero (0000xxxx). This made the wallet not accept valid PoS blocks from the chain tip
+        // and allowed the wallet to fork off. This fix allows us to pass in the boolean that is used to tell the code
+        // to set the veildatahash to zero manually for us. This can be done only after the PoWUpdateTimestamp as veildatahash isn't used
+        // in the block hash calculation after that timestamp.
+        return pindexSample->GetX16RTPoWHash(pindexSample->nTime >= Params().PowUpdateTimestamp());
+    }
 
     uint256 hashProof = pindexSample->GetBlockPoSHash();
     return hashProof;
@@ -140,8 +148,10 @@ int GetSampleBits(int nSampleCount)
 bool ZerocoinStake::GetModifier(uint64_t& nStakeModifier, const CBlockIndex* pindexChainPrev)
 {
     CBlockIndex* pindex = GetIndexFrom();
-    if (!pindex || !pindexChainPrev)
+
+    if (!pindex || !pindexChainPrev) {
         return false;
+    }
 
     uint256 hashModifier;
     if (pindexChainPrev->nHeight >= Params().HeightLightZerocoin()) {


### PR DESCRIPTION
- Added boolean logic to manually set veil data hash to zero when needed
- Added comments explaining why this is needed
- Change the hashing function name to better describe when it is doing