### PR TITLE
Fix crash on multiple progpow threads without hack

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -26,6 +26,7 @@
 #include "crypto/x16r/sph_shabal.h"
 #include "crypto/x16r/sph_whirlpool.h"
 #include "crypto/x16r/sph_sha2.h"
+#include "sync.h"
 
 #include <prevector.h>
 #include <serialize.h>
@@ -33,9 +34,14 @@
 #include <version.h>
 
 #include <vector>
+#include <crypto/ethash/include/ethash/ethash.hpp>
 
 class CBlockHeader;
 typedef uint256 ChainCode;
+
+/** Variables used by progpow **/
+extern CCriticalSection cs_context_builder;
+extern ethash::epoch_context_ptr progpow_context;
 
 /** A hasher class for Bitcoin's 256-bit hash (double SHA-256). */
 class CHash256 {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1240,20 +1240,6 @@ void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScri
         pthreadGroupRandomX->create_thread(boost::bind(&StartRandomXMining, pthreadGroupPoW,
                                            nThreads, coinbaseScript));
     } else {
-        if (GetMiningAlgorithm() == MINE_PROGPOW && GetTime() >= Params().PowUpdateTimestamp()) {
-            // XXX - Todo - This is a serious hack to get things working.  Not sure exactly
-            // what the root problem is, but when you start up more than one thread initially
-            // with progPoW, there is a crash deep in the algo calculations.  It's likely an
-            // initialization issue.  However, if you start one thread, stop it, then you can
-            // start as many threads as you want.  So, for now, we'll do that programatically.
-            pthreadGroupPoW->create_thread(boost::bind(&ThreadBitcoinMiner, coinbaseScript));
-            sleep(1);
-            pthreadGroupPoW->interrupt_all();
-            pthreadGroupPoW->join_all();
-            DeallocateVMVector();
-            DeallocateDataSet();
-        }
-
         for (int i = 0; i < nThreads; i++)
             pthreadGroupPoW->create_thread(boost::bind(&ThreadBitcoinMiner, coinbaseScript));
     }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -14,8 +14,6 @@
 
 // ProgPow
 #include <crypto/ethash/lib/ethash/endianness.hpp>
-#include <crypto/ethash/include/ethash/progpow.hpp>
-#include <crypto/ethash/helpers.hpp>
 
 // RandomX
 #include <crypto/randomx/randomx.h>


### PR DESCRIPTION
  ### Problem
  Starting multiple ProgPoW threads crashes deep in the depths of the algorithm:
  ```
  ethash::(anonymous namespace)::fnv1 (v=..., u=...) at crypto/ethash/lib/ethash/ethash.cpp:44
  44              r.word32s[i] = fnv1(u.word32s[i], v.word32s[i]);
  (gdb) bt
  #0  ethash::(anonymous namespace)::fnv1 (v=..., u=...) at crypto/ethash/lib/ethash/ethash.cpp:44
  #1  ethash::item_state::update (round=180, this=0xffffcfffbe00) at crypto/ethash/lib/ethash/ethash.cpp:203
  #2  ethash::calculate_dataset_item_2048 (context=..., index=<optimized out>) at crypto/ethash/lib/ethash/ethash.cpp:245
  #3  0x0000aaaaab16d350 in progpow::(anonymous namespace)::round (    lookup=0xaaaaab16b920 <ethash::calculate_dataset_item_2048(ethash_epoch_context const&, unsigned int)>, state=..., mix=..., r=62,  context=...) at crypto/ethash/lib/ethash/progpow.cpp:165
  #4  progpow::(anonymous namespace)::hash_mix (context=..., block_number=block_number@entry=24121, seed=seed@entry=0xffffcfffcbb8, lookup=0xaaaaab16b920 <ethash::calculate_dataset_item_2048(ethash_epoch_context const&, unsigned int)>) at crypto/ethash/lib/ethash/progpow.cpp:257
  #5  0x0000aaaaab16da9c in progpow::hash (context=..., block_number=24121, header_hash=..., nonce=<optimized out>) at crypto/ethash/lib/ethash/progpow.cpp:310
  #6  0x0000aaaaab0f5bd0 in ProgPowHash (blockHeader=..., mix_hash=...) at /usr/include/c++/9/bits/unique_ptr.h:360

  ```

  ### Root Cause
  Unknown