### PR TITLE
[Config] Ignore prune mode if txindex is set

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The PIVX developers
-// Copyright (c) 2018-2019 The Veil developers
+// Copyright (c) 2018-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -1000,7 +1000,7 @@ bool AppInitParameterInteraction()
     // if using block pruning, then disallow txindex
     if (gArgs.GetArg("-prune", 0)) {
         if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX))
-            return InitError(_("Prune mode is incompatible with -txindex."));
+            InitWarning(_("Ignoring Prune Mode: Incompatible with -txindex."));
     }
 
     // -bind and -whitebind can't be set when not listening
@@ -1122,6 +1122,10 @@ bool AppInitParameterInteraction()
     int64_t nPruneArg = gArgs.GetArg("-prune", 0);
     if (nPruneArg < 0) {
         return InitError(_("Prune cannot be configured with a negative value."));
+    }
+    if (nPruneArg && gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
+        // We already warned them that it's getting ignored
+        nPruneArg = 0;
     }
     nPruneTarget = (uint64_t) nPruneArg * 1024 * 1024;
     if (nPruneArg == 1) {  // manual pruning: -prune=1


### PR DESCRIPTION
### Problem
#253 - Prune mode incompatible with txindex.  
Having prune mode on can stick the user into being unable to start their wallet.  For Qt: they receive an error stating "Prune mode is Incompatible with -txindex"

### Root Cause
The error was a little heavy handed, and rejected the use of prune mode without txindex=0.  The part of this issue that makes it important to address is that you can inadvertently end up with bPrune set in your registry on windows; making it difficult to find and remove.  There is an additional issue that implies that uninstalling your wallet will not remove the registry entries; so getting bPrune=true in your registry would be quite challenging to clear out, and likely result in support tickets.

### Solution
**_Note that prune mode is unsupported and likely will result in corrupting your wallet.  This is not meant to claim that prune mode is functional._**

If Prune mode is set and txindex is not implicitly disabled [txindex=0], the wallet will not run.  This PR changes the prune mode from an error that shuts down the wallet, to a warning that ignores prune mode if txindex is enabled.   This warning will not show in a Windows pop-up, but rather in the log file and the terminal executing the daemon and/or qt.  It will also ignore the prune mode setting, changing it to '0' if it is set.

### Testing
combinations of txindex=[0|1], prune=[0|1] in your config file, command line, and bPrune=true in your registry [see issue #253 for registry details]

