### PR TITLE
[PoS][PoW] Refine PoS to manage overall chain spacing

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -876,6 +876,24 @@ const CChainParams &Params() {
     return *globalChainParams;
 }
 
+int64_t CChainParams::GetDwgPastBlocks(int nPowType, bool fProofOfStake) const {
+    if (fProofOfStake)
+        return consensus.nDgwPastBlocks * 2; // count twice as many blocks
+    return consensus.nDgwPastBlocks;
+}
+
+int64_t CChainParams::GetTargetSpacing(int nPoWType, bool fProofOfStake) const {
+    if (nPoWType & CBlockHeader::PROGPOW_BLOCK)
+        return consensus.nProgPowTargetSpacing;
+    if (nPoWType & CBlockHeader::RANDOMX_BLOCK)
+        return consensus.nRandomXTargetSpacing;
+    if (nPoWType & CBlockHeader::SHA256D_BLOCK)
+        return consensus.nSha256DTargetSpacing;
+    if (fProofOfStake)
+        return consensus.nPowTargetSpacing/2; // Special case - actual block spacing
+    return consensus.nPowTargetSpacing;
+}
+
 std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -196,7 +196,7 @@ public:
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
 
-        consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitSha256 = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -209,6 +209,7 @@ public:
         consensus.nSha256DTargetSpacing = 1200;
 
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
+        consensus.nDgwPastBlocks_old  = 30; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 84; // 70% of confirmation window
@@ -403,6 +404,7 @@ public:
         consensus.nSha256DTargetSpacing = 1200;
 
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
+        consensus.nDgwPastBlocks_old = 60; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 15; // 75% for testchains
@@ -574,6 +576,7 @@ public:
         consensus.nSha256DTargetSpacing = 1200;
 
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
+        consensus.nDgwPastBlocks_old = 60; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 15; // 75% for testchains
@@ -746,6 +749,7 @@ public:
         consensus.nSha256DTargetSpacing = 1200;
 
         consensus.nDgwPastBlocks = 60; // number of blocks to average in Dark Gravity Wave
+        consensus.nDgwPastBlocks_old = 60; // number of blocks to average in Dark Gravity Wave
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
@@ -876,13 +880,19 @@ const CChainParams &Params() {
     return *globalChainParams;
 }
 
-int64_t CChainParams::GetDwgPastBlocks(int nPowType, bool fProofOfStake) const {
+// Not called prior to Algo change fork
+int64_t CChainParams::GetDwgPastBlocks(const CBlockIndex* pindex, const int nPowType, const bool fProofOfStake) const
+{
+    assert(pindex->GetBlockTime() >= Params().PowUpdateTimestamp()); // Shouldn't be called if we're not active on the new PoW system
     if (fProofOfStake)
         return consensus.nDgwPastBlocks * 2; // count twice as many blocks
     return consensus.nDgwPastBlocks;
 }
 
-int64_t CChainParams::GetTargetSpacing(int nPoWType, bool fProofOfStake) const {
+// Not called prior to Algo change fork
+int64_t CChainParams::GetTargetSpacing(const CBlockIndex* pindex, const int nPoWType, const bool fProofOfStake) const
+{
+    assert(pindex->GetBlockTime() >= Params().PowUpdateTimestamp()); // Shouldn't be called if we're not active on the new PoW system
     if (nPoWType & CBlockHeader::PROGPOW_BLOCK)
         return consensus.nProgPowTargetSpacing;
     if (nPoWType & CBlockHeader::RANDOMX_BLOCK)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -734,8 +734,8 @@ public:
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.powLimitRandomX = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.powLimitProgPow = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitSha256 = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         consensus.nPowTargetSpacing = 120; // alternate PoW/PoS every one minute
@@ -859,7 +859,7 @@ public:
         /** RingCT/Stealth **/
         nDefaultRingSize = 11;
 
-        nHeightLightZerocoin = 10;
+        nHeightLightZerocoin = 500;
         nZerocoinRequiredStakeDepthV2 = 10; //The required confirmations for a zerocoin to be stakable
         nHeightEnforceBlacklist = 0;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -148,6 +148,16 @@ public:
 
     uint32_t PowUpdateTimestamp() const { return nPowUpdateTimestamp; }
 
+    /**
+     * Returns the number of blocks to use for Dark Gravity Wave calculations
+    */
+    int64_t GetDwgPastBlocks(int nPowType, bool fProofOfStake) const;
+
+    /**
+     * Returns the target spacing for the given algo
+     */
+    int64_t GetTargetSpacing(int nPoWType, bool fProofOfStake) const;
+
 protected:
     CChainParams() {}
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -12,6 +12,7 @@
 #include <primitives/block.h>
 #include <protocol.h>
 #include <libzerocoin/Params.h>
+#include <chain.h>
 
 #include <memory>
 #include <vector>
@@ -151,12 +152,12 @@ public:
     /**
      * Returns the number of blocks to use for Dark Gravity Wave calculations
     */
-    int64_t GetDwgPastBlocks(int nPowType, bool fProofOfStake) const;
+    int64_t GetDwgPastBlocks(const CBlockIndex* pindex, const int nPowType, const bool fProofOfStake) const;
 
     /**
      * Returns the target spacing for the given algo
      */
-    int64_t GetTargetSpacing(int nPoWType, bool fProofOfStake) const;
+    int64_t GetTargetSpacing(const CBlockIndex* pindex, const int nPoWType, const bool fProofOfStake) const;
 
 protected:
     CChainParams() {}

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -77,6 +77,7 @@ struct Params {
     bool fPowAllowMinDifficultyBlocks;
     bool fPowNoRetargeting;
     int64_t nDgwPastBlocks;
+    int64_t nDgwPastBlocks_old;
     int64_t nPowTargetSpacing;
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;

--- a/src/pow.h
+++ b/src/pow.h
@@ -27,6 +27,7 @@ extern bool fKeyBlockedChanged;
 arith_uint256 GetPowLimit(int nPoWType);
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&,
                                     bool fProofOfStake, int nPoWType);
+unsigned int DGW_old(const CBlockIndex* pindexLast, const Consensus::Params& params, bool fProofOfStake);
 unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Params& params, bool fProofOfStake, int nPoWType);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */

--- a/src/veil/proofofstake/stakeinput.cpp
+++ b/src/veil/proofofstake/stakeinput.cpp
@@ -163,6 +163,7 @@ bool ZerocoinStake::GetModifier(uint64_t& nStakeModifier, const CBlockIndex* pin
             nHeightPrevious = nHeightSample;
             auto pindexSample = pindexChainPrev->GetAncestor(nHeightSample);
 
+            if (!pindexSample) return false;
             //Get a sampling of entropy from this block. Rehash the sample, since PoW hashes may have lots of 0's
             uint256 hashSample = GetHashFromIndex(pindexSample);
             hashSample = Hash(hashSample.begin(), hashSample.end());

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -12,7 +12,7 @@
 /** What block version to use for new blocks (pre versionbits) */
 static const int32_t VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4;
 /** What bits to set in version for versionbits blocks */
-static const int32_t VERSIONBITS_TOP_BITS = 0x01000000UL;
+static const int32_t VERSIONBITS_TOP_BITS = 0x20000000UL;
 static const int32_t VERSIONBITS_OLD_POW_VERSION = 0x20000000UL;
 static const int32_t VERSIONBITS_NEW_POW_VERSION = 0x30000000UL;
 /** What bitmask determines whether versionbits is in use */


### PR DESCRIPTION
**_This PR will require another restart of devnet._**

### Problem
When there isn't enough hash power to maintain desired spacing for the different PoW algorithms, the block spacing tends to extend longer than 60 seconds per block.

### Root Cause
All the algos, PoS included, manage their difficulty adjustments based on their designed spacing.  ProgPow targets one block every 172 seconds; RandomX targets one block every 600 seconds and Sha256 targets one block every 1200 seconds.  This all together accounts for one PoW block every 120 seconds.  Combining that with PoS one block every 120 seconds; you end up with a block every 60 seconds.

However, if any of the algorithms aren't meeting their designated block creation rate; there isn't any adjustments made to other algorithms.  So taking it to an extreme, with zero mining, the chain will adjust to target an average of one PoS block every 120 seconds, instead of every 60.

### Solution
Create a special case for ProofOfStake that doesn't look at it's own spacing, but rather looks at the overall spacing of the last 120 blocks (instead of the individual algorithms analysis of the last 60 blocks).  It then adjusts the PoS difficulty based on how close the last 120 blocks are to 60 seconds per block.  This essentially makes PoS the master spacing keeper for all the block spacing, and creates a situation where PoS will fill in the gaps if hashing power drops away suddenly.

### Additional changes
**_Difficulty Adjustment Capping_**
Even with a 8GB quadcore CPU, the SHA256 difficulty increases significantly from the minimum difficulty; not to mention the rapid increase in PoS difficulty.  This results in several hours of adjustments before the difficulty is raised to a point that the algorithm isn't running ahead.  Given the adjustments made in #827 in regards to waiting to see the result before making further adjustments, the limiting of the difficulty increases to just 3x does not appear to be necessary.  That limitation was removed so that the difficulty reacts to the current environment much quicker then previously.  This should prove to have a significant stabilization of chain timing upon switchover when the difficulties will be at their minimum, and could have taken several days with real hardware mining before the difficulty is raised to a point that the spacing is stabilized.

**_Regtest Stability_**
Regtest allowed light zerocoin protocol before enough blocks existed to support the hashing algorithm; thus causing a SegFault when the blocks needed can't be found.  A check was added to make sure that the block exists, as well as an increase in the switching point made to ensure Light zerocoin doesn't start until there's enough blocks to support it (100 + [1++10]*6) == 100 + 55*6 = 430 blocks.  So the switchover is set to 500.  This problem only existed with regtest.

Additionally regtest difficulties were changed to align closer to the other chains, to better test against the primary change in this PR.  The SHA256 difficulty was not adjusted higher due to another issue... the miner doesn't recognize it's solving for a genesis block that needs to be X16rt, and so it tries to mine it as one of the new protocols.  This "bug" won't exist with the fork on an existing chain, so it's only an issue with starting up a new chain; without enough hashing power to easily meet the SHA256 minimum difficulty.
