### PR TITLE
[RPC][Mining] Add ability to switch between mining algorithms without restarting wallet

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1252,17 +1252,17 @@ int GetMiningAlgorithm() {
     return nMiningAlgorithm;
 }
 
-bool SetMiningAlgorithm(const std::string& algo) {
-    if (algo == PROGPOW_STRING) {
-        nMiningAlgorithm = MINE_PROGPOW;
-        return true;
-    } else if (algo == SHA256D_STRING) {
-        nMiningAlgorithm = MINE_SHA256D;
-        return true;
-    } else if (algo == RANDOMX_STRING) {
-        // Catches the default
-        nMiningAlgorithm = MINE_RANDOMX;
+bool SetMiningAlgorithm(const std::string& algo, bool fSet) {
+    int setAlgo = -1;
+
+    if (algo == PROGPOW_STRING)      setAlgo = MINE_PROGPOW;
+    else if (algo == SHA256D_STRING) setAlgo = MINE_SHA256D;
+    else if (algo == RANDOMX_STRING) setAlgo = MINE_RANDOMX;
+
+    if (setAlgo != -1) {
+        if (fSet) nMiningAlgorithm = setAlgo;
         return true;
     }
+
     return false;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1211,8 +1211,6 @@ void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScri
     }
     fGenerateBitcoins = fGenerate;
 
-    SetMiningAlgorithm(gArgs.GetArg("-mine", RANDOMX_STRING));
-
     if (nThreads < 0) {
         // In regtest threads defaults to 1
         nThreads = 1;
@@ -1254,12 +1252,17 @@ int GetMiningAlgorithm() {
     return nMiningAlgorithm;
 }
 
-void SetMiningAlgorithm(const std::string& algo) {
+bool SetMiningAlgorithm(const std::string& algo) {
     if (algo == PROGPOW_STRING) {
         nMiningAlgorithm = MINE_PROGPOW;
+        return true;
     } else if (algo == SHA256D_STRING) {
         nMiningAlgorithm = MINE_SHA256D;
-    } else {
+        return true;
+    } else if (algo == RANDOMX_STRING) {
+        // Catches the default
         nMiningAlgorithm = MINE_RANDOMX;
+        return true;
     }
+    return false;
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -241,6 +241,9 @@ private:
     int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 };
 
+bool GenerateActive();
+void setGenerate(bool fGenerate);
+
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlock* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);

--- a/src/miner.h
+++ b/src/miner.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -49,7 +50,7 @@ static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool 
 }
 
 int GetMiningAlgorithm();
-bool SetMiningAlgorithm(const std::string& algo);
+bool SetMiningAlgorithm(const std::string& algo, bool fSet = true);
 
 // End Pow algorithm to use
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -33,8 +33,23 @@ enum {
     MINE_SHA256D = 2
 };
 
+static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool block=true) {
+    if (block) {
+        if (fProofOfStake) return "PoS";
+        if (!nPoWType) return "X16RT";
+        if (nPoWType & CBlockHeader::SHA256D_BLOCK) return "Sha256d";
+        if (nPoWType & CBlockHeader::RANDOMX_BLOCK) return "RandomX";
+        if (nPoWType & CBlockHeader::PROGPOW_BLOCK) return "ProgPow";
+    } else {
+        if (MINE_RANDOMX == nPoWType) return RANDOMX_STRING;
+        if (MINE_PROGPOW == nPoWType) return PROGPOW_STRING;
+        if (MINE_SHA256D == nPoWType) return SHA256D_STRING;
+    }
+    return "Unknown";
+}
+
 int GetMiningAlgorithm();
-void SetMiningAlgorithm(const std::string& algo);
+bool SetMiningAlgorithm(const std::string& algo);
 
 // End Pow algorithm to use
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -21,15 +21,6 @@
 #include <validation.h>
 #include <chainparams.h>
 
-std::string GetType(int nPoWType, bool fProofOfStake) {
-    if (fProofOfStake) return "PoS";
-    if (!nPoWType) return "X16RT";
-    if (nPoWType & CBlockHeader::SHA256D_BLOCK) return "Sha256d";
-    if (nPoWType & CBlockHeader::RANDOMX_BLOCK) return "RandomX";
-    if (nPoWType & CBlockHeader::PROGPOW_BLOCK) return "ProgPow";
-    return "Unknown";
-}
-
 // TODO, build an class object that holds this data
 // Used by CPU miner for randomx
 CCriticalSection cs_randomx_mining;
@@ -341,7 +332,7 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         LogPrint(BCLog::BLOCKCREATION,
                  "%s: Blocks Measured=%d, PoS Blocks=%d, ActualPoWBlocks=%d, ExpectedPoWBlocks=%d, nPosSpacing=%d Overdue=%d (%s)\n",
                  __func__, nBlocksMeasured, nCountBlocks, nBlocksPoW, nBlocksIntended,
-                 nPosSpacing, nOverdueTime, GetType(nPoWType, fProofOfStake).c_str());
+                 nPosSpacing, nOverdueTime, GetMiningType(nPoWType, fProofOfStake).c_str());
     } else {
         // In the case of fProofOfStake, the actual timespan already runs to the tip, so
         // we're not going to add in the time from last of the proof to tip.
@@ -352,7 +343,7 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
     }
 
     LogPrint(BCLog::BLOCKCREATION, "%s: nActualTimespan=%d, nTargetTimespan=%d Overdue=%d (%s)\n", __func__,
-             nActualTimespan, nTargetTimespan, nOverdueTime, GetType(nPoWType, fProofOfStake).c_str());
+             nActualTimespan, nTargetTimespan, nOverdueTime, GetMiningType(nPoWType, fProofOfStake).c_str());
     // ***
     // Make sure we don't overadjust
 
@@ -360,20 +351,20 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         // if we're ahead and adjusting, we might already be where we need
         // to be.  Don't make it more difficult if we're already overdue.
         LogPrint(BCLog::BLOCKCREATION, "%s: %s is ahead but now overdue, don't adjust anymore.\n",
-                 __func__, GetType(nPoWType, fProofOfStake).c_str());
+                 __func__, GetMiningType(nPoWType, fProofOfStake).c_str());
         return bnNew.GetCompact();
     }
 
     if ((nActualTimespan > nTargetTimespan) && (nOverdueTime <= 0)) {
         // if we're behind, and we're not overdue, we might be where we need to be
         LogPrint(BCLog::BLOCKCREATION, "%s: %s is behind but moving don't adjust anymore.\n",
-            __func__, GetType(nPoWType, fProofOfStake).c_str());
+            __func__, GetMiningType(nPoWType, fProofOfStake).c_str());
         return bnNew.GetCompact();
     }
     // ***
 
     LogPrint(BCLog::BLOCKCREATION, "%s: Adjusting %s: old target: %s\n",
-             __func__, GetType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
+             __func__, GetMiningType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
 
     arith_uint256 bnOld(bnNew); // Save the old target
 
@@ -389,12 +380,12 @@ unsigned int DarkGravityWave(const CBlockIndex* pindexLast, const Consensus::Par
         // If we should be reducing the difficulty, and the target has gone down, we've overflowed.
         LogPrint(BCLog::BLOCKCREATION, "%s: Multiplier %.4f for %s overflowed.  Setting Min Difficulty.\n",
                  __func__, (double) ((double)nActualTimespan / (double)nTargetTimespan),
-                 GetType(nPoWType, fProofOfStake).c_str());
+                 GetMiningType(nPoWType, fProofOfStake).c_str());
         bnNew = bnPowLimit;
     }
 
     LogPrint(BCLog::BLOCKCREATION, "%s: Adjusting %s: new target: %s\n",
-             __func__, GetType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
+             __func__, GetMiningType(nPoWType, fProofOfStake).c_str(), bnNew.GetHex());
     return bnNew.GetCompact();
 }
 

--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -720,6 +720,15 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    // Check for mine algo to be valid
+    std::string sAlgo = gArgs.GetArg("-mine", RANDOMX_STRING);
+    if (!SetMiningAlgorithm(sAlgo))
+    {
+        error = "invalid mining algorithm: " + sAlgo;
+        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
+            QObject::tr("Error parsing command line arguments: %1.").arg(QString::fromStdString(error)));
+        return EXIT_FAILURE;
+    }
     // Check for miningaddress (has to be after we setup the parameters
     std::string sAddress = gArgs.GetArg("-miningaddress", "");
     if (!sAddress.empty()) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2146,7 +2146,6 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
 
     if (blockTime >= Params().PowUpdateTimestamp()) {
         nVersion = VERSIONBITS_NEW_POW_VERSION;
-        SetMiningAlgorithm(gArgs.GetArg("-mine", RANDOMX_STRING));
 
         if (fProofOfWork) {
             if (GetMiningAlgorithm() == MINE_PROGPOW) {

--- a/src/veild.cpp
+++ b/src/veild.cpp
@@ -14,6 +14,7 @@
 #include <fs.h>
 #include <rpc/server.h>
 #include <init.h>
+#include <miner.h>
 #include <noui.h>
 #include <shutdown.h>
 #include <util.h>
@@ -134,6 +135,12 @@ static bool AppInit(int argc, char* argv[])
         if (!AppInitSanityChecks())
         {
             // InitError will have been called with detailed error, which ends up on console
+            return false;
+        }
+        std::string sAlgo = gArgs.GetArg("-mine", RANDOMX_STRING);
+        if (!SetMiningAlgorithm(sAlgo))
+        {
+            fprintf(stderr, "Error: Invalid mining algorithm: %s\n", sAlgo.c_str());
             return false;
         }
         std::string sAddress = gArgs.GetArg("-miningaddress", "");


### PR DESCRIPTION
### Note
This is built on top of #876 and also contains a couple corrections to get the `getnetworkhashps` help.

### Problem
In order to switch mining algorithms, you must shut down the wallet and restart with a new `-mine=` flag.

### Root Cause
Never implemented

### Solution
Add `setminingalgo` cli command to allow you to switch between different algorithms.  This RPC command requires you to turn off mining before issuing the command and will error if it does not work. 

### Testing
```
$ veil-cli help setminingalgo
setminingalgo algorithm

Changes your mining algorithm to [algorithm].  Note that mining must be turned off when command is used.

Arguments:
1. algorithm   (string, required) Algorithm to mine [progpow, randomx, sha256d].

Result:
{
  "success": true|false, (boolean) Status of the switch
  "message": "text",     (text) Informational message about the switch
}

Examples:
> veil-cli setminingalgo sha256d
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "setminingalgo", "params": [sha256d] }' -H 'content-type: text/plain;' http://127.0.0.1:58812/
```
```
$ veil-cli setminingalgo randomx
{
  "success": true,
  "message": "Mining algorithm changed from sha256d to randomx"
}
 veil-cli getmininginfo
{
[...]
  "algorithm": "randomx",
  "difficulty": 0.003707938785486674,
  "networkhashps": 22.73835278085342,
[...]
}
```
```
$ veil-cli setminingalgo sha257d
error code: -8
error message:
sha257d is not a supported mining type
$ veil-cli setminingalgo sha256d
{
  "success": true,
  "message": "Mining algorithm changed from randomx to sha256d"
}
$ veil-cli getmininginfo
{
[...]
  "algorithm": "sha256d",
  "difficulty": 18.1774015474177,
  "networkhashps": 23.05669884097939,
[...]
}
```
```
$ veil-cli generatecontinuous true 1
$ veil-cli setminingalgo progpow
error code: -8
error message:
mining must be stopped to change algorithm
$ veil-cli generatecontinuous false
$ veil-cli setminingalgo progpow
{
  "success": true,
  "message": "Mining algorithm changed from sha256d to progpow"
}
$ veil-cli getmininginfo
{
[...]
  "algorithm": "progpow",
  "difficulty": 164.7481194885794,
  "networkhashps": 23.16038554216868,
[...]
}
```
