### PR TITLE
[RPC] Add RPC command 'getchainalgostats' to get block count for each algo

### DIFF
--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -19,6 +19,8 @@ static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
 
 static const unsigned int DEFAULT_CHECK_DIFFICULTY_BLOCK_COUNT = 1440; // ~1 day
 
+static const unsigned int ALGO_RATIO_LOOK_BACK_BLOCK_COUNT = 1440; // ~1 day
+
 extern std::map<std::string, CBlock> mapProgPowTemplates;
 
 /**


### PR DESCRIPTION
### Problem ###
There is no RPC that would return the block count breakdown per algo. 

### Root Cause ###
New algorithms were added for ProgPow, RandomX, and SHA256D.

### Solution ###
Added a new RPC command `getchainalgostats` was added to get the block count for each algo over the previous 1440 blocks.

### Unit Testing Results ###
**`getchainalgostats`**

```
{
  "pos": 727,
  "progpow": 476,
  "randomx": 156,
  "sha256d": 81,
  "x16rt": 0
}
```

**`getchainalgostats help`**

```
getchainalgostats

Returns the blocks found by each algo over that previous 1440 blocks.

Result:
{ 
   "pos" :     (numeric) The number of PoS blocks found in the previous 1440 blocks 
   "progpow":  (numeric) The number of ProgPow blocks found in the previous 1440 blocks 
   "randomx":  (numeric) The number of RandomX blocks found in the previous 1440 blocks 
   "sha256d":  (numeric) The number of SHA256D blocks found in the previous 1440 blocks 
   "x16rt":    (numeric) The number of x16rt blocks found in the previous 1440 blocks 
} 

Examples:
> veil-cli getchainalgostats 
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getchainalgostats", "params": [] }' -H 'content-type: text/plain;' http://127.0.0.1:58812/
```
