### PR TITLE
[GUI] Update Staking Slider to be reflective of status

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -988,6 +988,8 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
         tooltip += tr("Transactions after this will not yet be visible.");
     }
 
+    veilStatusBar->updateStakingCheckbox();
+
     // Don't word-wrap this (fixed-width) tooltip
     tooltip = QString("<nobr>") + tooltip + QString("</nobr>");
 

--- a/src/qt/veil/veilstatusbar.h
+++ b/src/qt/veil/veilstatusbar.h
@@ -52,8 +52,13 @@ private:
     WalletModel *walletModel = nullptr;
     ClientModel *clientModel = nullptr;
     UnlockPasswordDialog *unlockPasswordDialog = nullptr;
+#ifdef ENABLE_WALLET
+    void setStakingText();
+#endif
 
     bool preparingFlag = false;
+    bool syncFlag = true;
+    static const int64_t ACTIVE_STAKING_MAX_TIME = 70;
 };
 
 #endif // VEILSTATUSBAR_H

--- a/src/veil/mnemonic/mnemonicwalletinit.cpp
+++ b/src/veil/mnemonic/mnemonicwalletinit.cpp
@@ -73,7 +73,7 @@ bool MnemonicWalletInit::Open() const
             return false;
         }
 
-        if (gArgs.GetBoolArg("-exchangesandservicesmode", false))
+        if (gArgs.GetBoolArg("-exchangesandservicesmode", false) || !gArgs.GetBoolArg("-staking",true))
             pwallet->SetStakingEnabled(false);
 
         AddWallet(pwallet);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3388,6 +3388,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"hdseedid\": \"<hash160>\"            (string, optional) the Hash160 of the HD seed (only present when HD is enabled)\n"
             "  \"hdmasterkeyid\": \"<hash160>\"       (string, optional) alias for hdseedid retained for backwards-compatibility. Will be removed in V0.18.\n"
             "  \"private_keys_enabled\": true|false (boolean) false if privatekeys are disabled for this wallet (enforced watch-only wallet)\n"
+	    "  \"staking_enabled\" : true|false     (boolean) true if staking is enabled\n"
             "  \"staking_active\": true|false       (boolean) true if wallet is actively trying to create new blocks using proof of stake\n"
             "}\n"
             "\nExamples:\n"
@@ -3425,6 +3426,8 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
         obj.pushKV("hdmasterkeyid", seed_id.GetHex());
     }
     obj.pushKV("private_keys_enabled", !pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
+
+    obj.pushKV("staking_enabled", pwallet->IsStakingEnabled());
 
     // Determine if staking is recently active. Note that this is not immediate effect. Staking could be disabled and it could take up to 70 seconds to update state.
     int64_t nTimeLastHashing = 0;


### PR DESCRIPTION
### Problem
The staking slider does not always indicate the present state of staking.  There is a delay between when staking is enabled/disabled and when the actual enabling/disabling takes place.

### Root Cause
The Qt indicates the state that the wallet is in.  Some amount of time is required to ensure that the state change has taken affect.  Additionally, staking is not performed while syncing.  When the user initially opens the user interface, staking is displayed as active while syncing.  Staking is initially active but will not be performed until syncing is complete.

### Solution
* Text for the staking slider now shows the current state of actual staking (enabled, disable, disabled for sync, enabling ..., disabling...).
* The staking slider is disabled (cannot be changed) until syncing is complete.
* Once synchronization is complete, the staking slider will be changed to enabled with the state of "Enabling ...).  When finishing synchronization testing showed some thrashing between the states of "Enabling..." and "Staking Enabled" until a few blocks have gone by.  This is due to the way active staking is calculated.
* RPC getwalletinfo updated to show the actual state of staking and the wallet status
* Popup entering into staking disabled has been updated to indicate that some time is required prior to the state change taking effect.

### Issues Addressed
245: https://github.com/Veil-Project/veil/issues/245
504: https://github.com/Veil-Project/veil/issues/504

### Bounty Payment Address
sv1qqphsvuwhk29xcn2q9gdth9x73qpm8kcktmuxyd8szl50sgt2nt47egpqwnxr83hfj7s6fnec2jr0cv5yc7r6s7nvxhd9969qrgy4cgnznwewqqqauut5m