### PR TITLE
[RPC] Rework difficulty reporting in getblockchaininfo

### DIFF
--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <amount.h>
 #include <map>
+#include <arith_uint256.h>
 
 class CBlock;
 class CBlockIndex;
@@ -31,6 +32,8 @@ extern std::map<std::string, CBlock> mapProgPowTemplates;
  * difficulty (4295032833 hashes).
  */
 double GetDifficulty(const CBlockIndex* blockindex);
+double GetDifficulty(const uint32_t nBits);
+double GetDifficulty(const arith_uint256 bn);
 
 /** Callback for when block tip changed. */
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);


### PR DESCRIPTION
### Problem
`getblockchaininfo` reports "0" difficulty if there hasn't been a block of the type in the last day

### Root Cause
The algorithm used looked for the last block of each type, and reported that difficulty.  The difficulties were initialized to zero, so if there wasn't any blocks found, it would use the initialized value.

### Solution
Original solution was to set it to minimum difficulty if the last block of that algo wasn't found.  However, it was realized that just because a block wasn't found, doesn't mean the difficulty is minimum.  It can still be pairing down as the time stretches [in cases such as a very high hash rate miner goes offline temporarily].  So rather than `getblockchaininfo` making it's own assessment off the last difficulty used, it's been changed to tap into the current difficulty calculation done by consensus.  This calculation takes into account the spacing vs. desired spacing of each algorithm, and the time since the last block of that type was mined.  Therefore it will give a difficulty based on the current mining difficulty.

### Pending issues
Upon looking through `GetNextWorkRequired` it became apparent that the code isn't efficiently designed for looking up the next Proof of Stake difficulty; and it uses the X16rt minimum difficulty for it's calculations.  While this shouldn't be an issue because there will always be high PoS difficulty, it is something that should eventually be addressed in a refactoring effort.

### Integration testing results

Original code:
```
  "difficulty_pow": 0,
  "difficulty_randomx": 1.52587890625e-05,
  "difficulty_progpow": 0,
  "difficulty_sha256d": 0.1928401811435348,
  "difficulty_pos": 689095.6606888357,
```

Original Solution:
_(note that I took the liberty of reflecting X16rt as -1 assuming no blocks would indicate we were in the new PoW phase)_
```
  "difficulty_pow": -1,
  "difficulty_randomx": 1.52587890625e-05,
  "difficulty_progpow": 0.06249910592947572,
  "difficulty_sha256d": 0.1604146523553673,
  "difficulty_pos": 648904.9717508123,
```
The above numbers are the last difficulty used for each algo; with the exception of progpow, which with zero blocks, is the minimum difficulty.

Final Solution:
```
  "difficulty_pow": 0.03615514687425005,
  "difficulty_randomx": 0.002776409849355776,
  "difficulty_progpow": 0.06249910592947572,
  "difficulty_sha256d": 0.1655083063526298,
  "difficulty_pos": 585931.0087972664,
```
As you can see from the above; the current pow difficulty is reducing, the progpow difficulty is at the minimum, and the randomx difficulty is still in the process of pairing down.