### PR TITLE
[RPC][Mining] Extract last Hashspeed calculation

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -49,6 +49,8 @@ static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool 
     return "Unknown";
 }
 
+double GetHashSpeed();
+void ClearHashSpeed();
 int GetMiningAlgorithm();
 bool SetMiningAlgorithm(const std::string& algo, bool fSet = true);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -349,6 +349,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
             "  \"algorithm\": \"xxxx\",        (string) Algorithm set to mine (progpow, randomx, sha256d)\n"
             "  \"difficulty\": xxx.xxxxx    (numeric) The current difficulty\n"
             "  \"networkhashps\": nnn,      (numeric) The network hashes per second\n"
+            "  \"hashspeed\": nnn,          (numeric) The system hashes per second\n"
             "  \"pooledtx\": n              (numeric) The size of the mempool\n"
             "  \"chain\": \"xxxx\",           (string) current network name as defined in BIP70 (main, test, regtest)\n"
             "  \"warnings\": \"...\"          (string) any network and blockchain warnings\n"
@@ -379,6 +380,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
     obj.pushKV("algorithm",        sMiningAlgo);
     obj.pushKV("difficulty",       (double)nDiff);
     obj.pushKV("networkhashps",    getnetworkhashps(request));
+    obj.pushKV("hashspeed",        GetHashSpeed());
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain",            Params().NetworkIDString());
     obj.pushKV("warnings",         GetWarnings("statusbar"));
@@ -390,7 +392,7 @@ static UniValue setminingalgo(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "setminingalgo algorithm\n"
-            "\nChanges your mining algorithm to [algorithm].  Note that mining must be turned off when command is used.\n"
+            "\nChanges your mining algorithm to [algorithm].  Note that mining must be turned off when command is used.  This will also have the side effect of clearing your mining statistics.\n"
             "\nArguments:\n"
             "1. algorithm   (string, required) Algorithm to mine [progpow, randomx, sha256d].\n"
             "\nResult:\n"
@@ -412,6 +414,7 @@ static UniValue setminingalgo(const JSONRPCRequest& request)
     if (!SetMiningAlgorithm(sNewAlgo)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s is not a supported mining type", sNewAlgo));
     }
+    ClearHashSpeed();
     UniValue result(UniValue::VOBJ);
     result.pushKV("success", true);
     result.pushKV("message", strprintf("Mining algorithm changed from %s to %s", sOldAlgo, sNewAlgo));


### PR DESCRIPTION
### Problem
Users want to be able to see their current hashing speed

### Solution
Extract the last calculated hashspeed and provide it in `getmininginfo`.  To note, this only pulls the last calculation that was done, and is not a real-time pull.  It will be the average from the start of mining to the last calculation, from the time the first `generatecontinuous true` was run.  In other words, this will take into account any 'breaks' taken in mining.  e.g. if you have a script that turns off mining for a certain time; the hash speed calculations are still being run; and the break will be calculated into your overall hash rate.

Logic was added to `setminingalgo` to reset the statistical counters.  So after `setminingalgo` is issued, the statistics will restart on the next `generatecontinuous`.  This can be used to reset your counters even if you're not changing algorithms by setting your mining algo to the same algo:

```
$ ./veil-cli -regtest getmininginfo
{
[...]
  "hashspeed": 743034,
[...]
}
$ ./veil-cli -regtest setminingalgo sha256d
{
  "success": true,
  "message": "Mining algorithm changed from sha256d to sha256d"
}
$ ./veil-cli -regtest getmininginfo
{
[...]
  "hashspeed": 0,
}
```

Note that for simplicity sake, the calculation is "hashes per second", so that it can remain a numerical value and users can wrap the use however they wish if they want to convert it to kh/s or mh/s [or whatever they desire]