### PR TITLE
[DWG] Make sure OneBack exists

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -315,7 +315,9 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
     int64_t nOverdueTime = nTipToLastMatchingProof - nPowSpacing;
     if (!nTipToLastMatchingProof) {
         // Tip is our algo, so look one more back to see where we're at
-        nOverdueTime = pindexLastMatchingProof->GetBlockTime() - pindexOneBack->GetBlockTime() - nPowSpacing;
+        if (pindexOneBack) {
+            nOverdueTime = pindexLastMatchingProof->GetBlockTime() - pindexOneBack->GetBlockTime() - nPowSpacing;
+        }
     }
 
     if (fProofOfStake) {
@@ -330,9 +332,8 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         int64_t nBlocksPoW = nBlocksMeasured - nCountBlocks;
         int64_t nBlocksIntended = nBlocksMeasured >> 1; // 50%
         int64_t nPosSpacing = nPowSpacing + (nPowSpacing * nBlocksPoW / nBlocksIntended);
-        if (nTipToLastMatchingProof) {
-            nOverdueTime = nTipToLastMatchingProof - nPosSpacing;
-        } else {
+        nOverdueTime = nTipToLastMatchingProof - nPosSpacing;
+        if (!nTipToLastMatchingProof && pindexOneBack) {
             // Tip is our algo, so look one more back to see where we're at
             nOverdueTime = pindexLastMatchingProof->GetBlockTime() - pindexOneBack->GetBlockTime() - nPosSpacing;
         }


### PR DESCRIPTION
### Problem
segfault on first generated block after genesis block

### Root Cause
When there's only one block of a given algo, there is no "One Back", so the pIndexOneBack is null and thus calls to it's structure crash.

### Solution
If there's only one of any given algo, don't use oneback even if the tip is the current algo.