### PR TITLE
1.1 early stats

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -268,6 +268,9 @@ static UniValue getchainalgostats(const JSONRPCRequest& request)
         );
 
     int nBlockCount = ALGO_RATIO_LOOK_BACK_BLOCK_COUNT;
+    if (nBlockCount > chainActive.Height()) {
+        nBlockCount = chainActive.Height();
+    }
     if (request.params.size() > 0) {
         nBlockCount = request.params[0].get_int();
         if (nBlockCount <= 0 || nBlockCount > chainActive.Height())


### PR DESCRIPTION
### Problem
`getchainalgostats` doesn't work with defaults when < 1440 blocks on the chain

### Solution
Set it to the lesser of 1440 or chain height