### PR TITLE
[GUI] Fix RingCT Coin Control for minted change

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -913,10 +913,6 @@ void CoinControlDialog::updateView(int nCoinType)
                 if (out.nType != nCoinType)
                     continue;
 
-                //Also need to filter out zerocoinmints
-                if (txRef->vpout[i]->IsZerocoinMint())
-                    continue;
-
                 //Don't display zero confirmed outputs
                 if (nDepth < 1)
                     continue;


### PR DESCRIPTION
### Problem
Coin Control does not display all RingCT TXOs.

### Root Cause
An errant check in the Coin Control code was removing RingCT transactions from the coin control list that were zerocoin mints.  This resulted in RingCT change from a minting transaction from being listed in coin control.

### Solution
Remove the zerocoinmint check in the coin control check.

### Testing
Test against all coin types (basecoin, stealth, ringct) after minting from each coin type [including using the 'true' flag to mint from basecoin].  After all is mature, compare total balance for each coin type in coin control (by using 'select all') against the balance from `getbalances` and ensure they match. 