### PR TITLE
Change default automint denom to 1000

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -36,7 +36,7 @@
 
 
 // Preferences.
-const int DEFAULT_AUTOMINT_DENOM = 10;
+const int DEFAULT_AUTOMINT_DENOM = 1000;
 
 // Application startup time (used for uptime calculation)
 int64_t GetStartupTime();


### PR DESCRIPTION
Changing the default automint denomination to 1000. 