### PR TITLE
[PoW][RPC] Correct Sha256 Nonce incrementation

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -199,7 +199,7 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.powLimitSha256 = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimitSha256 = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         consensus.nPowTargetSpacing = 120; // alternate PoW/PoS every one minute
 
@@ -263,8 +263,6 @@ public:
         nPowTimeStampActive = 4294967295;
 
         int nTimeStart = 1540413025;
-        arith_uint256 nBits;
-        nBits.SetCompact(0x1e0ffff0);
         uint32_t nNonce = 3492319;
         genesis = CreateGenesisBlock(nTimeStart, nNonce, 0x1e0ffff0, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -395,7 +393,7 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.powLimitSha256 = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimitSha256 = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         consensus.nPowTargetSpacing = 120; // alternate PoW/PoS every one minute
 
@@ -567,7 +565,7 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitRandomX = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.powLimitProgPow = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.powLimitSha256 = uint256S("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimitSha256 = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetSpacing = 120; // alternate PoW/PoS every one minute
 
         // ProgPow, RandomX, Sha256d

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -180,10 +180,10 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
                 --nMaxTries;
             }
         } else if (pblock->IsSha256D() && pblock->nTime >= Params().PowUpdateTimestamp()) {
-            while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount &&
+            while (nMaxTries > 0 && pblock->nNonce64 < nInnerLoopCount &&
                    !CheckProofOfWork(pblock->GetSha256DPoWHash(), pblock->nBits,
                                      Params().GetConsensus(), CBlockHeader::SHA256D_BLOCK)) {
-                ++pblock->nNonce;
+                ++pblock->nNonce64;
                 --nMaxTries;
             }
         } else {
@@ -196,7 +196,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
         if (nMaxTries == 0) {
             break;
         }
-        if (pblock->nNonce == nInnerLoopCount) {
+        if ((pblock->nNonce == nInnerLoopCount) || (pblock->nNonce64 == nInnerLoopCount)) {
             continue;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);


### PR DESCRIPTION
### Problem
Every pass through `generateBlocks` loop was trying the same hash 65535 times.

### Root Cause
The Sha256 hashing serialization algorithm uses nNonce64; but the `generate` RPC call was incrementing `nNonce`, so it was trying all with the same value of nNonce64.

### Solution
Change the code to increment nNonce64; Also check so we can detect if an nNonce64 loop expired without finding a solution [also effects progPow] so that it doesn't try to submit a bad block.