### PR TITLE
[Miner] Move miner started event message inside the actual mining code

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -842,8 +842,6 @@ static arith_uint256 nHashes = 0;
 static int32_t nTimeStart = 0;
 
 void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfStake = false, bool fProofOfFullNode = false) {
-    LogPrintf("Veil Miner started\n");
-
     unsigned int nExtraNonce = 0;
     static const int nInnerLoopCount = 0x010000;
     static int nStakeHashesLast = 0;
@@ -854,6 +852,12 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
 
     while (fGenerateBitcoins || (fProofOfStake && enablewallet))
     {
+        if(fProofOfStake && enablewallet) {
+            LogPrintf("Veil PoS miner started\n");
+        } else {
+            LogPrintf("Veil PoW miner started\n");
+        }
+
         boost::this_thread::interruption_point();
 #ifdef ENABLE_WALLET
         if (enablewallet && fProofOfStake) {


### PR DESCRIPTION
### Problem ###
The event log message "Veil Miner started" is written to the debug.log before we check in the wallet is PoW or PoS mining.
```
2020-08-07T03:15:49Z ThreadStagingBlockProcessing() start
2020-08-07T03:15:49Z ThreadStakeMiner() start
2020-08-07T03:15:49Z Veil Miner started
2020-08-07T03:15:49Z GUI: Platform customization: "other"
```

### Root Cause ###
Log message is at the first line of BitcoinMiner()

### Solution ###
Move the code into the generate bitcoin and generate stake loop.

### Unit Testing Results ###
1. Start the wallet. 
2. Turn on staking
3. Check the event log
```
2020-08-11T03:49:29Z ThreadStagingBlockProcessing() start
2020-08-11T03:49:29Z ThreadStakeMiner() start
2020-08-11T03:49:29Z Veil PoS miner started
2020-08-11T03:49:29Z GUI: Platform customization: "other"
```

1. Start the wallet. 
2. Go to the console, enter `generatecontinuous true 1`
3. Check the event log
```
2020-08-11T04:51:29Z ThreadStagingBlockProcessing() start
2020-08-11T04:51:29Z ThreadStakeMiner() start
2020-08-11T04:51:29Z Veil PoW miner started
2020-08-11T04:51:29Z GUI: Platform customization: "other"
```