### PR TITLE
[Build] Fix Implicit Declaration Warnings

### DIFF
--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -41,6 +41,9 @@
 //#include "int-util.h"
 //#include "warnings.h"
 
+extern int swap32be();
+extern int swap64be();
+
 static inline void *padd(void *p, size_t i) {
   return (char *) p + i;
 }

--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -47,6 +47,9 @@
 #define THREADV __thread
 #endif
 
+extern void mdebug();
+extern void mwarning();
+
 typedef struct rx_state {
     CTHR_MUTEX_TYPE rs_mutex;
     char rs_hash[32];


### PR DESCRIPTION
### Problem
Build issued warnings for 4 routines implicitly declaration.

### Root Cause
Implicitly declared routines need to be declared.

### Solution
declare them.