### PR TITLE
[RPC] Reworked getnetworkhashps with tweaks to -mine and getmininginfo

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1252,17 +1252,17 @@ int GetMiningAlgorithm() {
     return nMiningAlgorithm;
 }
 
-bool SetMiningAlgorithm(const std::string& algo) {
-    if (algo == PROGPOW_STRING) {
-        nMiningAlgorithm = MINE_PROGPOW;
-        return true;
-    } else if (algo == SHA256D_STRING) {
-        nMiningAlgorithm = MINE_SHA256D;
-        return true;
-    } else if (algo == RANDOMX_STRING) {
-        // Catches the default
-        nMiningAlgorithm = MINE_RANDOMX;
+bool SetMiningAlgorithm(const std::string& algo, bool fSet) {
+    int setAlgo = -1;
+
+    if (algo == PROGPOW_STRING)      setAlgo = MINE_PROGPOW;
+    else if (algo == SHA256D_STRING) setAlgo = MINE_SHA256D;
+    else if (algo == RANDOMX_STRING) setAlgo = MINE_RANDOMX;
+
+    if (setAlgo != -1) {
+        if (fSet) nMiningAlgorithm = setAlgo;
         return true;
     }
+
     return false;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1211,8 +1211,6 @@ void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScri
     }
     fGenerateBitcoins = fGenerate;
 
-    SetMiningAlgorithm(gArgs.GetArg("-mine", RANDOMX_STRING));
-
     if (nThreads < 0) {
         // In regtest threads defaults to 1
         nThreads = 1;
@@ -1254,12 +1252,17 @@ int GetMiningAlgorithm() {
     return nMiningAlgorithm;
 }
 
-void SetMiningAlgorithm(const std::string& algo) {
+bool SetMiningAlgorithm(const std::string& algo) {
     if (algo == PROGPOW_STRING) {
         nMiningAlgorithm = MINE_PROGPOW;
+        return true;
     } else if (algo == SHA256D_STRING) {
         nMiningAlgorithm = MINE_SHA256D;
-    } else {
+        return true;
+    } else if (algo == RANDOMX_STRING) {
+        // Catches the default
         nMiningAlgorithm = MINE_RANDOMX;
+        return true;
     }
+    return false;
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -49,7 +50,7 @@ static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool 
 }
 
 int GetMiningAlgorithm();
-bool SetMiningAlgorithm(const std::string& algo);
+bool SetMiningAlgorithm(const std::string& algo, bool fSet = true);
 
 // End Pow algorithm to use
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -33,8 +33,23 @@ enum {
     MINE_SHA256D = 2
 };
 
+static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool block=true) {
+    if (block) {
+        if (fProofOfStake) return "PoS";
+        if (!nPoWType) return "X16RT";
+        if (nPoWType & CBlockHeader::SHA256D_BLOCK) return "Sha256d";
+        if (nPoWType & CBlockHeader::RANDOMX_BLOCK) return "RandomX";
+        if (nPoWType & CBlockHeader::PROGPOW_BLOCK) return "ProgPow";
+    } else {
+        if (MINE_RANDOMX == nPoWType) return RANDOMX_STRING;
+        if (MINE_PROGPOW == nPoWType) return PROGPOW_STRING;
+        if (MINE_SHA256D == nPoWType) return SHA256D_STRING;
+    }
+    return "Unknown";
+}
+
 int GetMiningAlgorithm();
-void SetMiningAlgorithm(const std::string& algo);
+bool SetMiningAlgorithm(const std::string& algo);
 
 // End Pow algorithm to use
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -21,15 +21,6 @@
 #include <validation.h>
 #include <chainparams.h>
 
-std::string GetType(int nPoWType, bool fProofOfStake) {
-    if (fProofOfStake) return "PoS";
-    if (!nPoWType) return "X16RT";
-    if (nPoWType & CBlockHeader::SHA256D_BLOCK) return "Sha256d";
-    if (nPoWType & CBlockHeader::RANDOMX_BLOCK) return "RandomX";
-    if (nPoWType & CBlockHeader::PROGPOW_BLOCK) return "ProgPow";
-    return "Unknown";
-}
-
 // TODO, build an class object that holds this data
 // Used by CPU miner for randomx
 CCriticalSection cs_randomx_mining;
@@ -341,7 +332,7 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         LogPrint(BCLog::BLOCKCREATION,
                  "%s: Blocks Measured=%d, PoS Blocks=%d, ActualPoWBlocks=%d, ExpectedPoWBlocks=%d, nPosSpacing=%d Overdue=%d (%s)\n",
                  __func__, nBlocksMeasured, nCountBlocks, nBlocksPoW, nBlocksIntended,
-                 nPosSpacing, nOverdueTime, GetType(nPoWType, fProofOfStake).c_str());
+                 nPosSpacing, nOverdueTime, GetMiningType(nPoWType, fProofOfStake).c_str());
     } else {
         // In the case of fProofOfStake, the actual timespan already runs to the tip, so
         // we're not going to add in the time from last of the proof to tip.
@@ -352,7 +343,7 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
     }
 
     LogPrint(BCLog::BLOCKCREATION, "%s: nActualTimespan=%d, nTargetTimespan=%d Overdue=%d (%s)\n", __func__,
-             nActualTimespan, nTargetTimespan, nOverdueTime, GetType(nPoWType, fProofOfStake).c_str());
+             nActualTimespan, nTargetTimespan, nOverdueTime, GetMiningType(nPoWType, fProofOfStake).c_str());
     // ***
     // Make sure we don't overadjust
 
@@ -360,20 +351,20 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         // if we're ahead and adjusting, we might already be where we need
         // to be.  Don't make it more difficult if we're already overdue.
         LogPrint(BCLog::BLOCKCREATION, "%s: %s is ahead but now overdue, don't adjust anymore.\n",
-                 __func__, GetType(nPoWType, fProofOfStake).c_str());
+                 __func__, GetMiningType(nPoWType, fProofOfStake).c_str());
         return bnNew.GetCompact();
     }
 
     if ((nActualTimespan > nTargetTimespan) && (nOverdueTime <= 0)) {
         // if we're behind, and we're not overdue, we might be where we need to be
         LogPrint(BCLog::BLOCKCREATION, "%s: %s is behind but moving don't adjust anymore.\n",
-            __func__, GetType(nPoWType, fProofOfStake).c_str());
+            __func__, GetMiningType(nPoWType, fProofOfStake).c_str());
         return bnNew.GetCompact();
     }
     // ***
 
     LogPrint(BCLog::BLOCKCREATION, "%s: Adjusting %s: old target: %s\n",
-             __func__, GetType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
+             __func__, GetMiningType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
 
     arith_uint256 bnOld(bnNew); // Save the old target
 
@@ -389,12 +380,12 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         // If we should be reducing the difficulty, and the target has gone down, we've overflowed.
         LogPrint(BCLog::BLOCKCREATION, "%s: Multiplier %.4f for %s overflowed.  Setting Min Difficulty.\n",
                  __func__, (double) ((double)nActualTimespan / (double)nTargetTimespan),
-                 GetType(nPoWType, fProofOfStake).c_str());
+                 GetMiningType(nPoWType, fProofOfStake).c_str());
         bnNew = bnPowLimit;
     }
 
     LogPrint(BCLog::BLOCKCREATION, "%s: Adjusting %s: new target: %s\n",
-             __func__, GetType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
+             __func__, GetMiningType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
     return bnNew.GetCompact();
 }
 

--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -720,6 +720,15 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    // Check for mine algo to be valid
+    std::string sAlgo = gArgs.GetArg("-mine", RANDOMX_STRING);
+    if (!SetMiningAlgorithm(sAlgo))
+    {
+        error = "invalid mining algorithm: " + sAlgo;
+        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
+            QObject::tr("Error parsing command line arguments: %1.").arg(QString::fromStdString(error)));
+        return EXIT_FAILURE;
+    }
     // Check for miningaddress (has to be after we setup the parameters
     std::string sAddress = gArgs.GetArg("-miningaddress", "");
     if (!sAddress.empty()) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2146,7 +2146,6 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
 
     if (blockTime >= Params().PowUpdateTimestamp()) {
         nVersion = VERSIONBITS_NEW_POW_VERSION;
-        SetMiningAlgorithm(gArgs.GetArg("-mine", RANDOMX_STRING));
 
         if (fProofOfWork) {
             if (GetMiningAlgorithm() == MINE_PROGPOW) {

--- a/src/veild.cpp
+++ b/src/veild.cpp
@@ -14,6 +14,7 @@
 #include <fs.h>
 #include <rpc/server.h>
 #include <init.h>
+#include <miner.h>
 #include <noui.h>
 #include <shutdown.h>
 #include <util.h>
@@ -134,6 +135,12 @@ static bool AppInit(int argc, char* argv[])
         if (!AppInitSanityChecks())
         {
             // InitError will have been called with detailed error, which ends up on console
+            return false;
+        }
+        std::string sAlgo = gArgs.GetArg("-mine", RANDOMX_STRING);
+        if (!SetMiningAlgorithm(sAlgo))
+        {
+            fprintf(stderr, "Error: Invalid mining algorithm: %s\n", sAlgo.c_str());
             return false;
         }
         std::string sAddress = gArgs.GetArg("-miningaddress", "");


### PR DESCRIPTION
[Problem]
#340 - `getnetworkhashps` seems to be unrelated to actual network hash
#32 - `getmininginfo` has vastly changing difficulties

[Root Cause]
As greatly discussed in #340, the `getnetworkhashps` never accurately reflected PoW vs. PoS; as if one of the blocks was a PoS block, and one was a PoW block, the average calculated would vary wildly.    Likewise, `getmininginfo` would only report on the last block, which gets even crazier with 4 different block types.

[Solution]
First was a need to get your current mining algorithm; this is a separate commit.  The original code was getting the mining algorithm only when generation was started; so the startup flag sat unused until that time.  This also had the side effect of not realizing you would be mining randomX, until you started mining, due to a typo in the `-mine` flag [e.g. sha256 instead of sha256d.  By changing the code to read the flag on startup, it opened the ability to sanity check it on startup; so users using an incorrect flag will now be told so.  This also opens the ability to switch mining algorithms without stopping the daemon [although that's for a future PR, as care is needed to make sure you're told to stop mining before switching algorithms].

```
% veild -mine=sha256
Error: Invalid mining algorithm: sha256
```

With that out of the way, `getnetworkhashps` was expanded to still function as would be expected, but instead of just randomly using whatever blocks it found; it now focuses on only the blocks related to the currently set algorithm.  e.g. if you want the average network hashes per second over the last 120 blocks [the default] it will be between the last 120 blocks of the specific algorithm you're configured for.  An algorithm parameter was added so that you can specify a different algorithm if you chose, including the historical xr16t, or if you care about PoS.  Note that this is actually calculating the change in difficulty over time, and not hashes.  That research was also out of scope for this PR, and if the logic needs to change it will be a separate PR.

The output to `getnetworkhashps` is also included in `getmininginfo`, which in testing revealed that `getmininginfo` displays the difficulty for the last block; and not the difficulty for the algorithm that you're actually mining.  So that logic was changed to report the difficulty for whatever algorithm you're set to mine.  An 'algorithm' field was also added to the output so it can be clear what algorithm the difficulty relates to:

```
$ veil-cli getmininginfo
{
  "blocks": 988984,
  "currentblockweight": 0,
  "currentblocktx": 0,
  "algorithm": "progpow",
  "difficulty": 174.107098381071,
  "networkhashps": 22.83160812508121,
  "pooledtx": 2,
  "chain": "main"
}
```

```
$ veil-cli getmininginfo
{
  "blocks": 988986,
  "currentblockweight": 0,
  "currentblocktx": 0,
  "algorithm": "sha256d",
  "difficulty": 19.31658925581963,
  "networkhashps": 23.3181708549265,
  "pooledtx": 1,
  "chain": "main"
}
```

Given the availability of all the difficulties with the `getblockchaininfo` command, a parameter to get mining info for a different algorithm was not added.