### PR TITLE
[Build] Remove constant string warnings

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -49,9 +49,9 @@
 #include "crypto/ethash/helpers.hpp"
 #include "crypto/ethash/progpow_test_vectors.hpp"
 
-char * PROGPOW_STRING = "progpow";
-char * SHA256D_STRING = "sha256d";
-char * RANDOMX_STRING = "randomx";
+const char * PROGPOW_STRING = "progpow";
+const char * SHA256D_STRING = "sha256d";
+const char * RANDOMX_STRING = "randomx";
 
 int nMiningAlgorithm = MINE_RANDOMX;
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -21,9 +21,9 @@ class CScript;
 
 
 // Used for determining which PoW mining algorithm to use
-extern char * PROGPOW_STRING;
-extern char * SHA256D_STRING;
-extern char * RANDOMX_STRING;
+extern const char * PROGPOW_STRING;
+extern const char * SHA256D_STRING;
+extern const char * RANDOMX_STRING;
 
 extern int nMiningAlgorithm;
 


### PR DESCRIPTION
### Problem
Build issued warnings for the three constant strings added.

### Root Cause
Should be const char rather than char

### Solution
correct them.