### PR TITLE
[PoW][RandomX] Don't check RandomX PoW until checking the block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4109,7 +4109,7 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
             }
         } else if (block.IsRandomX() && block.nTime >= Params().PowUpdateTimestamp()) {
             if (!CheckRandomXProofOfWork(block, block.nBits, consensusParams)) {
-                LogPrintf("%s : randomx proof of work failed %s\n", __func__, block.GetHash().GetHex());
+                LogPrintf("%s: randomx proof of work failed %s\n", __func__, block.GetHash().GetHex());
                 return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "randomx proof of work failed");
             }
         } else if (block.IsSha256D() && block.nTime >= Params().PowUpdateTimestamp()) {
@@ -4131,11 +4131,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         return true;
 
     // Check that the header is valid (particularly PoW).  This is mostly
-    // redundant with the call in AcceptBlockHeader.
+    // redundant with the call in AcceptBlockHeader except for checking the RandomX Proof of Work
     if (!CheckBlockHeader(block, state, consensusParams, (fCheckPOW && block.IsProofOfWork()), block.fProofOfFullNode)) {
-        if (block.IsRandomX()) {
-            LogPrintf("%s failed to get the correct value from CheckBlockHeader. block hash = %s\n", __func__, block.GetHash().GetHex());
-        }
         return false;
     }
 
@@ -4710,13 +4707,10 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
 
         bool fCheckPoW = !block.fProofOfStake;
 
-        if (!CheckBlockHeader(block, state, chainparams.GetConsensus(), fCheckPoW, fProofOfFullNode)) {
-            if (block.IsRandomX()) {
-                LogPrintf("%s failed to get the correct value from AcceptBlockHeader. block hash = %s\n", __func__, block.GetHash().GetHex());
-            } else {
-                return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(),
-                             FormatStateMessage(state));
-            }
+        // Don't check RandomX as we might not have the KeyBlock yet
+        if (!block.IsRandomX() && !CheckBlockHeader(block, state, chainparams.GetConsensus(), fCheckPoW, fProofOfFullNode)) {
+            return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(),
+                         FormatStateMessage(state));
         }
 
         // Get prev block index


### PR DESCRIPTION
### Problem ###
Syncing from scratch results in frequent randomx proof of work failures:
```
2020-08-09T02:06:21Z AcceptBlockHeader failed to get the correct value from AcceptBlockHeader. block hash = c5ef2daa3fab86b545ad4bee9dd87abe469b79dc5fb06d711a0a6d68eaf05c60
2020-08-09T02:06:21Z CheckBlockHeader : randomx proof of work failed 6d400e4584ce7617d4cdd05b84059eef56c9ff43780fe6312d03b0627259ff67
```

### Root Cause ###
The RandomX key block changes every 2048 blocks.  When checking the block headers on a sync that crosses this boundary (the chain height is less than the latest key block), `GetKeyBlock()` can use the wrong key block hash.  This is likely related to the high-hash problem from before.  However that fix disregarded a failed proof of work for randomX when the block was being checked as well.

### Solution ###
First off; `GetKeyBlock()` was a bit convoluted in the way it determined what key block a block should be using.  It calculated a remainder, and the gap before it changes, subtracting to get the key block based on the height desired and then figuring out if it should use the one before.  This code was mostly unnecessary; as we can easily calculate the multiple based on the divisor for the height desired minus the gap.

First off, reworked `GetKeyBlock()` to be less convoluted.   Added a check to make sure the key block desired is in the active chain. If it's not, an error message will be generated (there may be more work to be done for this), but that's unrelated to the problem at hand.

Secondly, changed `AcceptBlockHeader()` to not call `CheckBlockHeader()` for randomx blocks.  Also changed `CheckBlock()` to make sure that the randomX headers are checked (and we fail the block if they fail).  This way the headers aren't checked before the key block is in the chain, but it's checked when we get around to accepting the block.

### Testing ###
Integration tests included debug messages to confirm the `GetKeyBlock()` logic was finding the correct key block.  Other debug messages were included during integration testing to report the headers that were skipped:
```
2020-08-10T00:10:06Z (debug) AcceptBlockHeader: Skipping RandomX Check for block 61
2020-08-10T00:10:06Z (debug) AcceptBlockHeader: Skipping RandomX Check for block 62
2020-08-10T00:10:06Z (debug) AcceptBlockHeader: Skipping RandomX Check for block 63
2020-08-10T00:10:06Z (debug) AcceptBlockHeader: Skipping RandomX Check for block 64
```

And confirming they were checked when the block was received
```
2020-08-10T00:11:19Z (debug) CheckBlock: Checked RandomX header for block 61
2020-08-10T00:11:19Z (debug) CheckBlock: Checked RandomX header for block 62
2020-08-10T00:11:19Z (debug) CheckBlock: Checked RandomX header for block 63
2020-08-10T00:11:19Z (debug) CheckBlock: Checked RandomX header for block 64
```

Finally the transition from the first key block to the second key block (block 2112, technically 2114; the first randomx block after the key block switch) was confirmed to be functional.

```
2020-08-10T00:38:37Z DeallocateRandomXLightCache releasing the vm
2020-08-10T00:38:37Z DeallocateRandomXLightCache releasing the validating cache
2020-08-10T00:38:38Z (debug) CheckBlock: Checked RandomX header for block 2114
```

A full sync should be done against this PR.  Also, randomX mining, ideally on a block that's 64 + a multiple of 2048 (there aren't any that meet this criteria currently); and blocks between the multiple of 2048 to the switch (e.g. 2048*x to 2048*x+64) should be closely monitored.

Switchover blocks (2048*x+64) would be 2112, 4160, 6208, 8256...