### PR TITLE
[RPC] Fix getbalance to get all coin types

### DIFF
--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -200,8 +200,8 @@ public:
     CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
     CAmount GetSpendableBalance() const;        // Includes watch_only_cs balance
     CAmount GetUnconfirmedBalance() const;
-    CAmount GetBlindBalance();
-    CAmount GetAnonBalance();
+    CAmount GetBlindBalance(const int min_depth=0);
+    CAmount GetAnonBalance(const int min_depth=0);
 
     bool GetBalances(BalanceList &bal);
 //    CAmount GetAvailableBalance(const CCoinControl* coinControl = nullptr) const;

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -391,7 +391,7 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
 
     switch (typeIn) {
         case OUTPUT_STANDARD:
-            if (nTotal > wallet->GetBalance()) {
+            if (nTotal > wallet->GetBasecoinBalance()) {
                 throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
             }
             break;

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -128,7 +128,7 @@ std::vector<SerialHash> CzTracker::GetSerialHashes()
     return vHashes;
 }
 
-CAmount CzTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) const
+CAmount CzTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly, const int min_depth) const
 {
     CAmount nTotal = 0;
     //! zerocoin specific fields
@@ -148,6 +148,8 @@ CAmount CzTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) const
             if (fConfirmedOnly && !fConfirmed)
                 continue;
             if (fUnconfirmedOnly && fConfirmed)
+                continue;
+	    if (min_depth > (chainActive.Height() - meta.nHeight))
                 continue;
 
             nTotal += libzerocoin::ZerocoinDenominationToAmount(meta.denom);

--- a/src/veil/zerocoin/ztracker.h
+++ b/src/veil/zerocoin/ztracker.h
@@ -43,7 +43,7 @@ public:
     CMintMeta Get(const SerialHash& hashSerial);
     CMintMeta GetMetaFromPubcoin(const PubCoinHash& hashPubcoin);
     bool GetMetaFromStakeHash(const uint256& hashStake, CMintMeta& meta) const;
-    CAmount GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) const;
+    CAmount GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly, const int min_depth=0) const;
     std::vector<SerialHash> GetSerialHashes();
     std::vector<CMintMeta> GetMints(bool fConfirmedOnly) const;
     CAmount GetUnconfirmedBalance() const;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2542,7 +2542,7 @@ void CWallet::ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman
  */
 
 
-CAmount CWallet::GetBalance(const isminefilter& filter, const int min_depth) const
+CAmount CWallet::GetBasecoinBalance(const isminefilter& filter, const int min_depth) const
 {
     CAmount nTotal = 0;
     {
@@ -2556,6 +2556,16 @@ CAmount CWallet::GetBalance(const isminefilter& filter, const int min_depth) con
         }
     }
 
+    return nTotal;
+}
+
+CAmount CWallet::GetBalance(const isminefilter& filter, const int min_depth) const
+{
+    CAmount nTotal = 0;
+    nTotal += GetBasecoinBalance(filter, min_depth);
+    nTotal += GetZerocoinBalance(false, min_depth);
+    nTotal += pAnonWalletMain->GetAnonBalance(min_depth);
+    nTotal += pAnonWalletMain->GetBlindBalance(min_depth);
     return nTotal;
 }
 
@@ -2670,7 +2680,7 @@ string CWallet::GetUniqueWalletBackupName(bool fzAuto) const
     return strprintf("wallet%s.dat%s", fzAuto ? "-autozbackup" : "", FormatISO8601DateTime(GetTime()));
 }
 
-CAmount CWallet::GetUnconfirmedBalance() const
+CAmount CWallet::GetUnconfirmedBasecoinBalance() const
 {
     CAmount nTotal = 0;
     {
@@ -2685,7 +2695,20 @@ CAmount CWallet::GetUnconfirmedBalance() const
     return nTotal;
 }
 
-CAmount CWallet::GetImmatureBalance() const
+CAmount CWallet::GetUnconfirmedBalance() const
+{
+    CAmount nTotal = 0;
+    nTotal += GetUnconfirmedBasecoinBalance();
+    nTotal += GetUnconfirmedZerocoinBalance();
+    BalanceList bal;
+    pAnonWalletMain->GetBalances(bal);
+    nTotal += bal.nCTUnconf;
+    nTotal += bal.nRingCTUnconf;
+
+    return nTotal;
+}
+
+CAmount CWallet::GetImmatureBasecoinBalance() const
 {
     CAmount nTotal = 0;
     {
@@ -2696,6 +2719,19 @@ CAmount CWallet::GetImmatureBalance() const
             nTotal += pcoin->GetImmatureCredit();
         }
     }
+    return nTotal;
+}
+
+CAmount CWallet::GetImmatureBalance() const
+{
+    CAmount nTotal = 0;
+    nTotal += GetImmatureBasecoinBalance();
+    nTotal += GetImmatureZerocoinBalance();
+    BalanceList bal;
+    pAnonWalletMain->GetBalances(bal);
+    nTotal += bal.nCTImmature;
+    nTotal += bal.nRingCTImmature;
+
     return nTotal;
 }
 
@@ -3235,7 +3271,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
 
 std::map<libzerocoin::CoinDenomination, int> mapMintMaturity;
 int nLastMaturityCheck = 0;
-CAmount CWallet::GetZerocoinBalance(bool fMatureOnly) const
+CAmount CWallet::GetZerocoinBalance(bool fMatureOnly, const int min_depth) const
 {
     if (fMatureOnly) {
         if (chainActive.Height() > nLastMaturityCheck)
@@ -3245,14 +3281,14 @@ CAmount CWallet::GetZerocoinBalance(bool fMatureOnly) const
         CAmount nBalance = 0;
         std::vector<CMintMeta> vMints = zTracker->GetMints(true);
         for (auto meta : vMints) {
-            if (!mapMintMaturity.count(meta.denom) || meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0)
+            if (!mapMintMaturity.count(meta.denom) || meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0 || (min_depth > (chainActive.Height() - meta.nHeight)))
                 continue;
             nBalance += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
         }
         return nBalance;
     }
 
-    return zTracker->GetBalance(false, false);
+    return zTracker->GetBalance(false, false, min_depth);
 }
 
 CAmount CWallet::GetUnconfirmedZerocoinBalance() const
@@ -3829,12 +3865,9 @@ bool CWallet::CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits,
     scriptEmpty.clear();
     txNew.vpout.emplace_back(CTxOut(0, scriptEmpty).GetSharedPtr());
 
-    // Choose coins to use
-    CAmount nBalance = GetBalance();
-
     // Get the list of stakable inputs
     std::list<std::unique_ptr<ZerocoinStake> > listInputs;
-    if (!SelectStakeCoins(listInputs, nBalance))
+    if (!SelectStakeCoins(listInputs))
         return false;
 
     if (listInputs.empty())
@@ -3938,7 +3971,7 @@ bool CWallet::CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits,
     }
     return fKernelFound;
 }
-bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<ZerocoinStake> >& listInputs, CAmount nTargetAmount)
+bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<ZerocoinStake> >& listInputs)
 {
     LOCK(cs_main);
 
@@ -5866,7 +5899,7 @@ string CWallet::MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDetermin
         nBalance = pAnonWalletMain->GetBlindBalance();
         strTypeName = "CT";
     } else if (inputtype == OUTPUT_STANDARD) {
-        nBalance = GetBalance();
+        nBalance = GetBasecoinBalance();
         strTypeName = "Basecoin";
     }
 
@@ -5889,7 +5922,7 @@ string CWallet::MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDetermin
     std::vector<CTempRecipient> vecSend;
     if (!CreateZerocoinMintTransaction(nValue, txNew, vDMints, nFeeRequired, strError, vecSend, inputtype,
                                        coinControl)) {
-        if (nValue + nFeeRequired > GetBalance())
+        if (nValue + nFeeRequired > GetBasecoinBalance())
             return strprintf(_("Error: Failed to create transaction: %s"), strError);
         return strError;
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1078,10 +1078,13 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
+    CAmount GetBasecoinBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
     CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
     bool GetBalances(BalanceList& bal);
     std::pair<ZerocoinSpread, ZerocoinSpread> GetMyZerocoinDistribution() const;
+    CAmount GetUnconfirmedBasecoinBalance() const;
     CAmount GetUnconfirmedBalance() const;
+    CAmount GetImmatureBasecoinBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
@@ -1093,11 +1096,11 @@ public:
      * Does not include locked coins or coins associated with the basecoin address.
      */
     CAmount GetMintableBalance(std::vector<COutput>& vMintableCoins) const;
-    CAmount GetZerocoinBalance(bool fMatureOnly) const;
+    CAmount GetZerocoinBalance(bool fMatureOnly, const int min_depth=0) const;
     CAmount GetUnconfirmedZerocoinBalance() const;
     CAmount GetImmatureZerocoinBalance() const;
     bool CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits, CMutableTransaction& txNew, unsigned int& nTxNewTime, int64_t& nComputeTimeStart);
-    bool SelectStakeCoins(std::list<std::unique_ptr<ZerocoinStake> >& listInputs, CAmount nTargetAmount);
+    bool SelectStakeCoins(std::list<std::unique_ptr<ZerocoinStake> >& listInputs);
 
     // sub wallet seeds
     bool GetZerocoinSeed(CKey& keyZerocoinMaster);


### PR DESCRIPTION
### Problem
`getbalance` only returns the basecoin balance, and not the full balance.

### Root Cause
It was never integrated with the other coin types.

### Solution
Originally thought the anonwallet GetBalance() would be a simple fix, but it doesn't recognize zerocoin mints as spent, and only handles basecoin as well.  That should be addressed or removed from the code.  The original GetBalance() in wallet.cpp was renamed to GetBasecoinBalance() and GetBalance() was re-written to collect up the different balances.  Changes were made to the other balance code to allow for a min_value to be entered.

### Testing
This affects both `getbalance` and `getwalletinfo`.  getbalance will now return the total balance in the wallet; this may be different then `getspendablebalance` if there are immature or unconfirmed balances.   Compare the output of getbalance to the output of getbalances.   

Likewise `getwalletinfo` should display the same balance as `getbalance`, plus have accurate totals for immature and unconfirmed balances.

### Release Notes
[RPC] getbalance and getwalletinfo now return the total coin balance, rather than just basecoin.