### PR TITLE
[GUI] Make total balance menu easier to display

### DIFF
--- a/src/qt/veil/balance.cpp
+++ b/src/qt/veil/balance.cpp
@@ -129,7 +129,7 @@ void Balance::onBtnBalanceClicked(int type){
             thirdBalance = balances.basecoin_balance;
             widget = ui->btnBalance;
             posy = 0;
-            posx = widget->pos().rx()+150;
+            posx = widget->pos().rx()+190;
            break;
         case 1:
             firstTitle = QString::fromStdString("Zerocoin");


### PR DESCRIPTION
### Problem
Clicking on the question mark icon for the Total Balance does not (consistently) result in the tooltip appearing.

### Root Cause
The tooltip is drawn too close to where the cursor is.  

### Solution
Move the origin of the tooltip to the right.  Note that the whole of the item (text and all) is the clickable to make the menu appear.  The issue only occurred when clicking the icon which was on the right end of the button.

### Issues Addressed
https://github.com/Veil-Project/veil/issues/897