### PR TITLE
[Build] Clear Build Warnings

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -13,7 +13,6 @@
 
 #include <assert.h>
 
-#include <chainparamsseeds.h>
 #include "arith_uint256.h"
 #include "key.h"
 #include "key_io.h"

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -115,7 +115,7 @@ public:
     /** Zerocoin **/
     libzerocoin::ZerocoinParams* Zerocoin_Params() const;
     std::string Zerocoin_Modulus() const { return zerocoinModulus; }
-    int Zerocoin_MaxSpendsPerTransaction() const { return nMaxZerocoinSpendsPerTransaction; }
+    uint32_t Zerocoin_MaxSpendsPerTransaction() const { return nMaxZerocoinSpendsPerTransaction; }
     CAmount Zerocoin_MintFee() const { return nMinZerocoinMintFee; }
     int Zerocoin_MintRequiredConfirmations() const { return nMintRequiredConfirmations; }
     int Zerocoin_RequiredAccumulation() const { return nRequiredAccumulation; }
@@ -124,7 +124,7 @@ public:
     int Zerocoin_RequiredStakeDepthV2() const { return nZerocoinRequiredStakeDepthV2; }
     int Zerocoin_OverSpendAdjustment(libzerocoin::CoinDenomination denom) const;
     CAmount ValueBlacklisted() const { return nValueBlacklist; }
-    int Zerocoin_PreferredMintsPerBlock() const { return nPreferredMintsPerBlock; }
+    uint32_t Zerocoin_PreferredMintsPerBlock() const { return nPreferredMintsPerBlock; }
     int Zerocoin_PreferredMintsPerTransaction() const { return nPreferredMintsPerTx; }
 
     /** RingCT and Stealth **/
@@ -176,13 +176,13 @@ protected:
 
     // zerocoin
     std::string zerocoinModulus;
-    int nMaxZerocoinSpendsPerTransaction;
+    uint32_t nMaxZerocoinSpendsPerTransaction;
     CAmount nMinZerocoinMintFee;
     int nMintRequiredConfirmations;
     int nRequiredAccumulation;
     int nDefaultSecurityLevel;
     CAmount nValueBlacklist;
-    int nPreferredMintsPerBlock;
+    uint32_t nPreferredMintsPerBlock;
     int nPreferredMintsPerTx;
 
     //RingCT/Stealth

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -427,7 +427,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fSki
         if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
     } else if (tx.IsZerocoinSpend()) {
-        if (tx.vin.size() < 1 || static_cast<int>(tx.vin.size()) > Params().Zerocoin_MaxSpendsPerTransaction())
+        if (tx.vin.size() < 1 || tx.vin.size() > Params().Zerocoin_MaxSpendsPerTransaction())
             return state.DoS(10, error("CheckTransaction() : Zerocoin Spend has more than allowed txin's"),
                              REJECT_INVALID, "bad-zerocoinspend");
     } else {

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -252,6 +252,7 @@ WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
     return result;
 }
 
+/*
 WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, const CTransactionRecord &rtx)
 {
     WalletTxStatus result;
@@ -271,6 +272,7 @@ WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, 
     result.is_in_main_chain = result.depth_in_main_chain > 0;
     return result;
 }
+*/
 
 //! Construct wallet TxOut struct.
 WalletTxOut MakeWalletTxOut(CWallet& wallet, const CWalletTx& wtx, int n, int depth)

--- a/src/libzerocoin/SerialNumberSoK_small.cpp
+++ b/src/libzerocoin/SerialNumberSoK_small.cpp
@@ -403,7 +403,6 @@ bool SerialNumberSoK_small::Verify(const CBigNum& coinSerialNumber,
     auto proof = SerialNumberSoKProof(*this, coinSerialNumber, valueOfCommitmentToCoin, msghash);
     std::vector<const SerialNumberSoKProof*> vproof{&proof};
 
-    uint8_t nReturn;
     return SerialNumberSoKProof::BatchVerify(vproof);
 
 }
@@ -452,7 +451,6 @@ bool SerialNumberSoKProof::BatchVerify(std::vector<const SerialNumberSoKProof*> 
         const CBN_vector& ComC = proofs[w]->signature.ComC;
         const CBigNum& ComD = proofs[w]->signature.ComD;
         const CBigNum& comRdash  = proofs[w]->signature.comRdash;
-        const CBigNum& rho = proofs[w]->signature.rho;
         const PolynomialCommitment* polyComm = &proofs[w]->signature.polyComm;
         const Bulletproofs* innerProduct = &proofs[w]->signature.innerProduct;
 
@@ -619,7 +617,6 @@ bool SerialNumberSoKProof::BatchVerify(std::vector<const SerialNumberSoKProof*> 
         const auto& comRdash  = proofs2[w].signature.comRdash;
         const auto& rho = proofs2[w].signature.rho;
         const auto* polyComm = &proofs2[w].signature.polyComm;
-        const auto* innerProduct = &proofs2[w].signature.innerProduct;
 
         // Restore y1 in ComC
         CBN_vector ComC_(ComC);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -718,11 +718,11 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         assert(!inBlock.count(iter));
 
         uint64_t packageSize = iter->GetSizeWithAncestors();
-        CAmount packageFees = iter->GetModFeesWithAncestors();
+//        CAmount packageFees = iter->GetModFeesWithAncestors();
         int64_t packageSigOpsCost = iter->GetSigOpCostWithAncestors();
         if (fUsingModified) {
             packageSize = modit->nSizeWithAncestors;
-            packageFees = modit->nModFeesWithAncestors;
+//            packageFees = modit->nModFeesWithAncestors;
             packageSigOpsCost = modit->nSigOpCostWithAncestors;
         }
 
@@ -823,7 +823,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
 
     unsigned int nExtraNonce = 0;
     static const int nInnerLoopCount = 0x010000;
-    static int nStakeHashesLast = 0;
+    static uint32_t nStakeHashesLast = 0;
     bool enablewallet = false;
 #ifdef ENABLE_WALLET
     enablewallet = !gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1202,27 +1202,6 @@ static UniValue verifychain(const JSONRPCRequest& request)
     return CVerifyDB().VerifyDB(Params(), pcoinsTip.get(), nCheckLevel, nCheckDepth);
 }
 
-/** Implementation of IsSuperMajority with better feedback */
-static UniValue SoftForkMajorityDesc(int version, CBlockIndex* pindex, const Consensus::Params& consensusParams)
-{
-    UniValue rv(UniValue::VOBJ);
-    bool activated = false;
-    switch(version)
-    {
-        case 2:
-            activated = pindex->nHeight >= consensusParams.BIP34Height;
-            break;
-        case 3:
-            activated = pindex->nHeight >= consensusParams.BIP66Height;
-            break;
-        case 4:
-            activated = pindex->nHeight >= consensusParams.BIP65Height;
-            break;
-    }
-    rv.pushKV("status", activated);
-    return rv;
-}
-
 static UniValue BIP9SoftForkDesc(const Consensus::Params& consensusParams, Consensus::DeploymentPos id)
 {
     UniValue rv(UniValue::VOBJ);

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -97,8 +97,9 @@ IsMineResult IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey,
         break;
     }
     case TX_PUBKEYHASH:
-    case TX_TIMELOCKED_PUBKEYHASH:
     case TX_PUBKEYHASH256:
+    case TX_TIMELOCKED_PUBKEYHASH:
+    case TX_TIMELOCKED_PUBKEYHASH256:
         if (vSolutions[0].size() == 20)
             keyID = CKeyID(uint160(vSolutions[0]));
         else if (vSolutions[0].size() == 32)
@@ -116,8 +117,9 @@ IsMineResult IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey,
         }
         break;
     case TX_SCRIPTHASH:
-    case TX_TIMELOCKED_SCRIPTHASH:
     case TX_SCRIPTHASH256:
+    case TX_TIMELOCKED_SCRIPTHASH:
+    case TX_TIMELOCKED_SCRIPTHASH256:
     {
         if (sigversion != IsMineSigVersion::TOP) {
             // P2SH inside P2WSH or P2SH is invalid.
@@ -157,6 +159,7 @@ IsMineResult IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey,
     }
 
     case TX_MULTISIG:
+    case TX_TIMELOCKED_MULTISIG:
     {
         // Never treat bare multisig outputs as ours (they can still be made watchonly-though)
         if (sigversion == IsMineSigVersion::TOP) {
@@ -183,6 +186,9 @@ IsMineResult IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey,
 
         break;
     }
+    case TX_ZEROCOINMINT:
+        // TODO
+	break;
     }
 
     if (ret == IsMineResult::NO && keystore.HaveWatchOnly(scriptPubKey)) {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -46,8 +46,15 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_NONSTANDARD: return "nonstandard";
     case TX_PUBKEY: return "pubkey";
     case TX_PUBKEYHASH: return "pubkeyhash";
+    case TX_PUBKEYHASH256: return "pubkeyhash256";
+    case TX_TIMELOCKED_PUBKEYHASH: return "timelocked_pubkeyhash";
+    case TX_TIMELOCKED_PUBKEYHASH256: return "timelocked_pubkeyhash256";
     case TX_SCRIPTHASH: return "scripthash";
+    case TX_SCRIPTHASH256: return "scripthash256";
+    case TX_TIMELOCKED_SCRIPTHASH: return "timelocked_scripthash";
+    case TX_TIMELOCKED_SCRIPTHASH256: return "timelocked_scripthash256";
     case TX_MULTISIG: return "multisig";
+    case TX_TIMELOCKED_MULTISIG: return "timelocked_multisig";
     case TX_NULL_DATA: return "nulldata";
     case TX_WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
     case TX_WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -630,7 +630,7 @@ bool CZerocoinDB::WipeCoins(std::string strType)
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         try {
-            char chType;
+            char chType = 0;
             pcursor->GetKey(chType);
 
             if (chType == type) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3559,7 +3559,7 @@ void PruneStaleBlockIndexes()
     if (!pindexBestHeader) return;
 
     // If mapBlockIndex isn't bloated, don't bother taking the time.
-    if (chainActive.Height() > (mapBlockIndex.size() - PRUNE_COUNT)) {
+    if (chainActive.Height() > static_cast<int>(mapBlockIndex.size() - PRUNE_COUNT)) {
         return;
     }
 
@@ -3582,7 +3582,7 @@ void PruneStaleBlockIndexes()
             irrelevantIndexes++;
 
             // if it's also old enough, add it to the prune list.
-            if (pindex->nHeight + PRUNE_DEPTH < chainActive.Height()) {
+            if (chainActive.Height() > static_cast<int>(pindex->nHeight + PRUNE_DEPTH)) {
                 setDelete.emplace(p.first);
 
                 // save the lowest height that we're purging

--- a/src/veil/mnemonic/mnemonic.h
+++ b/src/veil/mnemonic/mnemonic.h
@@ -30,12 +30,12 @@
 /**
 * A valid mnemonic word count is evenly divisible by this number.
 */
-static size_t mnemonic_word_multiple = 3;
+static const size_t mnemonic_word_multiple = 3;
 
 /**
 * A valid seed byte count is evenly divisible by this number.
 */
-static size_t mnemonic_seed_multiple = 4;
+static const size_t mnemonic_seed_multiple = 4;
 
 template <size_t Size>
 using byte_array = std::array<uint8_t, Size>;

--- a/src/veil/ringct/anon.cpp
+++ b/src/veil/ringct/anon.cpp
@@ -106,7 +106,7 @@ bool VerifyMLSAG(const CTransaction &tx, CValidationState &state)
         size_t ofs = 0, nB = 0;
         for (size_t k = 0; k < nInputs; ++k) {
             for (size_t i = 0; i < nCols; ++i) {
-                int64_t nIndex;
+                int64_t nIndex = 0;
 
                 if (0 != GetVarInt(vMI, ofs, (uint64_t &) nIndex, nB))
                     return state.DoS(100, false, REJECT_MALFORMED, "bad-anonin-extract-i");
@@ -335,7 +335,7 @@ std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin)
     size_t ofs = 0, nB = 0;
     for (size_t k = 0; k < nInputs; ++k) {
         for (size_t i = 0; i < nCols; ++i) {
-            int64_t nIndex;
+            int64_t nIndex = 0;
 
             if (0 != GetVarInt(vMI, ofs, (uint64_t&) nIndex, nB))
                 continue;
@@ -379,7 +379,7 @@ bool GetRingCtInputs(const CTxIn& txin, std::vector<std::vector<COutPoint> >& vI
     for (size_t k = 0; k < nInputs; ++k) {
         std::vector<COutPoint> vOutpoints;
         for (size_t i = 0; i < nCols; ++i) {
-            int64_t nIndex;
+            int64_t nIndex = 0;
 
             if (0 != GetVarInt(vMI, ofs, (uint64_t&) nIndex, nB))
                 return false;

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -2718,7 +2718,7 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
             const uint256 &txhash = coin.first->first;
 
             COutPoint prevout(txhash, coin.second);
-            std::map<COutPoint, CInputData>::const_iterator it = coinControl->m_inputData.find(prevout);
+            //std::map<COutPoint, CInputData>::const_iterator it = coinControl->m_inputData.find(prevout);
             //if (it != coinControl->m_inputData.end()) {
             //    memcpy(&vInputBlinds[nIn * 32], it->second.blind.begin(), 32);
             //} else {
@@ -3091,7 +3091,7 @@ bool AnonWallet::IsMyAnonInput(const CTxIn& txin, COutPoint& myOutpoint)
     for (size_t k = 0; k < nInputs; ++k) {
         auto image = *((CCmpPubKey*)&vKeyImages[k*33]);
         for (size_t i = 0; i < nCols; ++i) {
-            int64_t nIndex;
+            int64_t nIndex = 0;
 
             if (0 != GetVarInt(vMI, ofs, (uint64_t &) nIndex, nB))
                 return false;

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -188,6 +188,7 @@ static UniValue rescanringctwallet(const JSONRPCRequest &request)
     return NullUniValue;
 }
 
+/*
 static void push(UniValue & entry, std::string key, UniValue const & value)
 {
     if (entry[key].getType() == 0) {
@@ -211,6 +212,7 @@ static std::string getAddress(UniValue const & transaction)
     }
     return std::string();
 }
+*/
 
 enum SortCodes
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5036,7 +5036,7 @@ UniValue recoveraddresses(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    int nCount = 100;
+    uint32_t nCount = 100;
     if (request.params.size() > 0)
         nCount = request.params[0].get_int();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1004,7 +1004,7 @@ public:
     void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool RestoreBaseCoinAddresses(int nCount) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool RestoreBaseCoinAddresses(uint32_t nCount) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
     void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
### Problem
Build warnings were starting to get a little overbearing, and inducing the ignoring of warnings; Which bit me in one of the things I was tweaking.

### Root Cause
Various, but primarily because devs tend to ignore warnings

### Solution
Address them
```
In file included from consensus/tx_verify.cpp:28:0:
./veil/zerocoin/lrucache.h: In instantiation of ‘void LRUCacheTemplate<K, V>::set(K, V) [with K = std::__cxx11::basic_string<char>; V = bool]’:
consensus/tx_verify.cpp:260:69:   required from here
./veil/zerocoin/lrucache.h:57:37: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             if (keyValuesMap.size() > csize) {

miner.cpp: In member function ‘std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript&, bool, bool, bool)’:
miner.cpp:249:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (setPubcoins.size() >= Params().Zerocoin_PreferredMintsPerBlock())
             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
miner.cpp: In member function ‘void BlockAssembler::addPackageTxs(int&, int&)’:
miner.cpp:721:17: warning: variable ‘packageFees’ set but not used [-Wunused-but-set-variable]
         CAmount packageFees = iter->GetModFeesWithAncestors();
                 ^~~~~~~~~~~
miner.cpp: In function ‘void BitcoinMiner(std::shared_ptr<CReserveScript>, bool, bool)’:
miner.cpp:893:67: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
                 if (it != mapStakeHashCounter.end() && it->second != nStakeHashesLast) {

  CXX      rpc/libbitcoin_server_a-blockchain.o
rpc/blockchain.cpp:1206:17: warning: ‘UniValue SoftForkMajorityDesc(int, CBlockIndex*, const Consensus::Params&)’ defined but not used [-Wunused-function]
 static UniValue SoftForkMajorityDesc(int version, CBlockIndex* pindex, const Consensus::Params& consensusParams)
                 ^~~~~~~~~~~~~~~~~~~~
  CXX      libbitcoin_server_a-txdb.o
txdb.cpp: In member function ‘bool CZerocoinDB::WipeCoins(std::__cxx11::string)’:
txdb.cpp:636:13: warning: ‘chType’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (chType == type) {
             ^~
  CXX      libbitcoin_server_a-validation.o
validation.cpp: In function ‘void PruneStaleBlockIndexes()’:
validation.cpp:3568:30: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (chainActive.Height() > (mapBlockIndex.size() - PRUNE_COUNT)) {
         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
validation.cpp:3591:47: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             if (pindex->nHeight + PRUNE_DEPTH < chainActive.Height()) {
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
  CXX      interfaces/libbitcoin_wallet_a-wallet.o
interfaces/wallet.cpp:255:16: warning: ‘interfaces::WalletTxStatus interfaces::{anonymous}::MakeWalletTxStatus(AnonWallet*, const uint256&, const CTransactionRecord&)’ defined but not used [-Wunused-function]
 WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, const CTransactionRecord &rtx)
                ^~~~~~~~~~~~~~~~~~
  CXX      veil/mnemonic/libbitcoin_wallet_a-generateseed.o
In file included from veil/mnemonic/generateseed.cpp:7:0:
./veil/mnemonic/mnemonic.h:38:15: warning: ‘mnemonic_seed_multiple’ defined but not used [-Wunused-variable]
 static size_t mnemonic_seed_multiple = 4;
               ^~~~~~~~~~~~~~~~~~~~~~
./veil/mnemonic/mnemonic.h:33:15: warning: ‘mnemonic_word_multiple’ defined but not used [-Wunused-variable]
 static size_t mnemonic_word_multiple = 3;
               ^~~~~~~~~~~~~~~~~~~~~~
In file included from veil/mnemonic/mnemonicwalletinit.cpp:13:0:
veil/mnemonic/mnemonic.h:38:15: warning: ‘mnemonic_seed_multiple’ defined but not used [-Wunused-variable]
 static size_t mnemonic_seed_multiple = 4;
               ^~~~~~~~~~~~~~~~~~~~~~
veil/mnemonic/mnemonic.h:33:15: warning: ‘mnemonic_word_multiple’ defined but not used [-Wunused-variable]
 static size_t mnemonic_word_multiple = 3;
               ^~~~~~~~~~~~~~~~~~~~~~
  CXX      wallet/libbitcoin_wallet_a-rpczerocoin.o
wallet/rpczerocoin.cpp: In function ‘UniValue spendzerocoinmints(const JSONRPCRequest&)’:
wallet/rpczerocoin.cpp:757:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (arrMints.size() > Params().Zerocoin_MaxSpendsPerTransaction())
         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CXX      wallet/libbitcoin_wallet_a-wallet.o
wallet/wallet.cpp: In member function ‘bool CWallet::RestoreBaseCoinAddresses(int)’:
wallet/wallet.cpp:516:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (unsigned int i = 0; i < nCount; i++) {
                              ~~^~~~~~~~
wallet/wallet.cpp: In member function ‘bool CWallet::MintToTxIn(CZerocoinMint, int, const uint256&, CTxIn&, CZerocoinSpendReceipt&, libzerocoin::SpendType, CBlockIndex*)’:
wallet/wallet.cpp:5741:19: warning: variable ‘statsStruct’ set but not used [-Wunused-but-set-variable]
         BIP9Stats statsStruct = VersionBitsTipStatistics(Params().GetConsensus(), Consensus::DEPLOYMENT_ZC_LIMP);
                   ^~~~~~~~~~~
wallet/wallet.cpp: In member function ‘bool CWallet::PrepareZerocoinSpend(CAmount, int, CZerocoinSpendReceipt&, std::vector<CZerocoinMint>&, bool, bool, std::vector<std::tuple<CWalletTx, std::vector<CDeterministicMint, std::allocator<CDeterministicMint> >, std::vector<CZerocoinMint, std::allocator<CZerocoinMint> > > >&, libzerocoin::CoinDenomination, CTxDestination*)’:
wallet/wallet.cpp:6037:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (auto start = 0; start < vMintsSelected.size(); start += nMaxSpends) {
                          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
wallet/wallet.cpp:6041:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (start + nMaxSpends >= vMintsSelected.size()) {
             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
wallet/wallet.cpp:6027:13: warning: unused variable ‘nValueSelected’ [-Wunused-variable]
     CAmount nValueSelected = 0;
             ^~~~~~~~~~~~~~
wallet/wallet.cpp: In member function ‘bool CWallet::CreateZerocoinMintTransaction(CAmount, CMutableTransaction&, std::vector<CDeterministicMint>&, int64_t&, std::__cxx11::string&, std::vector<CTempRecipient>&, OutputTypes, const CCoinControl*, bool)’:
wallet/wallet.cpp:6355:13: warning: unused variable ‘nTotalValue’ [-Wunused-variable]
     CAmount nTotalValue = (isZCSpendChange ? nValue : (nValue + nFee));
             ^~~~~~~~~~~
wallet/wallet.cpp:6357:13: warning: unused variable ‘nValueIn’ [-Wunused-variable]
     CAmount nValueIn = 0;
             ^~~~~~~~
In file included from wallet/wallet.cpp:38:0:
./veil/mnemonic/mnemonic.h: At global scope:
./veil/mnemonic/mnemonic.h:38:15: warning: ‘mnemonic_seed_multiple’ defined but not used [-Wunused-variable]
 static size_t mnemonic_seed_multiple = 4;
               ^~~~~~~~~~~~~~~~~~~~~~
./veil/mnemonic/mnemonic.h:33:15: warning: ‘mnemonic_word_multiple’ defined but not used [-Wunused-variable]
 static size_t mnemonic_word_multiple = 3;
  CXX      libbitcoin_common_a-chainparams.o
In file included from chainparams.cpp:16:0:
./chainparamsseeds.h:1281:18: warning: ‘pnSeed6_test’ defined but not used [-Wunused-variable]
 static SeedSpec6 pnSeed6_test[] = {
                  ^~~~~~~~~~~~
./chainparamsseeds.h:10:18: warning: ‘pnSeed6_main’ defined but not used [-Wunused-variable]
 static SeedSpec6 pnSeed6_main[] = {
                  ^~~~~~~~~~~~
  CXX      veil/ringct/libbitcoin_common_a-anon.o
veil/ringct/anon.cpp: In function ‘std::vector<COutPoint> GetRingCtInputs(const CTxIn&)’:
veil/ringct/anon.cpp:345:43: warning: ‘nIndex’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (!pblocktree->ReadRCTOutput(nIndex, ao)) {
                  ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
veil/ringct/anon.cpp: In function ‘bool GetRingCtInputs(const CTxIn&, std::vector<std::vector<COutPoint> >&)’:
veil/ringct/anon.cpp:389:43: warning: ‘nIndex’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (!pblocktree->ReadRCTOutput(nIndex, ao)) {
                  ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
  CXX      script/libbitcoin_common_a-ismine.o
script/ismine.cpp: In function ‘{anonymous}::IsMineResult {anonymous}::IsMineInner(const CKeyStore&, const CScript&, {anonymous}::IsMineSigVersion)’:
script/ismine.cpp:69:12: warning: enumeration value ‘TX_TIMELOCKED_SCRIPTHASH256’ not handled in switch [-Wswitch]
     switch (whichType)
            ^
script/ismine.cpp:69:12: warning: enumeration value ‘TX_TIMELOCKED_PUBKEYHASH256’ not handled in switch [-Wswitch]
script/ismine.cpp:69:12: warning: enumeration value ‘TX_TIMELOCKED_MULTISIG’ not handled in switch [-Wswitch]
script/ismine.cpp:69:12: warning: enumeration value ‘TX_ZEROCOINMINT’ not handled in switch [-Wswitch]
  CXX      script/libbitcoin_common_a-standard.o
script/standard.cpp: In function ‘const char* GetTxnOutputType(txnouttype)’:
script/standard.cpp:44:12: warning: enumeration value ‘TX_SCRIPTHASH256’ not handled in switch [-Wswitch]
     switch (t)
            ^
script/standard.cpp:44:12: warning: enumeration value ‘TX_PUBKEYHASH256’ not handled in switch [-Wswitch]
script/standard.cpp:44:12: warning: enumeration value ‘TX_TIMELOCKED_SCRIPTHASH’ not handled in switch [-Wswitch]
script/standard.cpp:44:12: warning: enumeration value ‘TX_TIMELOCKED_SCRIPTHASH256’ not handled in switch [-Wswitch]
script/standard.cpp:44:12: warning: enumeration value ‘TX_TIMELOCKED_PUBKEYHASH’ not handled in switch [-Wswitch]
script/standard.cpp:44:12: warning: enumeration value ‘TX_TIMELOCKED_PUBKEYHASH256’ not handled in switch [-Wswitch]
script/standard.cpp:44:12: warning: enumeration value ‘TX_TIMELOCKED_MULTISIG’ not handled in switch [-Wswitch]
  CXX      libzerocoin/libzerocoin_libbitcoin_zerocoin_a-SerialNumberSoK_small.o
libzerocoin/SerialNumberSoK_small.cpp: In member function ‘bool libzerocoin::SerialNumberSoK_small::Verify(const CBigNum&, const CBigNum&, uint256) const’:
libzerocoin/SerialNumberSoK_small.cpp:406:13: warning: unused variable ‘nReturn’ [-Wunused-variable]
     uint8_t nReturn;
             ^~~~~~~
libzerocoin/SerialNumberSoK_small.cpp: In static member function ‘static bool libzerocoin::SerialNumberSoKProof::BatchVerify(std::vector<const libzerocoin::SerialNumberSoKProof*>&)’:
libzerocoin/SerialNumberSoK_small.cpp:455:24: warning: unused variable ‘rho’ [-Wunused-variable]
         const CBigNum& rho = proofs[w]->signature.rho;
                        ^~~
libzerocoin/SerialNumberSoK_small.cpp:622:21: warning: unused variable ‘innerProduct’ [-Wunused-variable]
         const auto* innerProduct = &proofs2[w].signature.innerProduct;
                     ^~~~~~~~~~~~
leveldb/util/logging.cc: In function ‘bool leveldb::ConsumeDecimalNumber(leveldb::Slice*, uint64_t*)’:
leveldb/util/logging.cc:58:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
                                  ~~~~~~^~~~~~~~~~~~~~~
```
### Testing ###
Make sure everything still works right.