### PR TITLE
[logging] remove FindTx txid mismatch error when expected

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -257,7 +257,7 @@ bool TxIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 
 BaseIndex::DB& TxIndex::GetDB() const { return *m_db; }
 
-bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRef& tx) const
+bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRef& tx, bool log) const
 {
     CDiskTxPos postx;
     if (!m_db->ReadTxPos(tx_hash, postx)) {
@@ -279,7 +279,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         return error("%s: Deserialize or I/O error - %s", __func__, e.what());
     }
     if (tx->GetHash() != tx_hash) {
-        return error("%s: txid mismatch", __func__);
+        return berror(log, "%s: txid mismatch", __func__);
     }
     block_hash = header.GetHash();
     return true;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -45,7 +45,7 @@ public:
     /// @param[out]  block_hash  The hash of the block the transaction is found in.
     /// @param[out]  tx  The transaction itself.
     /// @return  true if transaction is found, false otherwise
-    bool FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRef& tx) const;
+    bool FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRef& tx, bool log = true) const;
 };
 
 /// The global transaction index, used in GetTransaction. May be null.

--- a/src/util.h
+++ b/src/util.h
@@ -82,6 +82,15 @@ bool error(const char* fmt, const Args&... args)
 }
 
 template<typename... Args>
+bool berror(bool log, const char* fmt, const Args&... args)
+{
+    if (log) {
+        LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
+    }
+    return false;
+}
+
+template<typename... Args>
 int errorN(int n, const char *fmt, const Args&... args)
 {
     LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));

--- a/src/validation.h
+++ b/src/validation.h
@@ -287,12 +287,12 @@ bool IsInitialBlockDownload();
 /** Check whether both headers and blocks are synced **/
 bool HeadersAndBlocksSynced();
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256& hash, CTransactionRef& tx, const Consensus::Params& params, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
+bool GetTransaction(const uint256& hash, CTransactionRef& tx, const Consensus::Params& params, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr, bool log = true);
 
 bool IsBlockHashInChain(const uint256& hashBlock, int& nHeight, const CBlockIndex* pindex = nullptr);
 
 /** Determine if the provided txid corresponds to a transaction in the blockchain */
-bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef& txRef, const Consensus::Params& params, const CBlockIndex* pindex = nullptr);
+bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef& txRef, const Consensus::Params& params, const CBlockIndex* pindex = nullptr, bool log = true);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, const Consensus::Params& params, const CBlockIndex* pindex = nullptr);
 
 /**

--- a/src/veil/zerocoin/zchain.cpp
+++ b/src/veil/zerocoin/zchain.cpp
@@ -298,7 +298,7 @@ bool IsSerialInBlockchain(const CBigNum& bnSerial, int& nHeightTx, const CBlockI
     return IsSerialInBlockchain(GetSerialHash(bnSerial), nHeightTx, pindex);
 }
 
-bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, const CBlockIndex* pindex)
+bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, const CBlockIndex* pindex, bool log)
 {
     uint256 txHash;
     // if not in zerocoinDB then its not in the blockchain
@@ -306,7 +306,7 @@ bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, const CBloc
         return false;
 
     CTransactionRef txRef;
-    return IsTransactionInChain(txHash, nHeightTx, txRef, Params().GetConsensus(), pindex);
+    return IsTransactionInChain(txHash, nHeightTx, txRef, Params().GetConsensus(), pindex, log);
 }
 
 bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend)

--- a/src/veil/zerocoin/zchain.h
+++ b/src/veil/zerocoin/zchain.h
@@ -35,7 +35,7 @@ bool GetZerocoinMint(const CBigNum& bnPubcoin, uint256& txHash);
 bool IsPubcoinInBlockchain(const uint256& hashPubcoin, int& nHeightTx, uint256& txid, CBlockIndex* pindexChain);
 bool IsPubcoinSpendInBlockchain(const uint256& hashPubcoin, int& nHeightTx, uint256& txid, CBlockIndex* pindexChain);
 bool IsSerialKnown(const CBigNum& bnSerial);
-bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, const CBlockIndex* pindex = nullptr);
+bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, const CBlockIndex* pindex = nullptr, bool log = true);
 bool IsSerialInBlockchain(const CBigNum& bnSerial, int& nHeightTx, const CBlockIndex* pindex = nullptr);
 bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend);
 bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend, CTransactionRef& txRef);


### PR DESCRIPTION
### Problem ###
Synching the 1.1.0 devnet chain generates many "ERROR: FindTx: txid mismatch" errors to the debug log file.

### Root Cause ###
For PoS blocks, when validating the blocks, if it's a zerocoinSpend, the validation code checks to make sure the serial hashes aren't already in the blockchain [e.g. already spent].  This check is an inverse logic check from normal use, as it expects it to not be found.  However, eventually it gets down to FindTx() and generates the error message, which is to be expected.  However it's very confusing when looking at your log.

### Solution ###
Add an optional parameter to the call structure, to pass down a logging variable to FindTx(), to not report the lack of finding the transaction as an error.

### Testing ###
When synching Devnet from zero, you'll see many txid mismatches.  Synching again with this fix will not generate the errors.