### PR TITLE
[PoW] Reduce overflow risk

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -562,10 +562,13 @@ public:
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+
+	// NOTE: Due to mathematical limits, these can never exceed "3fff...."
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitSha256 = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
         consensus.nPowTargetSpacing = 120; // alternate PoW/PoS every one minute
 
         // ProgPow, RandomX, Sha256d

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -1,6 +1,6 @@
-// Copyright (c) 2019 Veil developers
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -243,9 +243,11 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
     if (nActualTimespan > nTargetTimespan*3)
         nActualTimespan = nTargetTimespan*3;
 
-    // Retarget
-    bnNew *= nActualTimespan;
-    bnNew /= nTargetTimespan;
+    // Retarget:  actual is railed to 3x target, so the multiple here will never be greater
+    // than 3, therefore it will only be a boundary risk if bnPowLimit exceeds 1/3 of the
+    // uint256 max.
+    bnNew *= static_cast<float>(static_cast<float>(nActualTimespan) /
+                                static_cast<float>(nTargetTimespan));
 
     if (bnNew > bnPowLimit) {
         bnNew = bnPowLimit;


### PR DESCRIPTION
### Problem
The `nActualTimeSpan` is at risk of overflowing if parameters are changed (hash limit, nDgwPastBlocks, etc).  While the Actual Time Span is railed to 3x of the Target, when you multiply the difficulty hash by the number of seconds between the first and last in the series, it can easily exceed the uint256 boundary if parameters aren't carefully calculated during changes in the future.

### Solution
Instead of multiplying the bnNew by the actual; which can be exceeded with parameter changes... we will divide the Actual by the Target, which have already been railed and result in a bnNew multiplier from 1/3 to 3; thus greatly reducing the chance of an inadvertent overflow