### PR TITLE
[PoS] Don't try to stake txs below nStakeMinAge

### DIFF
--- a/src/veil/proofofstake/kernel.cpp
+++ b/src/veil/proofofstake/kernel.cpp
@@ -66,11 +66,7 @@ std::set<uint256> setFoundStakes;
 bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockFrom, unsigned int& nTimeTx, const CBlockIndex* pindexBest, uint256& hashProofOfStake, bool fWeightStake)
 {
     if (nTimeTx < nTimeBlockFrom)
-        return error("Stake() : nTime violation");
-
-    if (nTimeBlockFrom + nStakeMinAge > nTimeTx) // Min age requirement
-        return error("Stake() : min age violation - nTimeBlockFrom=%d nStakeMinAge=%d nTimeTx=%d",
-                     nTimeBlockFrom, nStakeMinAge, nTimeTx);
+        return error("%s: nTime violation", __func__);
 
     //grab difficulty
     arith_uint256 bnTargetPerCoinDay;
@@ -136,7 +132,7 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
 bool CheckProofOfStake(CBlockIndex* pindexCheck, const CTransactionRef txRef, const uint32_t& nBits, const unsigned int& nTimeBlock, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake)
 {
     if (!txRef->IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", txRef->GetHash().ToString().c_str());
+        return error("%s: called on non-coinstake %s", __func__, txRef->GetHash().ToString().c_str());
 
     //Construct the stakeinput object
     if (txRef->vin.size() != 1 && txRef->vin[0].IsZerocoinSpend())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3895,6 +3895,11 @@ bool CWallet::CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits,
         if (nTxNewTime < nTimeMinBlock)
             nTxNewTime = nTimeMinBlock + 1;
 
+        if (pindexFrom->GetBlockTime() + nStakeMinAge > nTxNewTime) {
+            // Skip this one as it doesn't meet the minimum age
+            continue;
+        }
+
         //iterates each utxo inside of CheckStakeKernelHash()
         bool fWeightStake = true;
         if (Stake(stakeInput.get(), nBits, pindexFrom->GetBlockTime(), nTxNewTime, pindexBest, hashProofOfStake, fWeightStake)) {


### PR DESCRIPTION
### Problem
2020-08-19T22:51:06Z ERROR: Stake() : min age violation - nTimeBlockFrom=1597877409 nStakeMinAge=60 nTimeTx=15978774

### Root Cause
`Stake()` checks the min age whereas the calls to it (and the coin selection) looks at the depth.  This leaves the potential for something to be considered stakeable when it really isn't; and generates annoying log messages as well as consuming resources.

### Solution
Move the check up and remove the error message.  Skip the tx; but don't leave it out of the list, so if it's just a couple seconds off it may be used for staking calculations as soon as the age is met.  This is much more prevalent when the depth requirement for coins is lower and when the chain is moving faster to catch up.