### PR TITLE
[PoW][RandomX] Display Hashspeed after processing

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -42,6 +42,10 @@ namespace Consensus { struct Params; };
 
 static const bool DEFAULT_PRINTPRIORITY = false;
 
+// This is used for both the nonce separation and the loop count, so
+// make it a constant used by both to maintain their synchronization
+static const uint32_t RANDOMX_INNER_LOOP_COUNT = 100000;
+
 enum TemplateFlags
 {
     TF_FAIL = 0,


### PR DESCRIPTION
### Problem
RandomX Hashspeed was not being displayed in the logfile when using blockcreation debugging

### Root Cause
Technically it does; however only when you actually win a block or you get through the full 100,000 hashes without another block coming in.   The problem was, if you stopped computing because another block came in while you were computing, it would restart the hashing on the next block, before it reports the hash speed used.

### Solution
Move the hash debugging to before the check if the block was already found or not.  Also a couple other tweaks made; reduce the cs_nonce critical section to minimum needed, as well as remove the hardcoded inner loop count, as that inner loop count is also used for nonce spacing.  That way if the inner loop count is changed, the nonce separation between threads is consistent and doesn't leave gaps.

### Issue
Addresses Issue #866