### PR TITLE
[budget] Update Multisig Budget Address

### DIFF
--- a/src/veil/budget.cpp
+++ b/src/veil/budget.cpp
@@ -165,7 +165,7 @@ BudgetParams::BudgetParams(std::string strNetwork)
     // Addresses must decode to be different, otherwise CheckBudgetTransaction() will fail
     if (strNetwork == "main") {
         nHeightAddressChange_legacy = 302401;
-        nHeightAddressChange_302401 = 860000;
+        nHeightAddressChange_302401 = 910000;
         budgetAddress_legacy = "3MvD3sxedwPzGSdLnehegDfBGfxpdMevk2";
         budgetAddress_302401 = "3LcNKTQSnxkdeuFkCNHet3XkEcUEyeENMF";
         budgetAddress = "35uS99ZnfaYB293sJ8ptUEXkUTQXH8WnDe";

--- a/src/veil/budget.cpp
+++ b/src/veil/budget.cpp
@@ -164,9 +164,11 @@ BudgetParams::BudgetParams(std::string strNetwork)
 {
     // Addresses must decode to be different, otherwise CheckBudgetTransaction() will fail
     if (strNetwork == "main") {
-        nHeightAddressChange = 302401;
+        nHeightAddressChange_legacy = 302401;
+        nHeightAddressChange_302401 = 860000;
         budgetAddress_legacy = "3MvD3sxedwPzGSdLnehegDfBGfxpdMevk2";
-        budgetAddress = "3LcNKTQSnxkdeuFkCNHet3XkEcUEyeENMF";
+        budgetAddress_302401 = "3LcNKTQSnxkdeuFkCNHet3XkEcUEyeENMF";
+        budgetAddress = "35uS99ZnfaYB293sJ8ptUEXkUTQXH8WnDe";
         founderAddress = "bv1qnauaweq25552zjthwqxq0puhz2flqrmhzh24h4";
         foundationAddress_legacy = "341PYScHCbq5Y3G3orR14V1pSmhb8qamP5";
         foundationAddress = "38J8RGLetRUNEXycBMPg8oZqLt4bB9hCbt";
@@ -187,8 +189,10 @@ BudgetParams::BudgetParams(std::string strNetwork)
 
 std::string BudgetParams::GetBudgetAddress(int nHeight) const
 {
-    if (nHeight < nHeightAddressChange)
+    if (nHeight < nHeightAddressChange_legacy)
         return budgetAddress_legacy;
+    if (nHeight < nHeightAddressChange_302401)
+        return budgetAddress_302401;
     return  budgetAddress;
 }
 
@@ -199,7 +203,7 @@ std::string BudgetParams::GetFounderAddress() const
 
 std::string BudgetParams::GetFoundationAddress(int nHeight) const
 {
-    if (nHeight < nHeightAddressChange)
+    if (nHeight < nHeightAddressChange_legacy)
         return foundationAddress_legacy;
     return  foundationAddress;
 }

--- a/src/veil/budget.h
+++ b/src/veil/budget.h
@@ -18,11 +18,13 @@ class BudgetParams
 private:
     explicit BudgetParams(std::string strNetwork);
     std::string budgetAddress_legacy;
+    std::string budgetAddress_302401;
     std::string budgetAddress;
     std::string founderAddress;
     std::string foundationAddress_legacy;
     std::string foundationAddress;
-    int nHeightAddressChange;
+    int nHeightAddressChange_legacy;
+    int nHeightAddressChange_302401;
 
 public:
     static bool IsSuperBlock(int nBlockHeight);


### PR DESCRIPTION
### Problem ###
Existing multisig budget address is hampered by staff changes, and is nearing critical mass.

### Solution ###
Establish new budget committee and generate a new multisig address for the budget moving forward.

### Note ###
This is setup to target the superblock after the next.  If the next fork is not timed to be in the July window, we will need to adjust this PR to have a new block stamp.  As such, it should wait to be merged until we are preparing the release.