### PR TITLE
[Trivial] Cleanup lingering stdout messages

### DIFF
--- a/src/crypto/randomx/randomx.cpp
+++ b/src/crypto/randomx/randomx.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2018-2019, tevador <tevador@gmail.com>
+Copyright (c) 2019-2020, Veil Developers
 
 All rights reserved.
 
@@ -191,13 +192,13 @@ extern "C" {
         if (fWaitFor30 && cache != nullptr) {
             int count = 0;
             while(cache != nullptr && count++ < 60 && !cache->isInitialized()) {
-                printf("%s : Cache not initialized\n", __func__);
+                LogPrintf("%s : Cache not initialized\n", __func__);
                 MilliSleep(250);
             }
         }
 
         if (cache && cache->isInitialized()) {
-            printf("%s : Cache is initialized\n", __func__);
+            LogPrintf("%s : Cache is initialized\n", __func__);
         }
         assert(cache == nullptr || cache->isInitialized());
         assert(dataset != nullptr || !(flags & RANDOMX_FLAG_FULL_MEM));

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -1,6 +1,6 @@
-// Copyright (c) 2019 Veil developers
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -264,7 +264,6 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
 
     // Check range
     if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(params.powLimit)) {
-        //std::cout << fNegative << " " << (bnTarget == 0) << " " << fOverflow << " " << (bnTarget > UintToArith256(params.powLimit)) << "\n";
         return false;
     }
 
@@ -315,7 +314,6 @@ bool CheckRandomXProofOfWork(const CBlockHeader& block, unsigned int nBits, cons
 
     // Check range
     if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(params.powLimitRandomX)) {
-        //std::cout << fNegative << " " << (bnTarget == 0) << " " << fOverflow << " " << (bnTarget > UintToArith256(params.powLimit)) << "\n";
         return false;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3857,7 +3857,6 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
         it++;
     }
 
-    std::cout << "in invalid block\n";
     InvalidChainFound(pindex);
 
     // Only notify about a new block tip if the active chain was modified.


### PR DESCRIPTION
### Problem
Some lingering stdout messages come to the terminal when running the wallet in the background

### Solution
Clean them up (one relating to invalidating blocks, one relating to the randomx vm cache.