### PR TITLE
[RPC] Remove lock check for listzerocoinamounts

### DIFF
--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2019 The PIVX developers
-// Copyright (c) 2019 The Veil developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -579,8 +579,6 @@ UniValue listzerocoinamounts(const JSONRPCRequest& request)
                 HelpExampleCli("listzerocoinamounts", "") + HelpExampleRpc("listzerocoinamounts", ""));
 
     LOCK2(cs_main, pwallet->cs_wallet);
-
-    EnsureWalletIsUnlocked(pwallet);
 
     std::pair<ZerocoinSpread, ZerocoinSpread> pZerocoinDist = pwallet->GetMyZerocoinDistribution();
     UniValue ret(UniValue::VARR);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2009-2018 The Bitcoin Core developers
-// Copyright (c) 2018-2019 The Veil developers
+// Copyright (c) 2018-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -5048,7 +5048,7 @@ void CWallet::AutoZeromint()
 
         // Return if something went wrong during minting
         if (strError != ""){
-            LogPrintf("CWallet::AutoZeromint(): auto minting failed with error: %s\n", strError);
+            LogPrintf("%s: auto minting failed with error: %s\n", __func__, strError);
             return;
         }
         nZerocoinBalance = GetZerocoinBalance(false);
@@ -5850,7 +5850,7 @@ string CWallet::MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, std:
 
     if (!coinControl->HasSelected()) {
         string strError = _("Error: No valid utxo!");
-        LogPrintf("MintZerocoin() : %s", strError.c_str());
+        LogPrintf("%s: %s\n", __func__, strError.c_str());
         return strError;
     }
 
@@ -5892,7 +5892,7 @@ string CWallet::MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDetermin
 
     if (IsLocked() || IsUnlockedForStakingOnly()) {
         string strError = _("Error: Wallet locked, unable to create transaction!");
-        LogPrintf("MintZerocoin() : %s", strError.c_str());
+        LogPrintf("%s: %s\n", __func__, strError.c_str());
         return strError;
     }
 


### PR DESCRIPTION
### Problem
`listzerocoinamounts` requires a wallet to be unlocked to execute

### Root Cause
There was a specific wallet unlocked check to prevent it's use without unlocking the wallet.

### Solution
Remove the check so that the `listzerocoinamounts` RPC command will execute against a locked wallet

### Note
Generally there will be little to no change to the zerocoin implementation as we are currently in the process of phasing it out.  However this was a team backed request that was a minimal interruption, so it's being pushed.  This will  be virtually obsolete after the next fork, but it will be usable from the master branch.

It is expected to be tested and approved by members of the team, and will be skipping the code review load on the dev team.
