### PR TITLE
Optimize hashing of internal sha256d miner.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -975,8 +975,9 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                 }
                 pblock->mixHash = mix_hash;
             } else if (pblock->IsSha256D() && pblock->nTime >= Params().PowUpdateTimestamp()) {
+                uint256 midStateHash = pblock->GetSha256dMidstate();
                 while (nTries < nInnerLoopCount &&
-                       !CheckProofOfWork(pblock->GetSha256DPoWHash(), pblock->nBits,
+                       !CheckProofOfWork(pblock->GetSha256D(midStateHash), pblock->nBits,
                                          Params().GetConsensus(), CBlockHeader::SHA256D_BLOCK)) {
                     boost::this_thread::interruption_point();
                     ++nTries;

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -48,10 +48,20 @@ uint256 CBlockHeader::GetX16RTPoWHash(bool fSetVeilDataHashNull) const
 uint256 CBlockHeader::GetSha256DPoWHash() const
 {
     CSha256dDataInput input(*this);
-
     uint256 dataHash = SerializeHash(input);
-
     CSha256dInput sha256Final(*this, dataHash);
+    return SerializeHash(sha256Final);
+}
+
+uint256 CBlockHeader::GetSha256dMidstate() const
+{
+    CSha256dDataInput input(*this);
+    return SerializeHash(input);
+}
+
+uint256 CBlockHeader::GetSha256D(uint256& midState) const
+{
+    CSha256dInput sha256Final(*this, midState);
     return SerializeHash(sha256Final);
 }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -198,6 +198,9 @@ public:
     uint256 GetX16RTPoWHash(bool fSetVeilDataHashNull = false) const;
     uint256 GetSha256DPoWHash() const;
 
+    uint256 GetSha256dMidstate() const;
+    uint256 GetSha256D(uint256& midState) const;
+
     uint256 GetProgPowHeaderHash() const;
     uint256 GetRandomXHeaderHash() const;
 


### PR DESCRIPTION
Since the datahash is not likely to change much between blocks (other than
work refresh), we can calculate it once and reuse the value.

Average hashrate beforehand on 4core vps was 4mh, averages around 5.5-6mh with
blocks successfully solved on devnet.