### PR TITLE
[PoW] Disallow stealth mining addresses

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,7 +1,6 @@
-// Copyright (c) 2019 Veil developers
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
-// Copyright (c) 2018-2019 The Veil developers
+// Copyright (c) 2018-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -535,7 +535,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     }
 
     if (pindexPrev && pindexPrev != chainActive.Tip()) {
-        error("%s: stail tip.", __func__);
+        error("%s: stale tip.", __func__);
         pblocktemplate->nFlags |= TF_STAILTIP;
         return std::move(pblocktemplate);
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1,6 +1,6 @@
-// Copyright (c) 2019 Veil developers
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -587,15 +587,22 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
 
         // Get mining address if it is set
         CScript script;
-        std::string address = gArgs.GetArg("-miningaddress", "");
-        if (!address.empty()) {
-            CTxDestination dest = DecodeDestination(address);
+        std::string sAddress = gArgs.GetArg("-miningaddress", "");
+        if (!sAddress.empty()) {
+            CTxDestination dest = DecodeDestination(sAddress);
 
             if (IsValidDestination(dest)) {
                 script = GetScriptForDestination(dest);
             } else {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "-miningaddress is not a valid address. Please use a valid address");
             }
+
+            // Disallow Stealth Addresses for now
+            CBitcoinAddress address(sAddress);
+            if (address.IsValidStealthAddress()) {
+               throw JSONRPCError(RPC_INVALID_PARAMETER, "-miningaddress must be a basecoin address");
+            }
+
         } else {
             script = CScript() << OP_TRUE;
         }

--- a/src/veild.cpp
+++ b/src/veild.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2018-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -16,6 +17,7 @@
 #include <noui.h>
 #include <shutdown.h>
 #include <util.h>
+#include <key_io.h>
 #include <httpserver.h>
 #include <httprpc.h>
 #include <utilstrencodings.h>
@@ -133,6 +135,24 @@ static bool AppInit(int argc, char* argv[])
         {
             // InitError will have been called with detailed error, which ends up on console
             return false;
+        }
+        std::string sAddress = gArgs.GetArg("-miningaddress", "");
+        if (!sAddress.empty())
+        {
+            // Sanity check the mining address
+            CTxDestination dest = DecodeDestination(sAddress);
+
+            if (!IsValidDestination(dest)) {
+                fprintf(stderr, "Error: miningaddress requires a valid basecoin address\n");
+                return false;
+            }
+
+            // Disallow Stealth Addresses for now
+            CBitcoinAddress address(sAddress);
+            if (address.IsValidStealthAddress()) {
+                fprintf(stderr, "Error: miningaddress must be a basecoin address\n");
+                return false;
+            }
         }
         if (gArgs.GetBoolArg("-daemon", false))
         {


### PR DESCRIPTION
### Problem
ProgPow block creation does not have a vout address for CoinBase (block mining) rewards when setting -miningaddress to a stealth address.

### Root Cause
The infrastructure for mining to Stealth Addresses is not present in the code at this time; it is moved to a future release.  The -miningaddress flag only applies to ProgPow, and is only used in the rpc command `getblocktemplate`, and doesn't care what type of address it is.  This allows a user to inadvertently set it to a stealth address and as such the mining reward is essentially burnt.

### Solution
Disallow setting a stealth address to -miningaddress (for now).  Also add checks on startup to also double check the address for the user, so that they are getting the feedback on starting the daemon, rather than until `getblocktemplate` is run.

Also fixed a typo.

### Testing
Invalid Addresses:
```
$veild -daemon=0 -mine=randomx -devnet -miningaddress="mmPRvduJzvskjVpim27EL7h3QxD776Uz"
Error: miningaddress requires a valid basecoin address
```
```
$ veild -daemon=0 -mine=randomx -devnet -miningaddress=tps1qqpyy6v22fpt0fwdm6etu4gae9tljqhejt8axvek4r7fg0rp8htw27qpqwclyxwfp4j822pyv5y9jgwyx32nha2w260t54a6uwaa2e89tl7f
Error: miningaddress requires a valid basecoin address
```
Stealth Address:
```
$ veild -daemon=0 -mine=randomx -devnet -miningaddress=tps1qqpfxdxgs90w5hjyr9x8l9jsf9jm25gzn46f0frkchyqzyjqjmenavcpqvw2l7jm6wwhjt88gfzde2ypxajazujgjz7r462qxs6u602je8yzuqqqjc7m6n
Error: miningaddress must be a basecoin address
```

Basecoin Address:
```
$ veild -daemon=0 -mine=randomx -devnet -miningaddress=mtQhyvf6z46tY2ZccBRTcAcFrMj73Y4qYq
```