### PR TITLE
[Build] Update build compatibility for 1.1.0.1 release changes

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -26,7 +26,7 @@ packages:
 - "faketime"
 - "bsdmainutils"
 - "ca-certificates"
-- "python"
+- "python3"
 remotes:
 - "url": "https://github.com/Veil-Project/veil.git"
   "dir": "veil"
@@ -36,11 +36,11 @@ script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
-  FAKETIME_HOST_PROGS=""
+  FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"
   HOST_CXXFLAGS="-O2 -g"
-  HOST_LDFLAGS=-static-libstdc++
+  HOST_LDFLAGS="-static-libstdc++ -Wl,-O2 -Wl,-z,noexecstack"
 
   export QT_RCC_TEST=1
   export QT_RCC_SOURCE_DATE_OVERRIDE=1
@@ -61,7 +61,7 @@ script: |
     echo "REAL=\`which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1\`" >> ${WRAP_DIR}/${prog}
     echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${prog}
     echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${prog}
-    echo "\$REAL \$@" >> $WRAP_DIR/${prog}
+    echo "\$REAL \"\$@\""  >> $WRAP_DIR/${prog}
     chmod +x ${WRAP_DIR}/${prog}
   done
   }
@@ -73,7 +73,7 @@ script: |
         echo "REAL=\`which -a ${i}-${prog} | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
         echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${i}-${prog}
         echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${i}-${prog}
-        echo "\$REAL \$@" >> $WRAP_DIR/${i}-${prog}
+        echo "\$REAL \"\$@\""  >> $WRAP_DIR/${i}-${prog}
         chmod +x ${WRAP_DIR}/${i}-${prog}
     done
   done
@@ -109,7 +109,7 @@ script: |
       break
     fi
   done
-  \$REAL \$@
+  \$REAL "\$@"
   EOF
   chmod +x ${WRAP_DIR}/${prog}
   done


### PR DESCRIPTION
### Problem ###
Code changes for the 1.1.0.1 release were not compatible with the current build settings. 

### Solution ###
Update settings

### Unit Testing Results ###
To test changes you will need to use gitian. 
Clone this repo [https://github.com/Veil-Project/docker-based-gitian-builder](https://github.com/Veil-Project/docker-based-gitian-builder)
```
git clone https://github.com/Veil-Project/docker-based-gitian-builder.git
cd docker-based-gitian-builder
sudo bash run_all.sh
```
When prompted for a repo enter
`https://github.com/codeofalltrades/veil.git`
Enter tag v1.1.0.99
