### PR TITLE
Update PoW Diff to use last blocktime

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -563,7 +563,7 @@ public:
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.powLimitRandomX = uint256S("000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitSha256 = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetSpacing = 120; // alternate PoW/PoS every one minute


### PR DESCRIPTION
(description by CaveSpectre, take with a grain of salt)

### Problem
Difficulty calculations are based on the spacing between the last X blocks of the algorithm, and does not take into account if the next block for that algo is overdue.

### Solution
Refine logic to consider the spacing between the tip and the last algo block, if overdue, and adjust calculated spacing accordingly.