### PR TITLE
[GUI]: add a small indicator for the last block time on lower veil status bar

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -541,6 +541,7 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel)
         {
             walletFrame->setClientModel(_clientModel);
             balance->setClientModel(_clientModel);
+            veilStatusBar->setClientModel(_clientModel);
         }
 #endif // ENABLE_WALLET
         unitDisplayControl->setOptionsModel(_clientModel->getOptionsModel());
@@ -925,6 +926,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     }
 
     veilStatusBar->updateSyncIndicator(count);
+    veilStatusBar->setNumBlocks(blockDate);
 
     QString tooltip;
 

--- a/src/qt/veil/forms/veilstatusbar.ui
+++ b/src/qt/veil/forms/veilstatusbar.ui
@@ -91,7 +91,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0">
         <property name="leftMargin">
          <number>9</number>
         </property>
@@ -188,12 +188,39 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_right">
+         <spacer name="horizontalSpacer_middle">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeType">
            <enum>QSizePolicy::Expanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelLastBlockTime_Head">
+          <property name="text">
+           <string> Last block time:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelLastBlockTime_Content">
+          <property name="text">
+           <string>N/A</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_right">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>

--- a/src/qt/veil/veilstatusbar.cpp
+++ b/src/qt/veil/veilstatusbar.cpp
@@ -6,6 +6,7 @@
 #include <qt/veil/forms/ui_veilstatusbar.h>
 
 #include <qt/bitcoingui.h>
+#include <qt/clientmodel.h>
 #include <qt/walletmodel.h>
 #include <qt/veil/qtutils.h>
 #include <iostream>
@@ -127,6 +128,19 @@ void VeilStatusBar::onBtnLockClicked()
 
     updateStakingCheckbox();
 }
+
+void VeilStatusBar::setClientModel(ClientModel *model){
+    this->clientModel = model;
+}
+
+void VeilStatusBar::setNumBlocks(const QDateTime& blockDate)
+{
+    if (!clientModel)
+        return;
+    
+    // Set the informative last block time label.
+    ui->labelLastBlockTime_Content->setText(blockDate.toString());
+}    
 
 void VeilStatusBar::setWalletModel(WalletModel *model)
 {

--- a/src/qt/veil/veilstatusbar.h
+++ b/src/qt/veil/veilstatusbar.h
@@ -6,11 +6,13 @@
 #define VEILSTATUSBAR_H
 
 #include <QWidget>
+#include <QDateTime>
 #include <miner.h>
 #include "unlockpassworddialog.h"
 
 class BitcoinGUI;
 class WalletModel;
+class ClientModel;
 class QPushButton;
 
 namespace Ui {
@@ -31,7 +33,9 @@ public:
     void setSyncStatusVisible(bool fVisible);
 #ifdef ENABLE_WALLET
     void setWalletModel(WalletModel *model);
+    void setClientModel(ClientModel *clientModel);
     void updateStakingCheckbox();
+    void setNumBlocks(const QDateTime& blockDate);
 #endif
 
 private Q_SLOTS:
@@ -46,6 +50,7 @@ private:
     Ui::VeilStatusBar *ui;
     BitcoinGUI* mainWindow;
     WalletModel *walletModel = nullptr;
+    ClientModel *clientModel = nullptr;
     UnlockPasswordDialog *unlockPasswordDialog = nullptr;
 
     bool preparingFlag = false;


### PR DESCRIPTION
### Problem
A small improvement to the usability: the user often needs to see what the block time is on the current node, and it is very annoying having to open the debug console to extract this information.

### Root Cause
The value is not visible.

### Solution
Two labels have been added to the bottom status bar and connected the signal to update the block time.

### Bounty Payment Address
`sv1qqphsvuwhk29xcn2q9gdth9x73qpm8kcktmuxyd8szl50sgt2nt47egpqwnxr83hfj7s6fnec2jr0cv5yc7r6s7nvxhd9969qrgy4cgnznwewqqqauut5m`



![Veil_Last_Block_In_Status_Bar2020-11-06 17-55-08](https://user-images.githubusercontent.com/71947895/98448005-2b46c000-20f7-11eb-8d7a-c1708c2bdb1e.png)
