### PR TITLE
[GUI] Adjust stretch factor Zerocoin minting page

### DIFF
--- a/src/qt/veil/forms/settingsminting.ui
+++ b/src/qt/veil/forms/settingsminting.ui
@@ -432,7 +432,7 @@ border:0;
            <property name="frameShadow">
             <enum>QFrame::Raised</enum>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,0,0,0,0,0">
+           <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,1,0,0,0,0,0,0,0">
             <property name="topMargin">
              <number>0</number>
             </property>
@@ -783,6 +783,19 @@ padding-bottom:3px;</string>
               </property>
              </widget>
             </item>
+            <item>
+             <spacer name="verticalSpacer_1">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
             <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
              <widget class="QPushButton" name="btnMint">
               <property name="minimumSize">
@@ -938,6 +951,19 @@ background-color:transparent;</string>
                <set>Qt::AlignCenter</set>
               </property>
              </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_5">


### PR DESCRIPTION
### Problem
Displayed text on the 'Zerocoin minting' page is cutoff.

### Root Cause
The height of the textlabel shrinks below the height of its content.

### Solution
Adjust the `stretch` factor.

### Bounty PR
Resolves #738

### Bounty Payment Address
`sv1qqp0j5cm6vrrkvkajpnq39gczt09eclw5z8h2zrmvrwndw7ppqaa28spqfqmkpana500t0jmjnhcjekg0rgt9jfll3w03m46p7ard9lqrpxduqqqe9a2qv`

### Unit Testing Results
1. Click Settings
1. Click Zerocoin minting

![fix](https://user-images.githubusercontent.com/31125485/88622551-57d45000-d0a3-11ea-947f-25f86cf537c4.png)
