### PR TITLE
[RingCT Staking] Fix creation of stealth staking address on startup

### DIFF
--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -125,8 +125,33 @@ static UniValue getstealthchangeaddress(const JSONRPCRequest &request)
                 + HelpExampleRpc("getstealthchangeaddress", ""));
 
     EnsureWalletIsUnlocked(wallet.get());
-    auto pAnonWallet = wallet->GetAnonWallet();
-    auto address = pAnonWallet->GetStealthChangeAddress();
+    AnonWallet *pAnonWallet = wallet->GetAnonWallet();
+    CStealthAddress address = pAnonWallet->GetStealthChangeAddress();
+
+    return address.ToString(true);
+}
+
+static UniValue getstealthstakeaddress(const JSONRPCRequest &request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+                "getstealthstakeaddress\n"
+                "Returns the default stealth staking address."
+                + HelpRequiringPassphrase(wallet.get()) +
+                "\nResult:\n"
+                "\"address\"              (string) The stealth staking address\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getstealthstakeaddress", "")
+                + HelpExampleRpc("getstealthstakeaddress", ""));
+
+    EnsureWalletIsUnlocked(wallet.get());
+    AnonWallet *pAnonWallet = wallet->GetAnonWallet();
+    CStealthAddress address;
+    pAnonWallet->GetStakeAddress(address);
 
     return address.ToString(true);
 }
@@ -1926,6 +1951,7 @@ static const CRPCCommand commands[] =
                 { "wallet",             "restoreaddresses",          &restoreaddresses,          {"generate_count"} },
                 { "wallet",             "rescanringctwallet",          &rescanringctwallet,          {} },
                 { "wallet",             "getstealthchangeaddress",          &getstealthchangeaddress,          {} },
+                { "wallet",             "getstealthstakeaddress",          &getstealthstakeaddress,          {} },
                 { "wallet",             "sendbasecointostealth", &sendbasecointostealth,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },
 
                 { "wallet",             "sendstealthtobasecoin", &sendstealthtobasecoin,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -763,6 +763,17 @@ static UniValue listaddresses(const JSONRPCRequest& request)
 
         results.push_back(entry);
     }
+    // Get the stealth stake address
+    pAnonWallet->GetStakeAddress(address);
+    if (AnonBalances[address]) {
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("address", address.ToString(true));
+        entry.pushKV("amount", ValueFromAmount(AnonBalances[address]));
+        entry.pushKV("label", "<stealth stake address>");
+
+        results.push_back(entry);
+    }
 
     return results;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2152,7 +2152,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
             }
             if (GetTime() >= nNow + 60) {
                 nNow = GetTime();
-                WalletLogPrintf("Still rescanning. At block %d. Progress=%f\n", pindex->nHeight, progress_current);
+                WalletLogPrintf("Still rescanning. At block %d. Progress=%.4f%%\n", pindex->nHeight, progress_current*100);
             }
 
             CBlock block;
@@ -2200,9 +2200,9 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
             }
         }
         if (pindex && fAbortRescan) {
-            WalletLogPrintf("Rescan aborted at block %d. Progress=%f\n", pindex->nHeight, progress_current);
+            WalletLogPrintf("Rescan aborted at block %d. Progress=%.4f%%\n", pindex->nHeight, progress_current*100);
         } else if (pindex && ShutdownRequested()) {
-            WalletLogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%f\n", pindex->nHeight, progress_current);
+            WalletLogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%.4f%%\n", pindex->nHeight, progress_current*100);
         }
         uiInterface.ShowProgress(strprintf("%s " + _("Rescanning..."), GetDisplayName()), 100, 0); // hide progress dialog in GUI
     }
@@ -5452,6 +5452,10 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         assert(pAnonWallet->Initialise(&extMasterAnon));
         LogPrintf("%s: loaded new Anon wallet", __func__);
     } else {
+        CExtKey extMasterAnon;
+        if (walletInstance->GetAnonWalletSeed(extMasterAnon)) {
+            assert(pAnonWallet->UnlockWallet(extMasterAnon));
+        } // else don't throw an error if it fails since they might be encrypted
         assert(pAnonWallet->Initialise());
     }
 


### PR DESCRIPTION
### Problem
A Stealth Staking address isn't properly created when initially starting 1.2 on an existing chain.

### Root Cause
Only 1.2 generated wallets were tested; not transition from existing wallets on upgrade.

### Solution
Added `getstealthstakingaddress` RPC command to see what your created staking address is
Added logic to list unspent to check and display any coins in the staking address
Reworked whole creation and loading logic to handle transition from 1.1 wallet to 1.2 wallet, prior to this PR, it only worked if the wallet was generated with 1.2 and not encrypted.

### Testing
- Tested transition from 1.1 to 1.2
- Tested restart of 1.2 after transition
- Tested creation of 1.2 wallet
- Tested restart of 1.2 wallet after creation
- Tested transition of an encrypted wallet 1.1 to 1.2 [and restart]
- Tested transition of a 1.2 created wallet to encrypted wallet
- Tested `getstealthstakingaddress` through all
- **_Did not_** test rescanning report log output change