### PR TITLE
[Wallet] updated to use GetBalance() instead of GetLegacyBalance()

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1535,7 +1535,7 @@ static UniValue sendmany(const JSONRPCRequest& request)
     EnsureWalletIsUnlocked(pwallet);
 
     // Check funds
-    if (totalAmount > pwallet->GetLegacyBalance(ISMINE_SPENDABLE, nMinDepth)) {
+    if (totalAmount > pwallet->GetBalance(ISMINE_SPENDABLE, nMinDepth)) {
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Wallet has insufficient funds");
     }
 


### PR DESCRIPTION
### Problem ###
sendmany is using GetLegacyBalance() to get the available balance. This method is excludes output that are input owned by the wallet.

### Solution ###
Change GetLegacyBalance to GetBalance. GetBalance includes transactions sent between addresses owned by the wallet (most likely change addresses) .

### Unit Testing Results ###
 ```
sendmany "" '{"tv1qkwzs0dvt5u0hc6puzjhd5mqa3sfygmghg2uuj0":0.01,"tv1qyeajk6ljxpls9x7crm2prv9wjud3uwcqy656wf":0.02}'
```


```{
  "amount": 0.00000000,
  "creditbase": 49.96995640,
  "debitbase": 50.00000000,
  "creditanon": 0.00000000,
  "debitanon": 0.00000000,
  "fee": -0.03004360,
  "confirmations": 1,
  "blockhash": "74e9061b1652529de0177283ed5b527b21e463b24925cd9d6728523995d2b8d0",
  "blockindex": 2,
  "blocktime": 1615519536,
  "txid": "abb2cebd87d1f0905863f528d9d4d734bdaa870c70ebfd65624f73986369e5d9",
  "walletconflicts": [
  ],
  "time": 1615519508,
  "timereceived": 1615519508,
  "computetime": 58,
  "bip125-replaceable": "no",
  "details": [
    {
      "address": "tv1qyeajk6ljxpls9x7crm2prv9wjud3uwcqy656wf",
      "category": "send",
      "amount": -0.02000000,
      "label": "exchange deposit 2",
      "vout": 0,
      "fee": -0.00004360,
      "abandoned": false
    },
    {
      "address": "tv1qkwzs0dvt5u0hc6puzjhd5mqa3sfygmghg2uuj0",
      "category": "send",
      "amount": -0.01000000,
      "label": "exchange deposit 1",
      "vout": 1,
      "fee": -0.00004360,
      "abandoned": false
    }
  ],
  "debug": {
    "vin": [
      {
        "from_me": true,
        "prevout_hash": "8b199065d834e69d44353659376bbaea0d3e04d0fd42dc7680b4a336ea0e54ec",
        "prevout_n": 0,
        "type": "basecoin"
      }
    ],
    "vout": [
      {
        "type": "basecoin",
        "sent_to": "tv1qyeajk6ljxpls9x7crm2prv9wjud3uwcqy656wf",
        "amount": "0.02",
        "is_mine": false,
        "has_tx_rec": false
      },
      {
        "type": "basecoin",
        "sent_to": "tv1qkwzs0dvt5u0hc6puzjhd5mqa3sfygmghg2uuj0",
        "amount": "0.01",
        "is_mine": false,
        "has_tx_rec": false
      },
      {
        "type": "basecoin",
        "sent_to": "tv1qmh5tz0fsg6u0xeqdgasygm5n5s30qah6k89cuq",
        "amount": "49.9699564",
        "is_mine": true,
        "has_tx_rec": false
      }
    ]
  },
  "hex": "0200005bd6070001ec540eea36a3b48076dc42fdd0043e0deaba6b37593635449de634d86590198b00000000484730440220092bc92afb23d0adf9bc6ccfce67e98908884c7ce99291452040c9e2acdf6a43022058772985e21e547911e492831d0cd89d7bb7a9cc376e0219d00342ae765d684601feffffff030180841e0000000000160014267b2b6bf2307f029bd81ed411b0ae971b1e3b000140420f0000000000160014b38507b58ba71f7c683c14aeda6c1d8c12446d1701381ad82901000000160014dde8b13d3046b8f3640d4760446e93a422f076fa"
}
```
