### PR TITLE
[GUI] Update QR Code on address selection

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -37,6 +37,7 @@
 #include <chainparams.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <key_io.h>
 #include <ui_interface.h>
 #include <util.h>
 
@@ -260,6 +261,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     modalOverlay = new ModalOverlay(this->centralWidget(), this);
 #ifdef ENABLE_WALLET
     if(enableWallet) {
+        connect(walletFrame, SIGNAL(changeSelectedRcvAddress(CTxDestination*)), this, SLOT(updatedSelectedRcvAddress(CTxDestination*)));
         connect(walletFrame, SIGNAL(requestedSyncWarningInfo()), this, SLOT(showModalOverlay()));
         connect(labelBlocksIcon, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
         connect(progressBar, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
@@ -1515,6 +1517,13 @@ void BitcoinGUI::toggleNetworkActive()
 {
     m_node.setNetworkActive(!m_node.getNetworkActive());
 }
+
+#ifdef ENABLE_WALLET
+void BitcoinGUI::updatedSelectedRcvAddress(CTxDestination* selectedRcvAddress) {
+    balance->setDisplayRcvAddress(selectedRcvAddress);
+    balance->refreshWalletStatus();
+}
+#endif 
 
 UnitDisplayStatusBarControl::UnitDisplayStatusBarControl(const PlatformStyle *platformStyle) :
     optionsModel(0),

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <amount.h>
+#include <script/standard.h>
 
 #include <QLabel>
 #include <QMainWindow>
@@ -235,6 +236,8 @@ public Q_SLOTS:
        @param[in] ret       pointer to a bool that will be modified to whether Ok was clicked (modal only)
     */
     void message(const QString &title, const QString &message, unsigned int style, bool *ret = nullptr);
+
+    void updatedSelectedRcvAddress(CTxDestination* selectedRcvAddress);
 
 #ifdef ENABLE_WALLET
     void initWalletMenu(std::string& mnemonic, unsigned int& flag, bool& ret);

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -30,6 +30,8 @@
 
 #include <iostream>
 
+#include <key_io.h>
+
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 5
 
@@ -222,6 +224,7 @@ AddressesWidget::AddressesWidget(const PlatformStyle *platformStyle, WalletView 
     ui->lblSplit->setVisible(false);
     //connect(ui->btnMiningAddress,SIGNAL(clicked()),this,SLOT(onNewMinerAddressClicked()));
     //connect(ui->btnMiningAddress2,SIGNAL(clicked()),this,SLOT(onNewMinerAddressClicked()));
+
 }
 
 void AddressesWidget::setWalletModel(WalletModel *model)
@@ -240,6 +243,11 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
         listView = ui->listAddresses;
         type = AddressTableModel::Receive;
         updatedIndex = proxyModel->mapToSource(index);
+        auto address = this->model->index(updatedIndex.row(), AddressTableModel::Address, updatedIndex);
+        QString addressStr = this->model->data(address, Qt::DisplayRole).toString();
+        CTxDestination selectedAddress = DecodeDestination(addressStr.toStdString());
+
+        Q_EMIT rcvAddressSelected(&selectedAddress);
     }else{
         listView = ui->listContacts;
         type = AddressTableModel::Send;
@@ -371,6 +379,7 @@ void AddressesWidget::onNewAddressClicked(){
         openToastDialog(QString::fromStdString(toast + " Creation Failed"), mainWindow->getGUI());
     }
     // if it's the first one created, display it without having to reload
+// WE NEED TO DISPLAY THE NEW ADDRESS HERE AND IN THE BALANCE AND RECEIVE WIDGETS
     onForeground();
 }
 

--- a/src/qt/veil/addresseswidget.h
+++ b/src/qt/veil/addresseswidget.h
@@ -50,6 +50,9 @@ public:
 
     void refreshWalletStatus();
 
+Q_SIGNALS:
+    void rcvAddressSelected(CTxDestination *address);
+
 private Q_SLOTS:
     void onMyAddressClicked();
     void onContactsClicked();

--- a/src/qt/veil/balance.h
+++ b/src/qt/veil/balance.h
@@ -34,6 +34,7 @@ public:
     void setWalletModel(WalletModel *walletModel);
     void refreshWalletStatus();
     bool eventFilter(QObject *obj, QEvent *event);
+    void setDisplayRcvAddress(CTxDestination *displayAddress);
 
 public Q_SLOTS:
     void setBalance(const interfaces::WalletBalances& balances);
@@ -58,6 +59,9 @@ private:
     TooltipBalance *tooltip = nullptr;
 
     void onBtnBalanceClicked(int type);
+
+    bool displayAddressSet = false;
+    CTxDestination currentDisplayAddress;
 };
 
 #endif // BALANCE_H

--- a/src/qt/veil/forms/balance.ui
+++ b/src/qt/veil/forms/balance.ui
@@ -414,6 +414,39 @@ color:#707070;</string>
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QLabel" name="labelAddressName">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: transparent;
+padding-left:5px;
+padding-right:5px;
+padding-bottom:3px;
+font-size:11px;
+color:#707070;</string>
+              </property>
+              <property name="midLineWidth">
+               <number>0</number>
+              </property>
+              <property name="text">
+               <string>N/A</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+              <property name="margin">
+               <number>0</number>
+              </property>
+              <property name="indent">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>

--- a/src/qt/veil/forms/receivewidget.ui
+++ b/src/qt/veil/forms/receivewidget.ui
@@ -210,7 +210,7 @@ QR code to send you veil</string>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,1">
+             <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,1,0,1">
               <property name="spacing">
                <number>20</number>
               </property>
@@ -221,8 +221,8 @@ QR code to send you veil</string>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>40</width>
-                  <height>20</height>
+                  <width>30</width>
+                  <height>21</height>
                  </size>
                 </property>
                </spacer>
@@ -246,6 +246,22 @@ QR code to send you veil</string>
                 </property>
                 <property name="text">
                  <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelAddressName">
+                <property name="maximumSize">
+                 <size>
+                  <width>300</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">color:#707070;</string>
+                </property>
+                <property name="text">
+                 <string>N/A</string>
                 </property>
                </widget>
               </item>

--- a/src/qt/veil/receivewidget.h
+++ b/src/qt/veil/receivewidget.h
@@ -27,7 +27,7 @@ public:
     virtual void showEvent(QShowEvent *event) override;
     virtual void hideEvent(QHideEvent *event) override;
     void setWalletModel(WalletModel *model);
-
+    void setDisplayRcvAddress(CTxDestination *displayAddress);
 
     void refreshWalletStatus();
 
@@ -45,6 +45,9 @@ private:
     QString qAddress;
 
     bool generateNewAddress(bool isOnDemand = false);
+
+    bool displayAddressSet = false;
+    CTxDestination currentDisplayAddress;
 };
 
 #endif // RECEIVEWIDGET_H

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -76,6 +76,8 @@ bool WalletFrame::addWallet(WalletModel *walletModel)
 
     connect(walletView, SIGNAL(outOfSyncWarningClicked()), this, SLOT(outOfSyncWarningClicked()));
 
+    connect(walletView, SIGNAL(signalChangeSelectedAddress(CTxDestination*)), this, SLOT(notifySelectedRcvAddyChanged(CTxDestination*)));
+
     return true;
 }
 
@@ -98,6 +100,9 @@ bool WalletFrame::removeWallet(const QString &name)
 
     WalletView *walletView = mapWalletViews.take(name);
     walletStack->removeWidget(walletView);
+
+    disconnect(walletView, SIGNAL(signalChangeSelectedAddress(CTxDestination*)), this, SLOT(notifySelectedRcvAddyChanged(CTxDestination*)));
+
     delete walletView;
     return true;
 }
@@ -232,4 +237,9 @@ WalletView *WalletFrame::currentWalletView()
 void WalletFrame::outOfSyncWarningClicked()
 {
     Q_EMIT requestedSyncWarningInfo();
+}
+
+void WalletFrame::notifySelectedRcvAddyChanged(CTxDestination* selectedRcvAddress)
+{
+    Q_EMIT changeSelectedRcvAddress(selectedRcvAddress);
 }

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -50,6 +50,8 @@ Q_SIGNALS:
     /** Notify that the user has requested more information about the out-of-sync warning */
     void requestedSyncWarningInfo();
 
+    void changeSelectedRcvAddress(CTxDestination* newSelectedRcvAddress);
+
 private:
     QStackedWidget *windowStack;
     QStackedWidget *walletStack;
@@ -98,6 +100,9 @@ public Q_SLOTS:
     void usedReceivingAddresses();
     /** Pass on signal over requested out-of-sync-warning information */
     void outOfSyncWarningClicked();
+
+    /** Notify selection of Receive Address **/
+    void notifySelectedRcvAddyChanged(CTxDestination* selectedRcvAddress);
 };
 
 #endif // BITCOIN_QT_WALLETFRAME_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -90,10 +90,18 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     connect(sendCoinsPage, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
     // Pass through messages from transactionView
     connect(transactionView, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+
+    // Notification that a new receive Address has been selected
+    connect(addressesWidget, SIGNAL(rcvAddressSelected(CTxDestination*)), this, SLOT(updatedRcvAddySelection(CTxDestination*)));
 }
 
 WalletView::~WalletView()
 {
+}
+
+void WalletView::updatedRcvAddySelection(CTxDestination* selectedRcvAddress){
+    receiveWidget->setDisplayRcvAddress(selectedRcvAddress);
+    Q_EMIT signalChangeSelectedAddress(selectedRcvAddress);
 }
 
 void WalletView::setBitcoinGUI(BitcoinGUI *gui)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -144,6 +144,8 @@ public Q_SLOTS:
     /** User has requested more information about the out of sync state */
     void requestedSyncWarningInfo();
 
+    void updatedRcvAddySelection(CTxDestination* selectedRcvAddress);
+
 Q_SIGNALS:
     /** Signal that we want to show the main window */
     void showNormalIfMinimized();
@@ -157,6 +159,9 @@ Q_SIGNALS:
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName);
     /** Notify that the out of sync warning icon has been pressed */
     void outOfSyncWarningClicked();
+
+    /** Signal that the selected receive address has changed **/
+    void signalChangeSelectedAddress(CTxDestination* selectedRcvAddress);
 };
 
 #endif // BITCOIN_QT_WALLETVIEW_H


### PR DESCRIPTION
### Problem
Selection of an address on the Address Book page does not update the QR codes on the receive page or the left hand side.

### Root Cause
Selection of an address on the Address Book page is isolated to the address book.

### Solution
Notify the other displays to allow for updates based on the selection of an address.  The update includes displaying address, QR code, name (if any).

### Issues Addressed
250: https://github.com/Veil-Project/veil/issues/250
136: https://github.com/Veil-Project/veil/issues/136