### PR TITLE
[DB] Data error checks and frequency changes

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -105,6 +106,10 @@ const CBlockIndex* CBlockIndex::GetAncestor(int height) const
             pindexWalk = pindexWalk->pskip;
             heightWalk = heightSkip;
         } else {
+            if (!pindexWalk->pprev) {
+                LogPrintf("%s: pindexWalk failed:  Hash: %s, Current Height: %d, Working Height: %d\n",
+                          __func__, pindexWalk->phashBlock->GetHex(), height, nHeight);
+            }
             assert(pindexWalk->pprev);
             pindexWalk = pindexWalk->pprev;
             heightWalk--;

--- a/src/validation.h
+++ b/src/validation.h
@@ -106,9 +106,9 @@ static const int MAX_BLOCKTXN_DEPTH = 10;
  *  want to make this a per-peer adaptive value at some point. */
 static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 /** Time to wait (in seconds) between writing blocks/block index to disk. */
-static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
+static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 6;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
-static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
+static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 6;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 /** Block download timeout base, expressed in millionths of the block interval (i.e. 10 min) */


### PR DESCRIPTION
### Problem
PindexWalk->pprev assert failures occur randomly on startup

### Root Cause
_**Note that root cause is not yet completely understood.  This is not a fix, but rather a mitigation that alleviates the risk of the problem occurring.**_

A corruption occurs occasionally in the writing of the block database, where an index no longer points to the correct block, but rather reads a different block off disk.  Usually the block read happens to be an orphan block.  It definitely is connected to writing of side chains and orphans, but the root cause is yet unknown.   This problem results in a valid block not being read from disk, so when it begins to connect the blocks together [for the staking algorithmic calculations], there is a block that doesn't have a valid previous [because it basically walks off the chain because there's a block missing.

### Mitigation
**_Note that this PR will not correct an already corrupt database; it will only minimize the occurrences.  Anyone currently with a corrupted database will have to recover their chain prior to being able to run this PR._**

Several changes were made.  Information is added to the debug log file to give an indication as to what the problem block was, when a problem block is detected on startup.  When the header information is disconnected from the block information, the block is no longer written to disk (This generally occurs with orphan blocks).  If a block is read when this occurs, it also is reported to the log file.

The frequency that blocks are written to disk has been changed to write a similar number of blocks at a time as Bitcoin.  Since veil's block creation is 10 times faster, the write timers have been changed to be 10% of what they were in Bitcoin.  This showed significant improvement to the occurrences of the corruption.  It's important to remind again that this is not a fix; there is still a lingering issue.  However over heavy test with two nodes, one of them running with the new write frequency and one without the write frequency; the one without the change found 63 instances of corrupted blocks in 1923 blocks.  The node with the change saw zero corruptions.

For that reason, this PR is being pushed to greatly reduce the occurrences that have become prevalent again as more people are in wallet mining and staking at the same time.  Issue #692 will remain open while this is continued to be worked over time, as attempts to correct the corruption are investigated, or root cause is continued to be found.  This PR however does reduce the urgency of the research.