### PR TITLE
[Wallet][RPC] Export basecoin transactions to CSV file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(src/crypto)
 include_directories(src/crypto/ctaes)
 include_directories(src/crypto/external)
 include_directories(src/crypto/x16r)
+include_directories(src/csv)
 include_directories(src/index)
 include_directories(src/interfaces)
 include_directories(src/leveldb/db)
@@ -181,6 +182,11 @@ add_executable(veil
         src/crypto/sha256_sse41.cpp
         src/crypto/sha512.cpp
         src/crypto/sha512.h
+        src/csv/CSVread.cpp
+        src/csv/CSVwrite.cpp
+        src/csv/libcsv.c.cpp
+        src/csv/strerror.cpp
+        src/csv/strerror.hpp
         src/index/base.cpp
         src/index/base.h
         src/index/txindex.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -115,6 +115,8 @@ BITCOIN_CORE_H = \
   consensus/tx_verify.h \
   core_io.h \
   core_memusage.h \
+  csv/csv.h \
+  csv/CSV.hpp \
   cuckoocache.h \
   fs.h \
   httprpc.h \
@@ -689,6 +691,11 @@ libbitcoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
+  csv/CSVread.cpp \
+  csv/CSVwrite.cpp \
+  csv/libcsv.c \
+  csv/strerror.cpp \
+  csv/strerror.hpp \
   fs.cpp \
   interfaces/handler.cpp \
   interfaces/node.cpp \
@@ -820,6 +827,7 @@ CLEANFILES += consensus/*.gcda consensus/*.gcno
 CLEANFILES += crypto/*.gcda crypto/*.gcno
 CLEANFILES += crypto/randomx/*.gcda crypto/randomx/*.gcno
 CLEANFILES += crypto/randomx/blake2/*.gcda crypto/randomx/blake2/*.gcno
+CLEANFILES += csv/*.gcda csv/*.gcno
 CLEANFILES += policy/*.gcda policy/*.gcno
 CLEANFILES += primitives/*.gcda primitives/*.gcno
 CLEANFILES += script/*.gcda script/*.gcno

--- a/src/csv/CSV.hpp
+++ b/src/csv/CSV.hpp
@@ -1,0 +1,729 @@
+/*
+Copyright (C) 2014 Jay Satiro <raysatiro@yahoo.com>
+All rights reserved.
+
+This file is part of CSV/jay::util.
+
+https://github.com/jay/CSV
+
+jay::util is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+jay::util is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with jay::util. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** Usage and design:
+
+Classes to read/write CSV records from/to a stream.
+
+If a bool in these classes is described as "set" without indicating true or false, it means true.
+
+
+class CSVread
+- A class to read comma separated values from a stream.
+
+class CSVwrite
+- A class to write comma separated values to a stream.
+
+
+These classes use libcsv --a powerful well written C library-- to parse the CSV records. Libcsv will
+parse binary CSV data. If you pass in a filename it is opened in binary mode unless you specify the
+flag 'text_mode'. Text mode does translations which may be undesirable for your data. If you pass in
+an existing istream the 'text_mode' flag is not used; you are responsible for making sure it's in
+the right mode for your data.
+
+Here is an example for CSVread:
+
+Car car;
+jay::util::CSVread csv( "filename" );
+if( csv.error ) { initialization failed, handle it }
+while( csv.ReadRecord() )
+{
+// assuming your field size is fixed at 4, check it first:
+if( csv.fields.size() != 4 ) {handle it. error, continue, etc}
+car.make = csv.fields[ 0 ];
+car.model = csv.fields[ 1 ];
+car.year = atoi( csv.fields[ 2 ] );
+car.description = csv.fields[ 3 ];
+Process(car);
+}
+
+For more examples refer to ..\Example\Example.sln
+*/
+
+#ifndef JAY_UTIL_CSV_HPP_
+#define JAY_UTIL_CSV_HPP_
+
+#include <stdint.h>
+
+#include <fstream>
+#include <list>
+#include <string>
+#include <vector>
+
+
+struct csv_parser;
+
+namespace jay {
+namespace util {
+
+
+
+class CSVread
+{
+public:
+    // flags for Open()/Associate()
+    enum Flags
+    {
+        none = 0,
+
+        /* Skip the UTF-8 BOM check.
+
+        'has_utf8_bom' will always be false if the check is skipped.
+
+        There is no UTF-8 processing done on the stream either way; the check is just to identify
+        and then ignore the BOM if present. You may pass this flag if you are certain your CSV
+        file/istream does not have a UTF-8 BOM.
+        */
+        skip_utf8_bom_check = 1 << 0,
+
+
+        /* Process empty records.
+
+        An empty record is a record that has nothing or only whitespace before its terminator. By
+        default empty records are ignored and not processed as records.
+
+        A record that consists of just a field separator --eg a comma `,`-- is *not* considered an
+        empty record by this parser, it is parsed as two empty fields.
+
+        Regarding its default behavior of ignoring empty records libcsv says:
+        "This behavior is meant to accommodate files using only either a linefeed or a carriage
+        return as a record separator to be parsed properly while at the same time being able to
+        parse files with rows terminated by multiple characters from resulting in blank rows after
+        each actual row of data (for example, processing a text CSV file created that was created on
+        a Windows machine on a Unix machine)."
+
+        I implemented the processing of empty records by ignoring carriage returns as a record
+        terminator in that case. If you are certain all records end in LF or CRLF but never just CR,
+        and you want to process empty records then you may pass this flag. An exception to the must
+        have LF or CRLF rule is the end record, since it's allowed to not have any terminator.
+
+        All empty records must be terminated to be processed. That means an end record cannot be
+        unterminated AND empty, which in that unique case means the stream ends in trailing
+        whitespace that is ignored regardless.
+
+        Keep in mind if using this flag that because each empty record is now considered a record
+        it will have its own record number; therefore the record number corresponding to each
+        record could be different depending on whether or not this flag is passed to Open().
+
+        Internally CSV_REPALL_NL is set for the csv parser when this flag is set.
+       */
+        process_empty_records = 1 << 1,
+
+
+        /* Strict mode.
+
+        By default libcsv's parser is forgiving and will parse a field even if it does not strictly
+        adhere to the most common CSV usage. More details can be found in libcsv's manual and
+        http://www.creativyst.com/Doc/Articles/CSV/CSV01.htm
+
+        You may pass this flag to error when parsing any format that's outside of common usage.
+
+        An end record missing a newline terminator is considered common usage unfortunately, and
+        strict mode will not error. To handle that condition eval 'end_record_not_terminated'.
+
+        Internally CSV_STRICT and CSV_STRICT_FINI are set for the csv parser when this flag is set.
+        */
+        strict_mode = 1 << 2,
+
+
+        /* Error on NULL byte in field.
+
+        If a field contains null bytes those bytes are considered part of the field by default. A
+        field is exposed as std::string, and it may be undesirable to allow NULL bytes in a string.
+        */
+        error_on_null_in_field = 1 << 3,
+
+
+        /* Open file in text mode instead of binary mode.
+
+        Libcsv handles files in binary mode and by default files are opened in binary mode by this
+        class. This should be fine for most purposes since libcsv autodetects CR,LF,CRLF as record
+        terminators. However if you have records with multiline data that is not binary then you
+        may prefer the translation. In that case you may associate an already existing istream that
+        has that translation enabled or pass in this flag with your file.
+
+        An error will occur if you use this flag when associating an existing istream. This is
+        subject to change, should I decide to roll my own translation someday for binary streams.
+        */
+        text_mode = 1 << 4
+    };
+
+
+    /* Constructor
+
+    The constructor calls Init().
+    The constructor also calls Open() if a filename is specified.
+    The constructor also calls Associate() if an istream is specified.
+
+    In any case check 'error' to determine whether or not construction succeeded.
+
+    [in] 'filename' : A file to open for input.
+    [in] 'stream' : An istream already opened for input.
+    [in][opt] 'flags' : Refer to CSVread::Flags. The default is no flags are set.
+    */
+    CSVread();
+    CSVread( std::string filename, Flags flags = none );
+    CSVread( std::istream *stream, Flags flags = none );
+
+    // If a file was opened by this class it's automatically closed when the class destructs.
+    ~CSVread();
+
+
+    /* CSVread::Reset()
+    - Reset to an empty state.
+
+    Resets most variables, calls ResetParser() and ResetCache().
+
+    The delimiter is not reset. To reset the delimiter call SetDelimiter( ',' ).
+    The size of the buffer is not reset. To reset the size of the buffer call ResizeBuffer().
+
+    If the file/istream is open/associated it's clear()'d, then its position is reset. If the
+    file/istream is not seekable do not call this function. The return code is undefined if the
+    stream is not seekable. Instead call Close() which will close/dissociate first before it calls
+    this function.
+
+    It shouldn't be necessary to call this function, typically. If there was an error and you wanted
+    to reset without associating/dissociating your istream, or opening/closing your file, you would
+    call this function.
+
+    [in] 'partial_reset' : A partial reset does everything described above but does not the reset
+        'fields', 'record_num', 'end_record_num', 'end_record_not_terminated'. Typically there
+        should be no reason to set this true. The default is false (a full reset).
+    [ret][failure] (false) : 'error' and 'error_msg' have been set.
+    [ret][success] (true)
+    */
+    bool Reset( bool partial_reset = false );
+
+
+    // Closes file if open or dissociates the existing istream, and then calls Reset().
+    // If this returns false the file/istream has been closed/dissociated but Reset() failed.
+    bool Close();
+
+    // This is the same as Close(). It may make your code easier to understand to call this when you
+    // are dissociating a stream not created by the class because it's not closed just dissociated.
+    bool Dissociate() { return Close(); };
+
+
+    /* CSVread::Open(), CSVread::Associate()
+    - Open a file or associate an existing istream.
+
+    If there is already an open file or associated istream this function fails.
+
+    If this function fails for any reason you must call Close() to reset before trying again.
+
+    When the class destructs if there is a file that was opened by this function it is automatically
+    closed, but you may call Close() before then.
+
+    If the stream starts with a UTF-8 BOM those bytes are ignored unless flag
+    CSVread::skip_utf8_bom_check is passed. There is no UTF-8 processing done on the stream
+    either way; the check is just to identify and then ignore the BOM if present.
+
+    Once the stream has been opened you may call ReadRecord() to retrieve each record.
+
+    The beginning of the file/istream current position must be the beginning of a record with an
+    optional UTF8 BOM. Keep in mind the first record read is 'record_num' 1.
+
+    If the file/istream is not seekable there are some limitations in ReadRecord().
+
+    [in] 'filename' : A file to open for input.
+    [in] 'stream' : An istream already opened for input.
+    [in][opt] 'flags' : Refer to CSVread::Flags. The default is no flags are set.
+    [ret][failure] (false) : 'error' and 'error_msg' are set.
+    [ret][success] (true) : 'has_utf8_bom' may be set.
+    */
+    bool Open( std::string filename, Flags flags = none );
+    bool Associate( std::istream *stream, Flags flags = none );
+
+
+    /* CSVread::GetDelimiter(), CSVread::SetDelimiter()
+    - Get or set the delimiter character to be used when parsing the stream.
+
+    The default delimiter is a comma and does not need to be set.
+
+    The delimiter is also known as the field separator character. Typically SetDelimiter() would be
+    used to set the delimiter to a semi-colon instead of the default comma.
+
+    The delimiter character must not conflict with any whitespace, terminator or qualifier (default:
+    double quote) character. No error checking is done because the advanced features of libcsv allow
+    all of those to be changed and therefore in rare circumstances one of those characters could be
+    technically acceptable as the delimiter.
+
+    The delimiter is persistent and will survive resets. It doesn't need to be set on each open.
+    */
+    unsigned char GetDelimiter();
+    void SetDelimiter( unsigned char delim );
+
+
+    /* CSVread::ReadRecord()
+    - Read and parse a record.
+
+    If the requested record number 'requested_record_num' is specified (ie not the default 0) and it
+    is less than the current record number 'record_num' then this function has to parse the stream
+    from the beginning to get to the requested record and is inefficient. In addition if the stream
+    is not seekable this function will fail in that case.
+
+    The end record is not known until this function attempts to read past it, the same way the EOF
+    of a stream is not known until you attempt to read past its end. Since records are parsed and
+    cached in advance the end record may or may not be known when you successfully request a record,
+    including what may be the end record. For instructions on testing for the end record refer to
+    the comment block above the declaration for 'end_record_num'.
+
+    'eof', 'end_record_num' or 'end_record_not_terminated' set on success is not an indication that
+    the record returned is the end record. You should keep calling ReadRecord(), until it fails, to
+    read any remaining records in the cache.
+
+    [in][opt] 'requested_record_num' : The record number to read. The default is the next record.
+    [ret][failure] (false) : 'error' and 'error_msg' are set;
+        'eof', 'end_record_num' and 'end_record_not_terminated' may also be set.
+    [ret][success] (true) : 'record_num' and 'fields' are set;
+        'eof', 'end_record_num' and 'end_record_not_terminated' may also be set.
+    */
+    bool ReadRecord( const uintmax_t requested_record_num = 0 );
+
+
+    /* Change the size of the buffer, in bytes.
+
+    The buffer exists for the life of the object. It has a default size of 4096 bytes and is used to
+    hold data read from the stream.
+
+    The cache list may allocate the same amount of memory as the size of the buffer at any time.
+
+    Libcsv has its own buffer that is unaffected by this setting.
+
+    [ret][failure] (false) : The buffer could not be resized and has retained its current size.
+        'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool ResizeBuffer( const std::streamsize bytes );
+
+
+    // The size of _buffer. Default 4096. Call ResizeBuffer() to change the size.
+    const std::streamsize &buffer_size; // = _buffer_size
+
+    /* Stream EOF.
+
+    EOF is just an indication that the end of the stream was reached. As noted in ReadRecord(), EOF
+    does not indicate the state of the records. If you want to determine whether the current record
+    is the end record refer to 'end_record_num'.
+    */
+    const bool &eof; // = _eof
+
+    // Error. Functions will not succeed when this is true. Call Reset() or Close() or Dissociate().
+    const bool &error; // = _error
+
+    // Contains an error message when 'error' or '_pending_error'.
+    // If 'error' you can read this string before calling Reset() or Close() or Dissociate().
+    const std::string &error_msg; // = _error_msg
+
+    // File/istream has a UTF-8 BOM
+    const bool &has_utf8_bom; // = _has_utf8_bom
+
+    // The record number of the current record.
+    // The first CSV record is record number 1.
+    const uintmax_t &record_num; // = _record_num
+
+
+    /* The record number of the end record.
+
+    This is set if 'eof' is true and all records were parsed successfully.
+
+    The value of this variable is undefined when 'eof' is false.
+
+    In order to parse the end record, every record before it will have been parsed successfully,
+    even if those records were ignored (eg you skipped them). Therefore when this is set all
+    records were parsed successfully.
+
+    Testing for the end record should come after a call to ReadRecord() fails, not before. There is
+    no guarantee on ReadRecord() success that the record read is known to be the end record even if
+    it is actually the end record.
+
+    // process all records including the end record
+    while( csv_read.ReadRecord() )
+    {
+    }
+
+    // determine if the end record was the last successfully read
+    if( obj.eof && ( obj.record_num == obj.end_record_num ) )
+    {
+    }
+
+    The example above assumes you are reading consecutively. Assuming the if statement is true,
+    since ReadRecord() does not set 'fields' or 'record_num' on failure they would still represent
+    the end record in that case.
+    */
+    const uintmax_t &end_record_num; // = _end_record_num
+
+
+    /* The end record was not terminated.
+
+    This is true if 'end_record_num' is set and the end record was not terminated.
+
+    Common usage of the CSV format does not require the end record to be terminated using a newline
+    sequence, defined as LF, CRLF or just CR (unless flag 'process_empty_records' was specified).
+    Despite this it's strongly recommended to always terminate in a newline and correct the
+    condition where it's missing. If you have this condition and something appends records to your
+    CSV file it likely will not check earlier records, so what was previously the end record in your
+    file and the first appended record would become one corrupted record.
+    */
+    const bool &end_record_not_terminated; // = _end_record_not_terminated
+
+
+    // The current record parsed into fields (columns), eg fields[0], fields[1], etc.
+    // Depending on your CSV data the number of fields may or may not differ between records.
+    // You can check fields.size() after each ReadRecord() to confirm the number is what's expected.
+    const std::vector<std::string> &fields; // = _fields
+
+
+    /* The libcsv parse object.
+
+    You may use this to set more advanced behavior.
+
+    To access this object you must include libcsv's "csv.h" in your code.
+
+    Do not call these functions on parse_obj:
+    csv_init(), csv_set_opts(), csv_parse(), csv_fini(), csv_free(), csv_get_delim(),
+    csv_set_delim().
+
+    To get/set the delimiter call Get/SetDelimiter() instead.
+
+    If 'error' parse_obj is not guaranteed != NULL or a good state; don't call any libcsv function.
+    */
+    struct ::csv_parser *parse_obj;
+
+
+private:
+    CSVread( const CSVread & );
+    CSVread & operator=( const CSVread & );
+
+    // Call this to reset parse_obj.
+    bool ResetParser();
+
+    // A file stream if one was opened by this class.
+    std::ifstream _file;
+
+    // The stream the records are read from.
+    // This points to the user specified istream or _file.
+    std::istream *_input_ptr;
+
+    // A list of the records (each as a vector containing the fields) most recently parsed.
+    // The back element is always used for the pending record. The size of the cache should never
+    // be less than 1.
+    // To clear this list call ResetCache(), which starts a new list with an empty back element.
+    std::list<std::vector<std::string>> _cache;
+
+    // Call this to reset _cache.
+    // The new list starts with one empty vector as the pending record.
+    void ResetCache();
+
+    // Whether or not an error is pending. Sometimes this is set instead of '_error' if there are
+    // completed records still in the cache when an error occurs. When the completed records are
+    // emptied if '_error_pending' then '_error' is set. See ReadRecord() definition.
+    bool _error_pending;
+
+    // The flags passed to Open()/Associate().
+    Flags _flags;
+
+    // The buffer used to hold data read from the stream.
+    char *_buffer;
+
+    // The field separator character.
+    unsigned char _delimiter; // = ,
+
+    // For a description of any of these refer to their public const references.
+    std::streamsize _buffer_size;
+    bool _eof;
+    bool _error;
+    std::string _error_msg;
+    bool _has_utf8_bom;
+    uintmax_t _record_num;
+    uintmax_t _end_record_num;
+    bool _end_record_not_terminated;
+    std::vector<std::string> _fields;
+
+    // Initialization to be called from the constructor only.
+    bool Init();
+};
+
+inline CSVread::Flags operator | (CSVread::Flags a, CSVread::Flags b)
+{
+    return CSVread::Flags( ( (int)a ) | ( (int)b ) );
+}
+inline CSVread::Flags & operator |= (CSVread::Flags &a, CSVread::Flags b)
+{
+    return (CSVread::Flags &)( ( (int &)a ) |= ( (int)b ) );
+}
+
+
+
+class CSVwrite
+{
+public:
+    // flags for Open()/Associate()
+    enum Flags
+    {
+        none = 0,
+
+        /* Truncate file.
+
+        Any contents that existed in the file before it is open are discarded.
+
+        An error will occur if you use this flag when associating an existing ostream. This is
+        subject to change, should I decide to handle discarding data in an existing ostream.
+        */
+        truncate = 1 << 0,
+
+        /* Open file in text mode instead of binary mode.
+
+        Records are written in binary mode by default. That means that characters are
+        untranslated.
+
+        You may prefer the translation done by text mode. In that case you may associate an already
+        existing stream that has that translation enabled or pass in this flag with your file.
+
+        An error will occur if you use this flag when associating an existing ostream. This is
+        subject to change, should I decide to roll my own translation someday for binary streams.
+        */
+        text_mode = 1 << 1,
+
+        /* Process empty records.
+
+        By default empty records (no fields) are ignored and not processed as records.
+
+        Empty records are completely empty. If you choose to process empty records only a
+        terminator is written for the empty record.
+
+        This flag changes the behavior of WriteRecord() but not WriteTerminator(). If you call
+        WriteTerminator() without first writing a field or record then you have written an empty
+        record, regardless of whether or not this flag is used.
+       */
+        process_empty_records = 1 << 2
+    };
+
+
+    /* Constructor
+
+    The constructor calls Init().
+    The constructor also calls Open() if a filename is specified.
+    The constructor also calls Associate() if an ostream is specified.
+
+    In any case check 'error' to determine whether or not construction succeeded.
+
+    [in] 'filename' : A file to open for output.
+    [in] 'stream' : An ostream already opened for output.
+    [in][opt] 'flags' : Refer to CSVwrite::Flags. The default is no flags are set.
+    */
+    CSVwrite();
+    CSVwrite( std::string filename, Flags flags = none );
+    CSVwrite( std::ostream *stream, Flags flags = none );
+
+    // If a file was opened by this class it's automatically closed when the class destructs.
+    ~CSVwrite();
+
+
+    // Closes file if open or dissociates the existing ostream, and then calls Reset().
+    // If this returns false the file/ostream has been closed/dissociated but Reset() failed.
+    bool Close();
+
+    // This is the same as Close(). It may make your code easier to understand to call this when you
+    // are dissociating a stream not created by the class because it's not closed just dissociated.
+    bool Dissociate() { return Close(); };
+
+
+    /* CSVwrite::Open(), CSVwrite::Associate()
+    - Open a file or associate an existing ostream.
+
+    A file is opened in append mode by default. To truncate the file instead pass the flag
+    CSVwrite::truncate.
+
+    If there is already an open file or associated istream this function fails.
+
+    If this function fails for any reason you must call Close() to reset before trying again.
+
+    When the class destructs if there is a file that was opened by this function it is automatically
+    closed, but you may call Close() before then.
+
+    If you are writing UTF-8 data and are writing from the beginning of the file/ostream and need
+    the UTF-8 BOM call WriteUTF8BOM() after opening.
+
+    Once the stream has been opened you may call WriteRecord() to write each record or WriteField()
+    to write fields one at a time.
+
+    The current position of the file/ostream must be the beginning of a record with an optional UTF8
+    BOM if it's the beginning of the file/ostream. If you are appending it's important that the end
+    record already in the file/ostream is terminated, otherwise there will be corruption when
+    appending the first record. For more on this refer to the comment block above the declaration
+    for CSVread::end_record_not_terminated.
+
+    [in] 'filename' : A file to open for output.
+    [in] 'stream' : An ostream already opened for output.
+    [in][opt] 'flags' : Refer to CSVwrite::Flags. The default is no flags are set.
+    [ret][failure] (false) : 'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool Open( std::string filename, Flags flags = none );
+    bool Associate( std::ostream *stream, Flags flags = none );
+
+
+    /* CSVwrite::WriteUTF8BOM()
+    - Write a UTF-8 BOM.
+
+    If at the beginning of a file/ostream you can call this to write a UTF-8 BOM, if necessary.
+
+    [ret][failure] (false) : 'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool WriteUTF8BOM();
+
+
+    /* CSVwrite::WriteTerminator()
+    - Write a record terminator.
+
+    If you are writing fields individually and you do not use the terminate option, or if you are
+    writing a record and you do not use the terminate option, you can terminate the record by
+    calling this function.
+
+    [ret][failure] (false) : 'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool WriteTerminator();
+
+
+    /* CSVwrite::WriteField()
+    - Write a field.
+
+    When writing the last field in the record set 'terminate' true or call WriteTerminator().
+
+    Every field is automatically qualified with quotes; you do not need to add your own qualifiers.
+
+    [in] 'field' : The field.
+    [in][opt] 'terminate' : Terminate the record. The default is false.
+    [ret][failure] (false) : 'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool WriteField( const std::string &field, const bool terminate = false );
+
+
+    /* CSVwrite::WriteRecord()
+    - Write a record.
+
+    All records should be terminated. If you set 'terminate' false make sure to call
+    WriteTerminator().
+
+    If this function is called and the previous record written by either this function or
+    WriteField() wasn't terminated then it is terminated before processing 'fields'.
+
+    If 'fields' has a size of 0 (no fields- empty record) nothing is written unless
+    flag CSVwrite::process_empty_records was specified, in which case a terminator is written.
+
+    Every field is automatically qualified with quotes; you do not need to add your own qualifiers.
+
+    [in] 'fields' : The record.
+    [in][opt] 'terminate' : Terminate the record. The default is true.
+    [ret][failure] (false) : 'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool WriteRecord( const std::vector<std::string> &fields, const bool terminate = true );
+
+
+    /* Change the size of the buffer, in bytes.
+
+    The buffer exists for the life of the object. It has a default size of 4096 bytes and is used to
+    hold data before it's written to the stream.
+
+    The buffer will hold at most a single field before writing it, therefore it's not as useful to
+    change the buffer size for this as it is for CSVread's buffer, unless your fields typically
+    are greater than 4096 bytes.
+
+    [ret][failure] (false) : The buffer could not be resized and has retained its current size.
+        'error' and 'error_msg' are set.
+    [ret][success] (true)
+    */
+    bool ResizeBuffer( const std::streamsize bytes );
+
+
+    // The size of _buffer. Default 4096. Call ResizeBuffer() to change the size.
+    const std::streamsize &buffer_size; // = _buffer_size
+
+    // Error. Functions will not succeed when this is true. Call Close() or Dissociate().
+    const bool &error; // = _error
+
+    // Contains an error message when 'error'.
+    // If 'error' you can read this string before calling Close() or Dissociate().
+    const std::string &error_msg; // = _error_msg
+
+    // Set this to change the delimiter.
+    // The delimiter should be a single character but prepended/appended whitespace is ok.
+    // The delimiter is persistent and will survive resets. It doesn't need to be set on each open.
+    std::string delimiter; // = ,
+
+    // Set this to change the terminator.
+    // The terminator should be a single character or \r\n but prepended/appended whitespace is ok.
+    // \n could be automatically translated and written as \r\n in text mode, depending on your OS.
+    // It's not recommended to set the terminator as \r\n explicitly.
+    // The terminator is persistent and will survive resets. It doesn't need to be set on each open.
+    std::string terminator; // = \n
+
+private:
+    CSVwrite( const CSVwrite & );
+    CSVwrite & operator=( const CSVwrite & );
+
+    // A file stream if one was opened by this class.
+    std::ofstream _file;
+
+    // The stream the records are written to.
+    // This points to the user specified ostream or _file.
+    std::ostream *_output_ptr;
+
+    // The flags passed to Open()/Associate().
+    Flags _flags;
+
+    // The buffer used to hold data written to the stream.
+    char *_buffer;
+
+    // Whether or not the field to be written is the first field in the record.
+    bool _is_first_field;
+
+    // For a description of any of these refer to their public const references.
+    std::streamsize _buffer_size;
+    bool _error;
+    std::string _error_msg;
+
+    // Initialization to be called from the constructor only.
+    bool Init();
+
+    // Resets most variables. Does not reset the buffer size, delimiter or terminator.
+    bool Reset();
+};
+
+inline CSVwrite::Flags operator | (CSVwrite::Flags a, CSVwrite::Flags b)
+{
+    return CSVwrite::Flags( ( (int)a ) | ( (int)b ) );
+}
+inline CSVwrite::Flags & operator |= (CSVwrite::Flags &a, CSVwrite::Flags b)
+{
+    return (CSVwrite::Flags &)( ( (int &)a ) |= ( (int)b ) );
+}
+
+
+} // namespace util
+} // namespace jay
+#endif // JAY_UTIL_CSV_HPP_

--- a/src/csv/CSVread.cpp
+++ b/src/csv/CSVread.cpp
@@ -1,0 +1,764 @@
+/*
+Copyright (C) 2014 Jay Satiro <raysatiro@yahoo.com>
+All rights reserved.
+
+This file is part of CSV/jay::util.
+
+https://github.com/jay/CSV
+
+jay::util is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+jay::util is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with jay::util. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** A class to read comma separated values (CSV) from a stream.
+
+Documentation is in CSV.hpp.
+*/
+
+#include "CSV.hpp"
+
+#include <stdint.h>
+
+#include <fstream>
+#include <limits>
+#include <list>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "csv.h"
+
+#include "strerror.hpp"
+
+
+using namespace std;
+
+
+namespace jay {
+namespace util {
+
+
+struct cb_stuff
+{
+    cb_stuff(
+        list<vector<string>> &_cache,
+        CSVread::Flags &_flags,
+        bool &_error_pending,
+        std::string &_error_msg,
+        bool &_end_record_not_terminated,
+        uintmax_t &pending,
+        uintmax_t &requested
+    ) :
+        _cache( _cache ), _flags( _flags ), _error_pending( _error_pending ), _error_msg( _error_msg ),
+            _end_record_not_terminated( _end_record_not_terminated ),
+            pending( pending ), requested( requested )
+    {
+    }
+
+    // A reference to the CSVread::_cache list.
+    list<vector<string>> &_cache;
+
+    // A reference to the CSVread::_flags.
+    const CSVread::Flags &_flags;
+
+    // A reference to CSVread::_error_pending.
+    bool &_error_pending;
+
+    // A reference to CSVread::_error_msg.
+    std::string &_error_msg;
+
+    // A reference to CSVread::_end_record_not_terminated.
+    bool &_end_record_not_terminated;
+
+    // A reference to the record number of the pending record.
+    uintmax_t &pending;
+
+    // A reference to the record number of the requested record.
+    const uintmax_t &requested;
+
+private:
+    cb_stuff( const cb_stuff & );
+    cb_stuff & operator=( const cb_stuff & );
+};
+
+
+// Called by libcsv when a new field has been parsed for the pending record.
+// The pending record is the back element in the cache list. If the record number of the pending
+// record is less than the record number of the requested record then it's ignored.
+static void Callback_Field( void *data, size_t data_size, void *userptr )
+{
+    cb_stuff *s = (cb_stuff *)userptr;
+
+    if( s->_error_pending )
+    {
+        return;
+    }
+
+    if( s->pending >= s->requested )
+    {
+        // Push the field to the back of the pending record.
+        s->_cache.back().push_back( string( (const char *)data, data_size ) );
+
+        if( ( s->_flags & CSVread::error_on_null_in_field )
+            && ( s->_cache.back().back().find_first_of( '\0' ) != string::npos )
+        )
+        {
+            s->_error_pending = true;
+            ostringstream ss;
+            ss << "Record #" << s->pending << " Field #" << s->_cache.back().size()
+                << " is invalid due to NULL byte in field.";
+            s->_error_msg = ss.str();
+            return;
+        }
+    }
+}
+
+
+// Called by libcsv when the pending record is complete (no more fields to parse).
+// The pending record is the back element in the cache list. If the record number of the pending
+// record is less than the record number of the requested record then it's ignored.
+static void Callback_Record( int terminator, void *userptr )
+{
+    cb_stuff *s = (cb_stuff *)userptr;
+
+    if( s->_error_pending
+        || ( ( terminator == CSV_CR ) && ( s->_flags & CSVread::process_empty_records ) )
+    )
+    {
+        return;
+    }
+
+    if( terminator == -1 )
+    {
+        s->_end_record_not_terminated = true;
+    }
+
+    if( s->pending >= s->requested )
+    {
+        // Push a vector to the back of the list to make a new pending record.
+        s->_cache.push_back( vector<string>() );
+    }
+
+    ++s->pending;
+}
+
+
+CSVread::CSVread() :
+    buffer_size( _buffer_size), eof( _eof ), error( _error ), error_msg( _error_msg ),
+        has_utf8_bom( _has_utf8_bom), record_num( _record_num ), end_record_num( _end_record_num ),
+        end_record_not_terminated( _end_record_not_terminated ), fields( _fields )
+{
+    if( !Init() )
+        return;
+}
+
+
+CSVread::CSVread( string filename, Flags flags /* = none */ ) :
+    buffer_size( _buffer_size), eof( _eof ), error( _error ), error_msg( _error_msg ),
+        has_utf8_bom( _has_utf8_bom), record_num( _record_num ), end_record_num( _end_record_num ),
+        end_record_not_terminated( _end_record_not_terminated ), fields( _fields )
+{
+    if( !Init() )
+        return;
+
+    Open( filename, flags );
+}
+
+
+CSVread::CSVread( istream *stream, Flags flags /* = none */ ) :
+    buffer_size( _buffer_size), eof( _eof ), error( _error ), error_msg( _error_msg ),
+        has_utf8_bom( _has_utf8_bom), record_num( _record_num ), end_record_num( _end_record_num ),
+        end_record_not_terminated( _end_record_not_terminated ), fields( _fields )
+{
+    if( !Init() )
+        return;
+
+    Associate( stream, flags );
+}
+
+
+CSVread::~CSVread()
+{
+    if( parse_obj )
+    {
+        csv_free( parse_obj );
+        delete parse_obj;
+    }
+    free( _buffer );
+}
+
+
+/* Resize a buffer.
+
+Both CSVread and CSVwrite use this to resize their respective buffers.
+
+[ret][failure] (false) : The buffer could not be resized and has retained its current size.
+    'error' and 'error_msg' are set.
+[ret][success] (true)
+*/
+bool CSVshared_ResizeBuffer(
+    const streamsize bytes,   // IN
+    char *&_buffer,   // INOUT
+    streamsize &_buffer_size,   // INOUT
+    bool &_error,   // OUT
+    string &_error_msg   // OUT
+)
+{
+    if( _buffer && ( _buffer_size == bytes ) )
+        return true;
+
+    if( bytes <= 0 )
+    {
+        _error = true;
+        _error_msg = "buffer allocation failed. size of bytes is <= 0.";
+        return false;
+    }
+
+    // CSV classes may cast 'buffer_size' to a size_t at any point so it can't be larger than that.
+    if( bytes > (std::numeric_limits<size_t>::max)() )
+    {
+        _error = true;
+        _error_msg = "buffer allocation failed. size of bytes is > std::numeric_limits<size_t>::max";
+        return false;
+    }
+
+    char *temp = (char *)realloc( _buffer, (size_t)bytes );
+    if( !temp )
+    {
+        _error = true;
+
+        ostringstream ss;
+        ss << "buffer allocation failed. size in bytes: " << bytes;
+        _error_msg = ss.str();
+
+        return false;
+    }
+
+    _buffer = temp;
+    _buffer_size = bytes;
+    return true;
+}
+
+
+bool CSVread::ResizeBuffer( const streamsize bytes )
+{
+    return CSVshared_ResizeBuffer( bytes, _buffer, _buffer_size, _error, _error_msg );
+}
+
+
+bool CSVread::ResetParser()
+{
+    /* libcsv resets the parser in csv_fini() but not in csv_free(). If there is an error in the
+    parser object then csv_fini() may not have been called or if it was it may not have reset.
+    Also libcsv's manual advises against calling csv_init() on a parse object more than once:
+    "memory allocated for the original structure will be lost"
+    Probably if any allocated memory is freed first then it can be reinitialized without leak.
+    But instead to be safer I'm recreating parse_obj.
+    */
+    if( parse_obj )
+    {
+        csv_free( parse_obj );
+        delete parse_obj;
+        parse_obj = NULL;
+    }
+
+    parse_obj = new csv_parser;
+    if( csv_init( parse_obj, 0 /* Options must be set in Associate(), not here! */ ) )
+    {
+        _error = true;
+        _error_msg = "libcsv: ";
+        _error_msg += csv_strerror( csv_error( parse_obj ) );
+
+        delete parse_obj;
+        parse_obj = NULL;
+
+        return false;
+    }
+
+    SetDelimiter( _delimiter );
+    return true;
+}
+
+
+void CSVread::ResetCache()
+{
+    _cache = list<vector<string>>( 1, vector<string>() );
+}
+
+
+// REM this function is also called by Init() for initialization.
+bool CSVread::Reset( bool partial_reset /* = false */ )
+{
+    if( !_buffer )
+    {
+        if( !ResizeBuffer( 4096 ) )
+            return false;
+    }
+
+    if( !ResetParser() )
+        return false;
+
+    ResetCache();
+
+    if( _input_ptr )
+    {
+        _input_ptr->clear();
+        _input_ptr->seekg( _has_utf8_bom ? 3 : 0 );
+        _eof = _input_ptr->eof();
+    }
+    else
+    {
+        _flags = CSVread::none;
+        _eof = false;
+        _has_utf8_bom = false;
+    }
+
+    csv_set_opts( parse_obj, ( ( _flags & process_empty_records ) ? CSV_REPALL_NL : 0 )
+            | ( ( _flags & strict_mode ) ? ( CSV_STRICT | CSV_STRICT_FINI ) : 0 )
+    );
+
+    _error = false;
+    _error_pending = false;
+    _error_msg = "";
+
+    if( !partial_reset )
+    {
+        _record_num = 0;
+        _end_record_num = 0;
+        _end_record_not_terminated = false;
+        _fields = vector<string>();
+    }
+
+    return true;
+}
+
+
+bool CSVread::Close()
+{
+    if( _file.is_open() )
+    {
+        _file.close();
+    }
+
+    _input_ptr =  NULL;
+
+    return Reset();
+}
+
+
+// Initialization to be called from the constructor only, first thing.
+bool CSVread::Init()
+{
+    // The vars here must be zeroed before any possible error aborts the initialization.
+    _buffer = NULL;
+    _buffer_size = 0;
+    parse_obj = NULL;
+    _input_ptr =  NULL;
+
+    _delimiter = (unsigned char)CSV_COMMA;
+
+    return Reset();
+}
+
+
+
+
+bool CSVread::Associate( istream *stream, const Flags flags /* = none */ )
+{
+    if( _error )
+        return false;
+
+    if( !stream )
+    {
+        _error = true;
+        _error_msg = "The stream parameter is NULL.";
+        return false;
+    }
+
+    if( _input_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is already associated. Call Close() to dissociate.";
+        return false;
+    }
+
+    if( ( flags & text_mode ) && ( stream != &_file ) )
+    {
+        // For the time being text mode is only valid if it's a file opened by this class.
+        _error = true;
+        _error_msg = "Text mode is only valid for files opened by this class.";
+        return false;
+    }
+
+    _flags = flags;
+    _input_ptr = stream;
+
+    if( !_input_ptr->good() )
+    {
+        _error = true;
+        _error_msg = "istream: " + ios_strerror( _input_ptr->rdstate() );
+        return false;
+    }
+
+    csv_set_opts( parse_obj, ( ( _flags & process_empty_records ) ? CSV_REPALL_NL : 0 )
+            | ( ( _flags & strict_mode ) ? ( CSV_STRICT | CSV_STRICT_FINI ) : 0 )
+    );
+
+    uintmax_t pending = 1;
+    uintmax_t requested = 1;
+
+    bool parsed_end_record = false;
+
+    cb_stuff args( _cache, _flags, _error_pending, _error_msg, _end_record_not_terminated, pending, requested );
+
+    /* At least 3 bytes need to be read to detect the UTF-8 BOM. If the _buffer has a size of less
+    than 3 then use temporary buffer a[] instead.
+    */
+    char a[ 3 ];
+    char *p = ( _buffer_size >= 3 ) ? _buffer : a;
+    streamsize p_size = ( _buffer_size >= 3 ) ? _buffer_size : (streamsize)sizeof a;
+
+    _input_ptr->read( p, p_size );
+    streamsize len = _input_ptr->gcount();
+    _eof = _input_ptr->eof();
+
+    if( len > 0 )
+    {
+        if( !( _flags & skip_utf8_bom_check )
+            && ( len >= 3 )
+            && ( p[ 0 ] == '\xEF' ) && ( p[ 1 ] == '\xBB' ) && ( p[ 2 ] == '\xBF' )
+        )
+        {
+            _has_utf8_bom = true;
+        }
+
+        if( !_has_utf8_bom || ( len > 3 ) )
+        {
+            char *adjusted_p = &p[ _has_utf8_bom ? 3 : 0 ];
+            size_t adjusted_len = (size_t)( _has_utf8_bom ? ( len - 3 ) : len );
+
+            // REM the callbacks can modify most of the 'args'
+            if( csv_parse(
+                    parse_obj,
+                    adjusted_p,
+                    adjusted_len,
+                    Callback_Field,
+                    Callback_Record,
+                    &args
+                ) != adjusted_len
+            )
+            {
+                if( !_error_pending )
+                {
+                    _error_pending = true;
+                    _error_msg = "libcsv: ";
+                    _error_msg += csv_strerror( csv_error( parse_obj ) );
+                }
+            }
+        }
+    }
+
+    // REM this block of code is duplicated in ReadRecord()
+    if( !_error_pending )
+    {
+        if( !_input_ptr->good() || ( len != p_size ) )
+        {
+            // REM the callbacks can modify most of the 'args'
+            if( csv_fini( parse_obj, Callback_Field, Callback_Record, &args ) )
+            {
+                _error_msg = "libcsv: ";
+                _error_msg += csv_strerror( csv_error( parse_obj ) );
+            }
+            else
+            {
+                _error_msg = "istream: " + ios_strerror( _input_ptr->rdstate() );
+
+                if( _eof )
+                {
+                    parsed_end_record = true;
+                }
+            }
+
+            _error_pending = true;
+        }
+    }
+
+    // REM this block of code is duplicated in ReadRecord()
+    if( parsed_end_record )
+    {
+        _end_record_num = pending - 1;
+        // _end_record_not_terminated is handled via csv_fini() @ Callback_Record()
+    }
+    else
+    {
+        _end_record_num = 0;
+        _end_record_not_terminated = false;
+    }
+
+    return true;
+}
+
+
+bool CSVread::Open( string filename, const Flags flags /* = none */ )
+{
+    if( _error )
+        return false;
+
+    if( _file.is_open() )
+    {
+        _error = true;
+        _error_msg = "A file is already open. Call Close() to close the file.";
+        return false;
+    }
+
+    if( _input_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is already associated. Call Close() to dissociate.";
+        return false;
+    }
+
+    ios::openmode mode = ( ( flags & text_mode ) ) ? ios::in : ios::binary;
+
+    _file.open( filename, mode );
+    if( !_file )
+    {
+        _error = true;
+        _error_msg = "Failed opening " + filename;
+        return false;
+    }
+
+    return Associate( &_file, flags );
+}
+
+
+
+
+unsigned char CSVread::GetDelimiter()
+{
+    return _delimiter;
+}
+
+
+void CSVread::SetDelimiter( unsigned char delim )
+{
+    _delimiter = delim;
+
+    if( parse_obj )
+    {
+        csv_set_delim( parse_obj, _delimiter );
+    }
+}
+
+
+
+
+bool CSVread::ReadRecord( const uintmax_t requested_record_num /* = 0 */ )
+{
+    if( _error )
+        return false;
+
+    if( !_input_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is not associated with the object.";
+        return false;
+    }
+
+    if( !_cache.size() )
+    {
+        _error = true;
+        _error_msg = "The cache list does not contain any elements";
+        return false;
+    }
+
+    _eof = _input_ptr->eof();
+    uintmax_t pending = _record_num + _cache.size();
+    uintmax_t requested = requested_record_num;
+
+    if( !requested )
+    {
+        if( _record_num == SIZE_MAX )
+        {
+            _error = true;
+            _error_msg = "The maximum number of lines have been read (SIZE_MAX)";
+            return false;
+        }
+        requested = _record_num + 1;
+    }
+
+    if( requested > _record_num )
+    {
+        if( requested < pending ) // the requested record is already in the cache
+        {
+            for( uintmax_t i = requested - _record_num - 1; i; --i )
+            {
+                _cache.pop_front();
+            }
+
+            _record_num = requested;
+            _fields.swap( _cache.front() );
+            _cache.pop_front();
+            return true;
+        }
+        else if( requested > pending ) // the requested record is not in the cache
+        {
+            // Discard all including the pending record.
+            ResetCache();
+        }
+        else // the requested record is the pending record
+        {
+            // Discard all except the pending record.
+            vector<string> temp;
+            temp.swap( _cache.back() );
+            ResetCache();
+            temp.swap( _cache.back() );
+        }
+    }
+    else if( requested < _record_num )
+    {
+        /* Records can span multiple lines and since the position of each record isn't exposed by
+        libcsv there's no way (short of modifying libcsv and keeping a separate cache) to seek
+        directly to the requested record's position. Instead do a partial reset here. A partial
+        reset does not change _fields, _record_num, _end_record_num and _end_record_not_terminated,
+        which are not to be changed unless this function is successful.
+        */
+
+        if( !Reset( true ) )
+        {
+            // _error and _error_msg are already set by Reset() or its helpers if it failed.
+            return false;
+        }
+
+        if( !_input_ptr->good() )
+        {
+            _error = true;
+            _error_msg = "istream seek failed: " + ios_strerror( _input_ptr->rdstate() );
+            return false;
+        }
+
+        pending = 1;
+    }
+    else // requested == _record_num
+    {
+        return true;
+    }
+
+    // At this point the cache does not have any complete records so error if an error is pending.
+    if( _error_pending )
+    {
+        _error_pending = false;
+        _error = true;
+        return false;
+    }
+
+    if( _cache.size() != 1 )
+    {
+        _error = true;
+
+        ostringstream ss;
+        ss << "The cache list has an unexpected size: " << _cache.size();
+        _error_msg = ss.str();
+
+        return false;
+    }
+
+    if( !_input_ptr->good() )
+    {
+        _error = true;
+        _error_msg = "istream: " + ios_strerror( _input_ptr->rdstate() );
+        return false;
+    }
+
+    bool parsed_end_record = false;
+
+    cb_stuff args( _cache, _flags, _error_pending, _error_msg, _end_record_not_terminated, pending, requested );
+
+    while( ( _cache.size() == 1 ) && !_error_pending )
+    {
+        _input_ptr->read( _buffer, _buffer_size );
+        streamsize len = _input_ptr->gcount();
+        _eof = _input_ptr->eof();
+
+        if( len > 0 )
+        {
+            // REM the callbacks can modify most of the 'args'
+            if( csv_parse( parse_obj, _buffer, (size_t)len, Callback_Field, Callback_Record, &args ) != len )
+            {
+                if( !_error_pending )
+                {
+                    _error_pending = true;
+                    _error_msg = "libcsv: ";
+                    _error_msg += csv_strerror( csv_error( parse_obj ) );
+                }
+            }
+        }
+
+        // REM this block of code is duplicated in Associate()
+        if( !_error_pending )
+        {
+            if( !_input_ptr->good() || ( len != _buffer_size ) )
+            {
+                // REM the callback can modify most of the 'args'
+                if( csv_fini( parse_obj, Callback_Field, Callback_Record, &args ) )
+                {
+                    _error_msg = "libcsv: ";
+                    _error_msg += csv_strerror( csv_error( parse_obj ) );
+                }
+                else
+                {
+                    _error_msg = "istream: " + ios_strerror( _input_ptr->rdstate() );
+
+                    if( _eof )
+                    {
+                        parsed_end_record = true;
+                    }
+                }
+
+                _error_pending = true;
+            }
+        }
+    }
+
+    // REM this block of code is duplicated in Associate()
+    if( parsed_end_record )
+    {
+        _end_record_num = pending - 1;
+        // _end_record_not_terminated is handled via csv_fini() @ Callback_Record()
+    }
+    else
+    {
+        _end_record_num = 0;
+        _end_record_not_terminated = false;
+    }
+
+    if( _cache.size() == 1 )
+    {
+        _error = true;
+        if( !_error_pending )
+        {
+            _error_msg = "istream: " + ios_strerror( _input_ptr->rdstate() );
+        }
+        return false;
+    }
+
+    _record_num = requested;
+    _fields.swap( _cache.front() );
+    _cache.pop_front();
+
+    return true;
+}
+
+
+} // namespace util
+} // namespace jay

--- a/src/csv/CSVwrite.cpp
+++ b/src/csv/CSVwrite.cpp
@@ -1,0 +1,440 @@
+/*
+Copyright (C) 2014 Jay Satiro <raysatiro@yahoo.com>
+All rights reserved.
+
+This file is part of CSV/jay::util.
+
+https://github.com/jay/CSV
+
+jay::util is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+jay::util is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with jay::util. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** A class to write comma separated values (CSV) to a stream.
+
+Documentation is in CSV.hpp.
+*/
+
+#include "CSV.hpp"
+
+#include <fstream>
+#include <list>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "strerror.hpp"
+
+
+using namespace std;
+
+
+namespace jay {
+namespace util {
+
+
+CSVwrite::CSVwrite() :
+    buffer_size( _buffer_size), error( _error ), error_msg( _error_msg )
+{
+    if( !Init() )
+        return;
+}
+
+
+CSVwrite::CSVwrite( string filename, Flags flags /* = none */ ) :
+    buffer_size( _buffer_size), error( _error ), error_msg( _error_msg )
+{
+    if( !Init() )
+        return;
+
+    Open( filename, flags );
+}
+
+
+CSVwrite::CSVwrite( ostream *stream, Flags flags /* = none */ ) :
+    buffer_size( _buffer_size), error( _error ), error_msg( _error_msg )
+{
+    if( !Init() )
+        return;
+
+    Associate( stream, flags );
+}
+
+
+CSVwrite::~CSVwrite()
+{
+    free( _buffer );
+}
+
+
+bool CSVshared_ResizeBuffer(
+    const streamsize bytes,   // IN
+    char *&buffer,   // INOUT
+    streamsize &buffer_size,   // INOUT
+    bool &error,   // OUT
+    string &error_msg   // OUT
+); // This function defined and documented above CSVread::ResizeBuffer().
+
+
+bool CSVwrite::ResizeBuffer( const streamsize bytes )
+{
+    return CSVshared_ResizeBuffer( bytes, _buffer, _buffer_size, _error, _error_msg );
+}
+
+
+// REM This function is also called by Init() for initialization
+bool CSVwrite::Reset()
+{
+    if( _output_ptr )
+    {
+        _error = true;
+        _error_msg = "Not implemented";
+        return false;
+    }
+
+    if( !_buffer )
+    {
+        if( !ResizeBuffer( 4096 ) )
+            return false;
+    }
+
+    _flags = CSVwrite::none;
+    _error = false;
+    _error_msg = "";
+    _is_first_field = true;
+
+    return true;
+}
+
+
+bool CSVwrite::Close()
+{
+    if( _file.is_open() )
+    {
+        _file.close();
+    }
+
+    _output_ptr =  NULL;
+
+    return Reset();
+}
+
+
+// Initialization to be called from the constructor only, first thing.
+bool CSVwrite::Init()
+{
+    // The vars here must be zeroed before any possible error aborts the initialization.
+    _buffer = NULL;
+    _buffer_size = 0;
+    _output_ptr =  NULL;
+
+    delimiter = ",";
+    terminator = "\n";
+
+    return Reset();
+}
+
+
+
+
+bool CSVwrite::Associate( ostream *stream, const Flags flags /* = none */ )
+{
+    if( _error )
+        return false;
+
+    if( !stream )
+    {
+        _error = true;
+        _error_msg = "The stream parameter is NULL.";
+        return false;
+    }
+
+    if( _output_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is already associated. Call Close() to dissociate.";
+        return false;
+    }
+
+    if( ( flags & text_mode ) && ( stream != &_file ) )
+    {
+        // For the time being text mode is only valid if it's a file opened by this class.
+        _error = true;
+        _error_msg = "Text mode is only valid for files opened by this class.";
+        return false;
+    }
+
+    _flags = flags;
+    _output_ptr = stream;
+
+    if( !_output_ptr->good() )
+    {
+        _error = true;
+        _error_msg = "ostream: " + ios_strerror( _output_ptr->rdstate() );
+        return false;
+    }
+
+    return true;
+}
+
+
+bool CSVwrite::Open( string filename, const Flags flags /* = none */ )
+{
+    if( _error )
+        return false;
+
+    if( _file.is_open() )
+    {
+        _error = true;
+        _error_msg = "A file is already open. Call Close() to close the file.";
+        return false;
+    }
+
+    if( _output_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is already associated. Call Close() to dissociate.";
+        return false;
+    }
+
+    ios::openmode mode = ( ( flags & text_mode ) ) ? ios::out : ios::binary;
+    mode |= ( ( flags & truncate ) ) ? ios::trunc : ios::app;
+
+    _file.open( filename, mode );
+    if( !_file )
+    {
+        _error = true;
+        _error_msg = "Failed opening " + filename;
+        return false;
+    }
+
+    return Associate( &_file, flags );
+}
+
+
+
+
+bool CSVwrite::WriteUTF8BOM()
+{
+    if( _error )
+        return false;
+
+    if( !_output_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is not associated with the object.";
+        return false;
+    }
+
+    _output_ptr->write( "\xEF\xBB\xBF", 3 );
+    if( !_output_ptr->good() )
+    {
+        _error = true;
+        _error_msg = "ostream: " + ios_strerror( _output_ptr->rdstate() );
+        return false;
+    }
+
+    return true;
+}
+
+
+bool CSVwrite::WriteTerminator()
+{
+    if( _error )
+        return false;
+
+    if( !_output_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is not associated with the object.";
+        return false;
+    }
+
+    _output_ptr->write( terminator.c_str(), terminator.length() );
+    if( !_output_ptr->good() )
+    {
+        _error = true;
+        _error_msg = "ostream: " + ios_strerror( _output_ptr->rdstate() );
+        return false;
+    }
+
+    _is_first_field = true;
+    return true;
+}
+
+
+bool CSVwrite::WriteField( const string &field, bool terminate /* = false */ )
+{
+    if( _error )
+        return false;
+
+    if( !_output_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is not associated with the object.";
+        return false;
+    }
+
+    char *p = _buffer;
+    const char *const buffer_end = _buffer + (size_t)_buffer_size;
+
+    list<char> prepend, append;
+
+    if( !_is_first_field )
+    {
+        prepend.assign( delimiter.begin(), delimiter.end() );
+    }
+
+    if( terminate )
+    {
+        append.assign( terminator.begin(), terminator.end() );
+    }
+
+    // All fields are qualified with double quotes since that is what libcsv write functions do
+    prepend.push_back( '"' );
+    append.push_front( '"' );
+
+    // This is set when there is a quote that needs to be escaped but there's no room in the buffer
+    bool quote = false;
+
+    // This is set when the buffer needs to be written to the stream even if the buffer is not full
+    bool flush = false;
+
+    for( string::const_iterator it = field.begin();; )
+    {
+        if( flush || ( p == buffer_end ) )
+        {
+            _output_ptr->write( _buffer, ( p - _buffer ) );
+            if( !_output_ptr->good() )
+            {
+                _error = true;
+                _error_msg = "ostream: " + ios_strerror( _output_ptr->rdstate() );
+                return false;
+            }
+
+            if( flush && ( it == field.end() ) )
+            {
+                break;
+            }
+
+            p = _buffer;
+        }
+
+        if( it == field.begin() )
+        {
+            while( prepend.size() && ( p != buffer_end ) )
+            {
+                *p++ = *prepend.begin();
+                prepend.pop_front();
+            }
+
+            if( p == buffer_end )
+            {
+                continue;
+            }
+        }
+
+        if( quote )
+        {
+            *p++ = '"';
+            quote = false;
+
+            if( p == buffer_end )
+            {
+                continue;
+            }
+        }
+
+        if( it == field.end() )
+        {
+            while( append.size() && ( p != buffer_end ) )
+            {
+                *p++ = *append.begin();
+                append.pop_front();
+            }
+
+            if( !append.size() || ( p != buffer_end ) )
+            {
+                flush = true;
+            }
+
+            continue;
+        }
+
+        while( ( p != buffer_end ) && ( it != field.end() ) )
+        {
+            *p = *it++;
+            if( *p++ == '"' )
+            {
+                if( p == buffer_end )
+                {
+                    quote = true;
+                    break;
+                }
+
+                *p++ = '"';
+            }
+        }
+    }
+
+    _is_first_field = terminate;
+    return true;
+}
+
+bool CSVwrite::WriteRecord( const vector<string> &fields, bool terminate /* = true */ )
+{
+    if( _error )
+        return false;
+
+    if( !_output_ptr )
+    {
+        _error = true;
+        _error_msg = "A stream is not associated with the object.";
+        return false;
+    }
+
+    if( !_is_first_field )
+    {
+        if( !WriteTerminator() )
+        {
+            return false;
+        }
+    }
+
+    if( !fields.size() && !(( _flags & CSVwrite::process_empty_records )) )
+    {
+        return true;
+    }
+
+    for( vector<string>::const_iterator it = fields.begin(); it != fields.end(); ++it )
+    {
+        if( !WriteField( *it ) )
+        {
+            return false;
+        }
+    }
+
+    if( terminate )
+    {
+        if( !WriteTerminator() )
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+} // namespace util
+} // namespace jay

--- a/src/csv/License_GPLv3.txt
+++ b/src/csv/License_GPLv3.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/src/csv/csv.h
+++ b/src/csv/csv.h
@@ -1,0 +1,88 @@
+#ifndef LIBCSV_H__
+#define LIBCSV_H__
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CSV_MAJOR 3
+#define CSV_MINOR 0
+#define CSV_RELEASE 3
+
+/* Error Codes */
+#define CSV_SUCCESS 0
+#define CSV_EPARSE 1   /* Parse error in strict mode */
+#define CSV_ENOMEM 2   /* Out of memory while increasing buffer size */
+#define CSV_ETOOBIG 3  /* Buffer larger than SIZE_MAX needed */
+#define CSV_EINVALID 4 /* Invalid code,should never be received from csv_error*/
+
+
+/* parser options */
+#define CSV_STRICT 1    /* enable strict mode */
+#define CSV_REPALL_NL 2 /* report all unquoted carriage returns and linefeeds */
+#define CSV_STRICT_FINI 4 /* causes csv_fini to return CSV_EPARSE if last
+                             field is quoted and doesn't containg ending 
+                             quote */
+#define CSV_APPEND_NULL 8 /* Ensure that all fields are null-terminated */
+#define CSV_EMPTY_IS_NULL 16 /* Pass null pointer to cb1 function when
+                                empty, unquoted fields are encountered */
+
+
+/* Character values */
+#define CSV_TAB    0x09
+#define CSV_SPACE  0x20
+#define CSV_CR     0x0d
+#define CSV_LF     0x0a
+#define CSV_COMMA  0x2c
+#define CSV_QUOTE  0x22
+
+struct csv_parser {
+  int pstate;         /* Parser state */
+  int quoted;         /* Is the current field a quoted field? */
+  size_t spaces;      /* Number of continious spaces after quote or in a non-quoted field */
+  unsigned char * entry_buf;   /* Entry buffer */
+  size_t entry_pos;   /* Current position in entry_buf (and current size of entry) */
+  size_t entry_size;  /* Size of entry buffer */
+  int status;         /* Operation status */
+  unsigned char options;
+  unsigned char quote_char;
+  unsigned char delim_char;
+  int (*is_space)(unsigned char);
+  int (*is_term)(unsigned char);
+  size_t blk_size;
+  void *(*malloc_func)(size_t);
+  void *(*realloc_func)(void *, size_t);
+  void (*free_func)(void *);
+};
+
+/* Function Prototypes */
+int csv_init(struct csv_parser *p, unsigned char options);
+int csv_fini(struct csv_parser *p, void (*cb1)(void *, size_t, void *), void (*cb2)(int, void *), void *data);
+void csv_free(struct csv_parser *p);
+int csv_error(struct csv_parser *p);
+char * csv_strerror(int error);
+size_t csv_parse(struct csv_parser *p, const void *s, size_t len, void (*cb1)(void *, size_t, void *), void (*cb2)(int, void *), void *data);
+size_t csv_write(void *dest, size_t dest_size, const void *src, size_t src_size);
+int csv_fwrite(FILE *fp, const void *src, size_t src_size);
+size_t csv_write2(void *dest, size_t dest_size, const void *src, size_t src_size, unsigned char quote);
+int csv_fwrite2(FILE *fp, const void *src, size_t src_size, unsigned char quote);
+int csv_get_opts(struct csv_parser *p);
+int csv_set_opts(struct csv_parser *p, unsigned char options);
+void csv_set_delim(struct csv_parser *p, unsigned char c);
+void csv_set_quote(struct csv_parser *p, unsigned char c);
+unsigned char csv_get_delim(struct csv_parser *p);
+unsigned char csv_get_quote(struct csv_parser *p);
+void csv_set_space_func(struct csv_parser *p, int (*f)(unsigned char));
+void csv_set_term_func(struct csv_parser *p, int (*f)(unsigned char));
+void csv_set_realloc_func(struct csv_parser *p, void *(*)(void *, size_t));
+void csv_set_free_func(struct csv_parser *p, void (*)(void *));
+void csv_set_blk_size(struct csv_parser *p, size_t);
+size_t csv_get_buffer_size(struct csv_parser *p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/csv/libcsv.c
+++ b/src/csv/libcsv.c
@@ -1,0 +1,581 @@
+/*
+libcsv - parse and write csv data
+Copyright (C) 2008  Robert Gamble
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#if ___STDC_VERSION__ >= 199901L
+#  include <stdint.h>
+#else
+#  define SIZE_MAX ((size_t)-1) /* C89 doesn't have stdint.h or SIZE_MAX */
+#endif
+
+#include "csv.h"
+
+#define VERSION "3.0.3"
+
+#define ROW_NOT_BEGUN           0
+#define FIELD_NOT_BEGUN         1
+#define FIELD_BEGUN             2
+#define FIELD_MIGHT_HAVE_ENDED  3
+
+/*
+  Explanation of states
+  ROW_NOT_BEGUN    There have not been any fields encountered for this row
+  FIELD_NOT_BEGUN  There have been fields but we are currently not in one
+  FIELD_BEGUN      We are in a field
+  FIELD_MIGHT_HAVE_ENDED
+                   We encountered a double quote inside a quoted field, the
+                   field is either ended or the quote is literal
+*/
+
+#define MEM_BLK_SIZE 128
+
+#define SUBMIT_FIELD(p) \
+  do { \
+   if (!quoted) \
+     entry_pos -= spaces; \
+   if (p->options & CSV_APPEND_NULL) \
+     ((p)->entry_buf[entry_pos]) = '\0'; \
+   if (cb1 && (p->options & CSV_EMPTY_IS_NULL) && !quoted && entry_pos == 0) \
+     cb1(NULL, entry_pos, data); \
+   else if (cb1) \
+     cb1(p->entry_buf, entry_pos, data); \
+   pstate = FIELD_NOT_BEGUN; \
+   entry_pos = quoted = spaces = 0; \
+ } while (0)
+
+#define SUBMIT_ROW(p, c) \
+  do { \
+    if (cb2) \
+      cb2(c, data); \
+    pstate = ROW_NOT_BEGUN; \
+    entry_pos = quoted = spaces = 0; \
+  } while (0)
+
+#define SUBMIT_CHAR(p, c) ((p)->entry_buf[entry_pos++] = (c))
+
+static char *csv_errors[] = {"success",
+                             "error parsing data while strict checking enabled",
+                             "memory exhausted while increasing buffer size",
+                             "data size too large",
+                             "invalid status code"};
+
+int
+csv_error(struct csv_parser *p)
+{
+  /* Return the current status of the parser */
+  return p->status;
+}
+
+char *
+csv_strerror(int status)
+{
+  /* Return a textual description of status */
+  if (status >= CSV_EINVALID || status < 0)
+    return csv_errors[CSV_EINVALID];
+  else
+    return csv_errors[status];
+}
+
+int
+csv_get_opts(struct csv_parser *p)
+{
+  /* Return the currently set options of parser */
+  if (p == NULL)
+    return -1;
+
+  return p->options;
+}
+
+int
+csv_set_opts(struct csv_parser *p, unsigned char options)
+{
+  /* Set the options */
+  if (p == NULL)
+    return -1;
+
+  p->options = options;
+  return 0;
+}
+
+int
+csv_init(struct csv_parser *p, unsigned char options)
+{
+  /* Initialize a csv_parser object returns 0 on success, -1 on error */
+  if (p == NULL)
+    return -1;
+
+  p->entry_buf = NULL;
+  p->pstate = ROW_NOT_BEGUN;
+  p->quoted = 0;
+  p->spaces = 0;
+  p->entry_pos = 0;
+  p->entry_size = 0;
+  p->status = 0;
+  p->options = options;
+  p->quote_char = CSV_QUOTE;
+  p->delim_char = CSV_COMMA;
+  p->is_space = NULL;
+  p->is_term = NULL;
+  p->blk_size = MEM_BLK_SIZE;
+  p->malloc_func = NULL;
+  p->realloc_func = realloc;
+  p->free_func = free;
+
+  return 0;
+}
+
+void
+csv_free(struct csv_parser *p)
+{
+  /* Free the entry_buffer of csv_parser object */
+  if (p == NULL)
+    return;
+
+  if (p->entry_buf)
+    p->free_func(p->entry_buf);
+
+  p->entry_buf = NULL;
+  p->entry_size = 0;
+
+  return;
+}
+
+int
+csv_fini(struct csv_parser *p, void (*cb1)(void *, size_t, void *), void (*cb2)(int c, void *), void *data)
+{
+  /* Finalize parsing.  Needed, for example, when file does not end in a newline */
+  int quoted = p->quoted;
+  int pstate = p->pstate;
+  size_t spaces = p->spaces;
+  size_t entry_pos = p->entry_pos;
+
+  if (p == NULL)
+    return -1;
+
+
+  if (p->pstate == FIELD_BEGUN && p->quoted && p->options & CSV_STRICT && p->options & CSV_STRICT_FINI) {
+    /* Current field is quoted, no end-quote was seen, and CSV_STRICT_FINI is set */
+    p->status = CSV_EPARSE;
+    return -1;
+  }
+
+  switch (p->pstate) {
+    case FIELD_MIGHT_HAVE_ENDED:
+      p->entry_pos -= p->spaces + 1;  /* get rid of spaces and original quote */
+      /* Fall-through */
+    case FIELD_NOT_BEGUN:
+    case FIELD_BEGUN:
+      quoted = p->quoted, pstate = p->pstate;
+      spaces = p->spaces, entry_pos = p->entry_pos;
+      SUBMIT_FIELD(p);
+      SUBMIT_ROW(p, -1);
+    case ROW_NOT_BEGUN: /* Already ended properly */
+      ;
+  }
+
+  /* Reset parser */
+  p->spaces = p->quoted = p->entry_pos = p->status = 0;
+  p->pstate = ROW_NOT_BEGUN;
+
+  return 0;
+}
+
+void
+csv_set_delim(struct csv_parser *p, unsigned char c)
+{
+  /* Set the delimiter */
+  if (p) p->delim_char = c;
+}
+
+void
+csv_set_quote(struct csv_parser *p, unsigned char c)
+{
+  /* Set the quote character */
+  if (p) p->quote_char = c;
+}
+
+unsigned char
+csv_get_delim(struct csv_parser *p)
+{
+  /* Get the delimiter */
+  return p->delim_char;
+}
+
+unsigned char
+csv_get_quote(struct csv_parser *p)
+{
+  /* Get the quote character */
+  return p->quote_char;
+}
+
+void
+csv_set_space_func(struct csv_parser *p, int (*f)(unsigned char))
+{
+  /* Set the space function */
+  if (p) p->is_space = f;
+}
+ 
+void
+csv_set_term_func(struct csv_parser *p, int (*f)(unsigned char))
+{
+  /* Set the term function */
+  if (p) p->is_term = f;
+}
+
+void
+csv_set_realloc_func(struct csv_parser *p, void *(*f)(void *, size_t))
+{
+  /* Set the realloc function used to increase buffer size */
+  if (p && f) p->realloc_func = f;
+}
+ 
+void
+csv_set_free_func(struct csv_parser *p, void (*f)(void *))
+{
+  /* Set the free function used to free the buffer */
+  if (p && f) p->free_func = f;
+}
+
+void
+csv_set_blk_size(struct csv_parser *p, size_t size)
+{
+  /* Set the block size used to increment buffer size */
+  if (p) p->blk_size = size;
+}
+
+size_t
+csv_get_buffer_size(struct csv_parser *p)
+{
+  /* Get the size of the entry buffer */
+  if (p)
+    return p->entry_size;
+  return 0;
+}
+ 
+static int
+csv_increase_buffer(struct csv_parser *p)
+{
+  /* Increase the size of the entry buffer.  Attempt to increase size by 
+   * p->blk_size, if this is larger than SIZE_MAX try to increase current
+   * buffer size to SIZE_MAX.  If allocation fails, try to allocate halve 
+   * the size and try again until successful or increment size is zero.
+   */
+
+  size_t to_add = p->blk_size;
+  void *vp;
+
+  if ( p->entry_size >= SIZE_MAX - to_add )
+    to_add = SIZE_MAX - p->entry_size;
+
+  if (!to_add) {
+    p->status = CSV_ETOOBIG;
+    return -1;
+  }
+
+  while ((vp = p->realloc_func(p->entry_buf, p->entry_size + to_add)) == NULL) {
+    to_add /= 2;
+    if (!to_add) {
+      p->status = CSV_ENOMEM;
+      return -1;
+    }
+  }
+
+  /* Update entry buffer pointer and entry_size if successful */
+  p->entry_buf = vp;
+  p->entry_size += to_add;
+  return 0;
+}
+ 
+size_t
+csv_parse(struct csv_parser *p, const void *s, size_t len, void (*cb1)(void *, size_t, void *), void (*cb2)(int c, void *), void *data)
+{
+  unsigned const char *us = s;  /* Access input data as array of unsigned char */
+  unsigned char c;              /* The character we are currently processing */
+  size_t pos = 0;               /* The number of characters we have processed in this call */
+
+  /* Store key fields into local variables for performance */
+  unsigned char delim = p->delim_char;
+  unsigned char quote = p->quote_char;
+  int (*is_space)(unsigned char) = p->is_space;
+  int (*is_term)(unsigned char) = p->is_term;
+  int quoted = p->quoted;
+  int pstate = p->pstate;
+  size_t spaces = p->spaces;
+  size_t entry_pos = p->entry_pos;
+
+
+  if (!p->entry_buf && pos < len) {
+    /* Buffer hasn't been allocated yet and len > 0 */
+    if (csv_increase_buffer(p) != 0) { 
+      p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;
+      return pos;
+    }
+  }
+
+  while (pos < len) {
+    /* Check memory usage, increase buffer if neccessary */
+    if (entry_pos == ((p->options & CSV_APPEND_NULL) ? p->entry_size - 1 : p->entry_size) ) {
+      if (csv_increase_buffer(p) != 0) {
+        p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;
+        return pos;
+      }
+    }
+
+    c = us[pos++];
+
+    switch (pstate) {
+      case ROW_NOT_BEGUN:
+      case FIELD_NOT_BEGUN:
+        if ((is_space ? is_space(c) : c == CSV_SPACE || c == CSV_TAB) && c!=delim) { /* Space or Tab */
+          continue;
+        } else if (is_term ? is_term(c) : c == CSV_CR || c == CSV_LF) { /* Carriage Return or Line Feed */
+          if (pstate == FIELD_NOT_BEGUN) {
+            SUBMIT_FIELD(p);
+            SUBMIT_ROW(p, (unsigned char)c); 
+          } else {  /* ROW_NOT_BEGUN */
+            /* Don't submit empty rows by default */
+            if (p->options & CSV_REPALL_NL) {
+              SUBMIT_ROW(p, (unsigned char)c);
+            }
+          }
+          continue;
+        } else if (c == delim) { /* Comma */
+          SUBMIT_FIELD(p);
+          break;
+        } else if (c == quote) { /* Quote */
+          pstate = FIELD_BEGUN;
+          quoted = 1;
+        } else {               /* Anything else */
+          pstate = FIELD_BEGUN;
+          quoted = 0;
+          SUBMIT_CHAR(p, c);
+        }
+        break;
+      case FIELD_BEGUN:
+        if (c == quote) {         /* Quote */
+          if (quoted) {
+            SUBMIT_CHAR(p, c);
+            pstate = FIELD_MIGHT_HAVE_ENDED;
+          } else {
+            /* STRICT ERROR - double quote inside non-quoted field */
+            if (p->options & CSV_STRICT) {
+              p->status = CSV_EPARSE;
+              p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;
+              return pos-1;
+            }
+            SUBMIT_CHAR(p, c);
+            spaces = 0;
+          }
+        } else if (c == delim) {  /* Comma */
+          if (quoted) {
+            SUBMIT_CHAR(p, c);
+          } else {
+            SUBMIT_FIELD(p);
+          }
+        } else if (is_term ? is_term(c) : c == CSV_CR || c == CSV_LF) {  /* Carriage Return or Line Feed */
+          if (!quoted) {
+            SUBMIT_FIELD(p);
+            SUBMIT_ROW(p, (unsigned char)c);
+          } else {
+            SUBMIT_CHAR(p, c);
+          }
+        } else if (!quoted && (is_space? is_space(c) : c == CSV_SPACE || c == CSV_TAB)) { /* Tab or space for non-quoted field */
+            SUBMIT_CHAR(p, c);
+            spaces++;
+        } else {  /* Anything else */
+          SUBMIT_CHAR(p, c);
+          spaces = 0;
+        }
+        break;
+      case FIELD_MIGHT_HAVE_ENDED:
+        /* This only happens when a quote character is encountered in a quoted field */
+        if (c == delim) {  /* Comma */
+          entry_pos -= spaces + 1;  /* get rid of spaces and original quote */
+          SUBMIT_FIELD(p);
+        } else if (is_term ? is_term(c) : c == CSV_CR || c == CSV_LF) {  /* Carriage Return or Line Feed */
+          entry_pos -= spaces + 1;  /* get rid of spaces and original quote */
+          SUBMIT_FIELD(p);
+          SUBMIT_ROW(p, (unsigned char)c);
+        } else if (is_space ? is_space(c) : c == CSV_SPACE || c == CSV_TAB) {  /* Space or Tab */
+          SUBMIT_CHAR(p, c);
+          spaces++;
+        } else if (c == quote) {  /* Quote */
+          if (spaces) {
+            /* STRICT ERROR - unescaped double quote */
+            if (p->options & CSV_STRICT) {
+              p->status = CSV_EPARSE;
+              p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;
+              return pos-1;
+            }
+            spaces = 0;
+            SUBMIT_CHAR(p, c);
+          } else {
+            /* Two quotes in a row */
+            pstate = FIELD_BEGUN;
+          }
+        } else {  /* Anything else */
+          /* STRICT ERROR - unescaped double quote */
+          if (p->options & CSV_STRICT) {
+            p->status = CSV_EPARSE;
+            p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;
+            return pos-1;
+          }
+          pstate = FIELD_BEGUN;
+          spaces = 0;
+          SUBMIT_CHAR(p, c);
+        }
+        break;
+     default:
+       break;
+    }
+  }
+  p->quoted = quoted, p->pstate = pstate, p->spaces = spaces, p->entry_pos = entry_pos;
+  return pos;
+}
+
+size_t
+csv_write (void *dest, size_t dest_size, const void *src, size_t src_size)
+{
+  unsigned char *cdest = dest;
+  const unsigned char *csrc = src;
+  size_t chars = 0;
+
+  if (src == NULL)
+    return 0;
+
+  if (cdest == NULL)
+    dest_size = 0;
+
+  if (dest_size > 0)
+    *cdest++ = '"';
+  chars++;
+
+  while (src_size) {
+    if (*csrc == '"') {
+      if (dest_size > chars)
+        *cdest++ = '"';
+      if (chars < SIZE_MAX) chars++;
+    }
+    if (dest_size > chars)
+      *cdest++ = *csrc;
+    if (chars < SIZE_MAX) chars++;
+    src_size--;
+    csrc++;
+  }
+
+  if (dest_size > chars)
+    *cdest = '"';
+  if (chars < SIZE_MAX) chars++;
+
+  return chars;
+}
+
+int
+csv_fwrite (FILE *fp, const void *src, size_t src_size)
+{
+  const unsigned char *csrc = src;
+
+  if (fp == NULL || src == NULL)
+    return 0;
+
+  if (fputc('"', fp) == EOF)
+    return EOF;
+
+  while (src_size) {
+    if (*csrc == '"') {
+      if (fputc('"', fp) == EOF)
+        return EOF;
+    }
+    if (fputc(*csrc, fp) == EOF)
+      return EOF;
+    src_size--;
+    csrc++;
+  }
+
+  if (fputc('"', fp) == EOF) {
+    return EOF;
+  }
+
+  return 0;
+}
+
+size_t
+csv_write2 (void *dest, size_t dest_size, const void *src, size_t src_size, unsigned char quote)
+{
+  unsigned char *cdest = dest;
+  const unsigned char *csrc = src;
+  size_t chars = 0;
+
+  if (src == NULL)
+    return 0;
+
+  if (dest == NULL)
+    dest_size = 0;
+
+  if (dest_size > 0)
+    *cdest++ = quote;
+  chars++;
+
+  while (src_size) {
+    if (*csrc == quote) {
+      if (dest_size > chars)
+        *cdest++ = quote;
+      if (chars < SIZE_MAX) chars++;
+    }
+    if (dest_size > chars)
+      *cdest++ = *csrc;
+    if (chars < SIZE_MAX) chars++;
+    src_size--;
+    csrc++;
+  }
+
+  if (dest_size > chars)
+    *cdest = quote;
+  if (chars < SIZE_MAX) chars++;
+
+  return chars;
+}
+
+int
+csv_fwrite2 (FILE *fp, const void *src, size_t src_size, unsigned char quote)
+{
+  const unsigned char *csrc = src;
+
+  if (fp == NULL || src == NULL)
+    return 0;
+
+  if (fputc(quote, fp) == EOF)
+    return EOF;
+
+  while (src_size) {
+    if (*csrc == quote) {
+      if (fputc(quote, fp) == EOF)
+        return EOF;
+    }
+    if (fputc(*csrc, fp) == EOF)
+      return EOF;
+    src_size--;
+    csrc++;
+  }
+
+  if (fputc(quote, fp) == EOF) {
+    return EOF;
+  }
+
+  return 0;
+}

--- a/src/csv/strerror.cpp
+++ b/src/csv/strerror.cpp
@@ -1,0 +1,81 @@
+/*
+Copyright (C) 2014 Jay Satiro <raysatiro@yahoo.com>
+All rights reserved.
+
+This file is part of CSV/jay::util.
+
+https://github.com/jay/CSV
+
+jay::util is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+jay::util is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with jay::util. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** Error to string functions
+*/
+
+#include "strerror.hpp"
+
+#include <fstream>
+#include <list>
+#include <sstream>
+#include <string>
+#include <vector>
+
+
+using namespace std;
+
+
+namespace jay {
+namespace util {
+
+
+string ios_strerror( ios::iostate state )
+{
+    if( !state )
+        return "No errors";
+
+    string s;
+
+    if( ( state & ios::eofbit ) )
+    {
+        if( s.length() )
+            s += ", ";
+
+        s += "EOF on input operation";
+    }
+
+    if( ( state & ios::failbit ) )
+    {
+        if( s.length() )
+            s += ", ";
+
+        s += "Logical error on i/o operation";
+    }
+
+    if( ( state & ios::badbit ) )
+    {
+        if( s.length() )
+            s += ", ";
+
+        s += "Read/write error on i/o operation";
+    }
+
+    if( !s.length() )
+        s = "Unknown error";
+
+    return s;
+}
+
+
+} // namespace util
+} // namespace jay

--- a/src/csv/strerror.hpp
+++ b/src/csv/strerror.hpp
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2014 Jay Satiro <raysatiro@yahoo.com>
+All rights reserved.
+
+This file is part of CSV/jay::util.
+
+https://github.com/jay/CSV
+
+jay::util is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+jay::util is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with jay::util. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef JAY_UTIL_STRERROR_HPP_
+#define JAY_UTIL_STRERROR_HPP_
+
+#include <ios>
+#include <string>
+
+
+namespace jay {
+namespace util {
+
+
+// Returns an iostate error message.
+std::string ios_strerror( std::ios::iostate state );
+
+
+} // namespace util
+} // namespace jay
+#endif // JAY_UTIL_STRERROR_HPP_

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -108,3 +108,61 @@ std::string FormatISO8601Time(int64_t nTime) {
 #endif
     return strprintf("%02i:%02i:%02iZ", ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
+
+uint64_t ISO8601Date_Now()
+{
+     time_t rawtime;
+     time ( &rawtime );
+
+     return (uint64_t) rawtime;
+}
+
+uint64_t ISO8601Date_FromString(const std::string& dateString)
+{
+    int year;
+    int month;
+    int day;
+    int hour;
+    int minute;
+    sscanf(dateString.c_str(), "%d-%d-%d:%d:%d", &year, &month, &day, &hour, &minute);
+    tm time;
+    time.tm_year = year - 1900; // Year since 1900
+    time.tm_mon = month - 1;    // 0-11
+    time.tm_mday = day;         // 1-31
+    time.tm_hour = hour;        // 0-23
+    time.tm_min = minute;       // 0-59
+    time.tm_sec = 0;
+    time_t rawtime = mktime(&time);
+    return (uint64_t)rawtime;
+}
+
+bool ISO8601Date_Validate(const std::string& dateString)
+{
+    int year;
+    int month;
+    int day;
+    int hour;
+    int minute;
+    sscanf(dateString.c_str(), "%d-%d-%d:%d:%d", &year, &month, &day, &hour, &minute);
+    if (year < 1900)
+        return false;
+    if (month < 1 || month > 12)
+        return false;
+    if (day < 1)
+        return false;
+    if ( (month == 1 || month == 3 || month == 5 || month == 7 || month == 9 || month == 11) && day > 31 )
+        return false;
+    if ( (month == 4 || month == 6 || month == 8 || month == 10 || month == 12) && day > 30 )
+        return false;
+    if ( (month == 2) && (year % 400 == 0 || (year % 4 == 0 && year % 100 != 0) && (day != 29) ) )
+        return false;
+    else if ( month == 2 && day > 28)
+        return false;
+    if (hour > 24)
+        return false;
+    if (minute > 60)
+        return false;
+
+    return true;
+}
+

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -34,5 +34,7 @@ void MilliSleep(int64_t n);
 std::string FormatISO8601DateTime(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
 std::string FormatISO8601Time(int64_t nTime);
-
+uint64_t ISO8601Date_Now();
+uint64_t ISO8601Date_FromString(const std::string& dateString);
+bool ISO8601Date_Validate(const std::string& dateString);
 #endif // BITCOIN_UTILTIME_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <csv/CSV.hpp>
 #include <httpserver.h>
 #include <validation.h>
 #include <key_io.h>
@@ -47,6 +48,60 @@
 
 #include <functional>
 #include <boost/assign.hpp>
+
+// This enumeration determines the order of the CSV file header columns
+typedef enum
+{
+    TRANSACTION_CSV_FIELD_DATETIME_HUMAN_READABLE,
+    TRANSACTION_CSV_FIELD_ACCOUNT,
+    TRANSACTION_CSV_FIELD_ADDRESS,
+    TRANSACTION_CSV_FIELD_CATEGORY,
+    TRANSACTION_CSV_FIELD_AMOUNT,
+    TRANSACTION_CSV_FIELD_LABEL,
+    TRANSACTION_CSV_FIELD_VOUT,
+    TRANSACTION_CSV_FIELD_FEE,
+    TRANSACTION_CSV_FIELD_CONFIRMATION,
+    TRANSACTION_CSV_FIELD_GENERATED,
+    TRANSACTION_CSV_FIELD_BLOCKHASH,
+    TRANSACTION_CSV_FIELD_BLOCKINDEX,
+    TRANSACTION_CSV_FIELD_BLOCKTIME,
+    TRANSACTION_CSV_FIELD_TRUSTED,
+    TRANSACTION_CSV_FIELD_WALLETCONFLICTS,
+    TRANSACTION_CSV_FIELD_TXID,
+    TRANSACTION_CSV_FIELD_TIME,
+    TRANSACTION_CSV_FIELD_TIMERECEIVED,
+    TRANSACTION_CSV_FIELD_COMPUTETIME,
+    TRANSACTION_CSV_FIELD_BIP125_REPLACEABLE,
+    TRANSACTION_CSV_FIELD_ABANDONED,
+    TRANSACTION_CSV_FIELD_WATCHONLY,
+    TRANSACTION_CSV_FIELD_COUNT
+} TRANSACTION_CSV_FIELDS;
+
+const std::map<TRANSACTION_CSV_FIELDS, std::string> CSV_HEADERS =
+{
+    {TRANSACTION_CSV_FIELD_DATETIME_HUMAN_READABLE, "date"},
+    {TRANSACTION_CSV_FIELD_ACCOUNT, "account"},
+    {TRANSACTION_CSV_FIELD_ADDRESS, "address"},
+    {TRANSACTION_CSV_FIELD_CATEGORY, "category"},
+    {TRANSACTION_CSV_FIELD_AMOUNT, "amount"},
+    {TRANSACTION_CSV_FIELD_LABEL, "label"},
+    {TRANSACTION_CSV_FIELD_VOUT, "vout"},
+    {TRANSACTION_CSV_FIELD_FEE, "fee"},
+    {TRANSACTION_CSV_FIELD_CONFIRMATION, "confirmation"},
+    {TRANSACTION_CSV_FIELD_GENERATED, "generated"},
+    {TRANSACTION_CSV_FIELD_BLOCKHASH, "blockhash"},
+    {TRANSACTION_CSV_FIELD_BLOCKINDEX, "blockindex"},
+    {TRANSACTION_CSV_FIELD_BLOCKTIME, "blocktime"},
+    {TRANSACTION_CSV_FIELD_TRUSTED, "trusted"},
+    {TRANSACTION_CSV_FIELD_WALLETCONFLICTS, "conflicts"},
+    {TRANSACTION_CSV_FIELD_TXID, "txid"},
+    {TRANSACTION_CSV_FIELD_TIME, "time"},
+    {TRANSACTION_CSV_FIELD_TIMERECEIVED, "timereceived"},
+    {TRANSACTION_CSV_FIELD_COMPUTETIME, "computetime"},
+    {TRANSACTION_CSV_FIELD_BIP125_REPLACEABLE, "bip125-replaceable"},
+    {TRANSACTION_CSV_FIELD_ABANDONED, "abandoned"},
+    {TRANSACTION_CSV_FIELD_WATCHONLY, "watchonly"},
+};
 
 std::string GetDestType(CTxDestination dest) {
     if (dest.type() == typeid(CNoDestination))
@@ -162,6 +217,53 @@ static void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     for (const std::pair<const std::string, std::string>& item : wtx.mapValue)
         entry.pushKV(item.first, item.second);
 }
+
+static void WalletTxToCsv(std::vector<std::string>& csvRecord, const CWalletTx& wtx)
+{
+    int confirms = wtx.GetDepthInMainChain();
+    csvRecord[TRANSACTION_CSV_FIELD_CONFIRMATION] = std::to_string(confirms);
+    if (wtx.IsCoinBase())
+        csvRecord[TRANSACTION_CSV_FIELD_GENERATED] = "true";
+    if (confirms > 0)
+    {
+        csvRecord[TRANSACTION_CSV_FIELD_BLOCKHASH] = wtx.hashBlock.GetHex();
+        csvRecord[TRANSACTION_CSV_FIELD_BLOCKINDEX] = std::to_string(wtx.nIndex);
+        csvRecord[TRANSACTION_CSV_FIELD_BLOCKTIME] = std::to_string(LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
+    }
+    else
+    {
+        csvRecord[TRANSACTION_CSV_FIELD_TRUSTED] = wtx.IsTrusted() ? "true" : "false";
+    }
+
+    uint256 hash = wtx.GetHash();
+    csvRecord[TRANSACTION_CSV_FIELD_TXID] = hash.GetHex();
+
+    std::string conflicts = "";
+    for (const uint256& conflict : wtx.GetConflicts())
+    {
+        conflicts += conflict.GetHex();
+        conflicts += ",";
+    }
+    csvRecord[TRANSACTION_CSV_FIELD_WALLETCONFLICTS] = conflicts;
+    csvRecord[TRANSACTION_CSV_FIELD_TIME] = std::to_string(wtx.GetTxTime());
+    csvRecord[TRANSACTION_CSV_FIELD_DATETIME_HUMAN_READABLE] = FormatISO8601DateTime(wtx.GetTxTime());
+    csvRecord[TRANSACTION_CSV_FIELD_TIMERECEIVED] = std::to_string(wtx.nTimeReceived);
+    csvRecord[TRANSACTION_CSV_FIELD_COMPUTETIME] = std::to_string(wtx.nComputeTime);
+
+    // Add opt-in RBF status
+    std::string rbfStatus = "no";
+    if (confirms <= 0) {
+        LOCK(mempool.cs);
+        RBFTransactionState rbfState = IsRBFOptIn(*wtx.tx, mempool);
+        if (rbfState == RBFTransactionState::UNKNOWN)
+            rbfStatus = "unknown";
+        else if (rbfState == RBFTransactionState::REPLACEABLE_BIP125)
+            rbfStatus = "yes";
+    }
+    csvRecord[TRANSACTION_CSV_FIELD_BIP125_REPLACEABLE] = rbfStatus;
+}
+
+
 
 static std::string LabelFromValue(const UniValue& value)
 {
@@ -2031,13 +2133,6 @@ static UniValue listreceivedbylabel(const JSONRPCRequest& request)
     return ListReceived(pwallet, request.params, true);
 }
 
-static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
-{
-    if (IsValidDestination(dest)) {
-        entry.pushKV("address", EncodeDestination(dest));
-    }
-}
-
 /**
  * List transactions based on the given criteria.
  *
@@ -2067,15 +2162,14 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const
         for (const COutputEntry& s : listSent)
         {
             UniValue entry(UniValue::VOBJ);
-            if (involvesWatchonly || (::IsMine(*pwallet, s.destination) & ISMINE_WATCH_ONLY)) {
+            if (involvesWatchonly || (::IsMine(*pwallet, s.destination) & ISMINE_WATCH_ONLY))
                 entry.pushKV("involvesWatchonly", true);
-            }
-            MaybePushAddress(entry, s.destination);
+            if (IsValidDestination(s.destination))
+                entry.pushKV("address", EncodeDestination(s.destination));
             entry.pushKV("category", "send");
             entry.pushKV("amount", ValueFromAmount(-s.amount));
-            if (pwallet->mapAddressBook.count(s.destination)) {
+            if (pwallet->mapAddressBook.count(s.destination))
                 entry.pushKV("label", pwallet->mapAddressBook[s.destination].name);
-            }
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong)
@@ -2091,17 +2185,23 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const
         for (const COutputEntry& r : listReceived)
         {
             std::string account;
-            if (pwallet->mapAddressBook.count(r.destination)) {
+            if (pwallet->mapAddressBook.count(r.destination))
                 account = pwallet->mapAddressBook[r.destination].name;
-            }
             if (fAllAccounts || (account == strAccount))
             {
                 UniValue entry(UniValue::VOBJ);
-                if (involvesWatchonly || (::IsMine(*pwallet, r.destination) & ISMINE_WATCH_ONLY)) {
+                if (involvesWatchonly || (::IsMine(*pwallet, r.destination) & ISMINE_WATCH_ONLY))
                     entry.pushKV("involvesWatchonly", true);
+                if (IsDeprecatedRPCEnabled("accounts")) 
+                    entry.pushKV("account", account);
+                if (IsValidDestination(r.destination))
+                {
+                    auto item = pwallet->mapAddressBook.find(r.destination);
+                    if (item->first.type() == typeid(CKeyID))
+                        entry.pushKV("address", EncodeDestination(r.destination, false));
+                    else
+                        entry.pushKV("address", EncodeDestination(r.destination));
                 }
-                if (IsDeprecatedRPCEnabled("accounts")) entry.pushKV("account", account);
-                MaybePushAddress(entry, r.destination);
                 if (wtx.IsCoinBase())
                 {
                     if (wtx.GetDepthInMainChain() < 1)
@@ -2116,9 +2216,8 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const
                     entry.pushKV("category", "receive");
                 }
                 entry.pushKV("amount", ValueFromAmount(r.amount));
-                if (pwallet->mapAddressBook.count(r.destination)) {
+                if (pwallet->mapAddressBook.count(r.destination))
                     entry.pushKV("label", account);
-                }
                 entry.pushKV("vout", r.vout);
                 if (fLong)
                     WalletTxToJSON(wtx, entry);
@@ -2284,7 +2383,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
         {
             CWalletTx *const pwtx = (*it).second;
             if (pwtx != nullptr)
-                ListTransactions(pwallet, *pwtx, "", 0, true, retReversed, filter);
+                ListTransactions(pwallet, *pwtx, strAccount, 0, true, retReversed, filter);
 
             if ((int)retReversed.size() >= nCount + nFrom)
                 break;
@@ -2315,6 +2414,330 @@ UniValue listtransactions(const JSONRPCRequest& request)
     retReversed.push_backV(arrTmp);
 
     return retReversed;
+}
+
+static void String_Tokenize(std::string const &str, const char delim, std::vector<std::string> &out)
+{
+    size_t start;
+    size_t end = 0;
+
+    while ((start = str.find_first_not_of(delim, end)) != std::string::npos)
+    {
+        end = str.find(delim, start);
+        out.push_back(str.substr(start, end - start));
+    }
+}
+
+static bool IsExportableTransaction(std::vector<std::string>& record, std::vector<std::string>& transactionFilters)
+{
+    bool exportable = transactionFilters.empty();
+    for (uint16_t i = 0; !exportable && i < transactionFilters.size(); ++i)
+    {
+        exportable = std::find(record.begin(), record.end(), transactionFilters[i]) != record.end();
+    }
+
+    return exportable;
+}
+
+
+/**
+ * Export transactions based on the given criteria.
+ *
+ * @param  pwallet              The wallet.
+ * @param  wtx                  The wallet transaction.
+ * @param  strAccount           The account, if any, or "*" for all.
+ * @param  csvWrite             The minimum confirmation depth.
+ * @param  fLong                Whether to include the details of the transaction.
+ * @param  transactionFilters   List of transaction filters
+ * @param  ismineFilter         The "is mine" filter bool.
+ */
+static void ExportTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount,
+        jay::util::CSVwrite& csv_write, bool fLong, std::vector<std::string>& transactionFilters, const isminefilter& ismineFilter)
+{
+    CAmount nFee;
+    std::string dummy_account;
+    std::list<COutputEntry> listReceived;
+    std::list<COutputEntry> listSent;
+
+    wtx.GetAmounts(listReceived, listSent, nFee, ismineFilter);
+
+    bool fAllAccounts = (strAccount == std::string("*"));
+    bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
+
+    // Sent
+    if ((!listSent.empty() || nFee != 0))
+    {
+        for (auto s = listSent.rbegin(); s != listSent.rend(); ++s)
+        {
+            std::vector<std::string> csvRecord(TRANSACTION_CSV_FIELD_COUNT);
+            if (involvesWatchonly || (::IsMine(*pwallet, s->destination) & ISMINE_WATCH_ONLY))
+                csvRecord[TRANSACTION_CSV_FIELD_WATCHONLY] = "true";
+            if ( IsValidDestination(s->destination) )
+                csvRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(s->destination);
+            csvRecord[TRANSACTION_CSV_FIELD_CATEGORY] = "send";
+            csvRecord[TRANSACTION_CSV_FIELD_AMOUNT] = ValueFromAmount(-s->amount).getValStr();
+            if (pwallet->mapAddressBook.count(s->destination))
+                csvRecord[TRANSACTION_CSV_FIELD_LABEL] = pwallet->mapAddressBook[s->destination].name;
+            csvRecord[TRANSACTION_CSV_FIELD_VOUT] = std::to_string(s->vout);
+            csvRecord[TRANSACTION_CSV_FIELD_FEE] = ValueFromAmount(-nFee).getValStr();
+            WalletTxToCsv(csvRecord, wtx);
+            if (wtx.isAbandoned())
+                csvRecord[TRANSACTION_CSV_FIELD_ABANDONED] = true;
+            if (IsExportableTransaction(csvRecord, transactionFilters))
+                csv_write.WriteRecord(csvRecord, true);
+        }
+    }
+
+    // Received
+    if (listReceived.size() > 0 /*&& wtx.GetDepthInMainChain() >= nMinDepth*/)
+    {
+        for (auto r = listReceived.rbegin(); r != listReceived.rend(); ++r)
+        {
+            std::string account;
+            if (pwallet->mapAddressBook.count(r->destination))
+                account = pwallet->mapAddressBook[r->destination].name;
+            if (fAllAccounts || (account == strAccount))
+            {
+                std::vector<std::string> csvRecord(TRANSACTION_CSV_FIELD_COUNT);
+                if (involvesWatchonly || (::IsMine(*pwallet, r->destination) & ISMINE_WATCH_ONLY))
+                    csvRecord[TRANSACTION_CSV_FIELD_WATCHONLY] = "true";
+                if(IsDeprecatedRPCEnabled("accounts"))
+                    csvRecord[TRANSACTION_CSV_FIELD_ACCOUNT] = account;
+                if ( IsValidDestination(r->destination) )
+                {
+                    auto item = pwallet->mapAddressBook.find(r->destination);
+                    if (item->first.type() == typeid(CKeyID))
+                        csvRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(r->destination, false);
+                    else
+                        csvRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(r->destination);
+                }
+                if (wtx.IsCoinBase())
+                {
+                    if (wtx.GetDepthInMainChain() < 1)
+                        csvRecord[TRANSACTION_CSV_FIELD_CATEGORY] = "orphan";
+                    else if (wtx.GetBlocksToMaturity() > 0)
+                        csvRecord[TRANSACTION_CSV_FIELD_CATEGORY] = "immature";
+                    else
+                        csvRecord[TRANSACTION_CSV_FIELD_CATEGORY] = "generate";
+                }
+                else
+                {
+                    csvRecord[TRANSACTION_CSV_FIELD_CATEGORY] = "receive";
+                }
+                csvRecord[TRANSACTION_CSV_FIELD_AMOUNT] = ValueFromAmount(r->amount).getValStr();
+                if (pwallet->mapAddressBook.count(r->destination))
+                    csvRecord[TRANSACTION_CSV_FIELD_LABEL] = account;
+                csvRecord[TRANSACTION_CSV_FIELD_VOUT] = std::to_string(r->vout);
+                WalletTxToCsv(csvRecord, wtx);
+                if (IsExportableTransaction(csvRecord, transactionFilters)) {
+                    csv_write.WriteRecord(csvRecord, true);
+
+                    // Basecoin sent transactions are nested here
+					// This section currently assumes that for the sent transaction:
+                    // 1. The "data" type (transaction fee) is the first record
+                    // 2. Each basecoin record denotes a subtotal of the entire amount sent
+                    // If these assumptions are untrue then te code needs to be reevaluated
+                    std::vector<std::string> csvSubRecord(TRANSACTION_CSV_FIELD_COUNT);
+                    for (unsigned int i = 0; i < wtx.tx->vpout.size(); ++i) {
+                        auto pout = wtx.tx->vpout[i];
+                        bool fIsMyOutput = pwallet->IsMine(pout.get());
+
+                        switch(pout->GetType())
+                        {
+                        case OUTPUT_DATA:
+                        {
+                            // This typically denotes the transaction fee and is the first record
+                            CTxOutData* outData = (CTxOutData*)pout.get();
+                            CAmount nFeeData;
+                            if (outData->GetCTFee(nFeeData)) {
+                                csvSubRecord[TRANSACTION_CSV_FIELD_FEE] = FormatMoney(nFeeData);
+                            }
+                            break;
+                        }
+
+                        case OUTPUT_STANDARD:
+                            if (!fIsMyOutput) {
+                                if (pout->IsZerocoinMint()) {
+                                    // Do nothing
+                                } else { // basecoin
+                                    CTxDestination dest;
+                                    if (ExtractDestination(*pout->GetPScriptPubKey(), dest)) {
+                                        csvSubRecord[TRANSACTION_CSV_FIELD_CATEGORY] = "send";
+                                        csvSubRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(dest, true);
+                                        csvSubRecord[TRANSACTION_CSV_FIELD_AMOUNT] = FormatMoney(pout->GetValue());
+                                        WalletTxToCsv(csvSubRecord, wtx);
+                                        csv_write.WriteRecord(csvSubRecord, true);
+                                    }
+                                }
+                            }
+                            break;
+
+                        default:
+                            // Do nothing
+                            break;
+                        } // switch
+                    } // for
+                } // if
+            }
+        }
+    }
+}
+
+
+static UniValue exporttransactions(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    std::string help_text {};
+    if (!IsDeprecatedRPCEnabled("accounts")) {
+        help_text = "exporttransactions (dummy filename start end filter include_watchonly)\n"
+            "\nExports transactions between 'start' date and 'end' date matching 'categories' to a CSV file.\n"
+            "Note: To export from a specified \"account\", restart veild with -deprecatedrpc=accounts and\n"
+            "use this RPC with an \"account\" argument\n"
+            "\nArguments:\n"
+            "1. \"dummy\"      (string, optional) If set, should be \"*\" for backwards compatibility.\n"
+            "2. \"filename\"   (string, optional) The filename with path (either absolute or relative to veild) [default=<datadir>/export/transactions.csv].\n"
+            "3. \"start\"      (string, optional) The start date in the format YYYY-MM-DD [default=beginning of ISO8601 time].\n"
+            "4. \"end\"        (string, optional) The end date in the format YYYY-MM-DD\n [default=present time]."
+            "5. \"filter\"     (string, optional) A pipe(|) separated transaction filter [default=no filter]\n"
+            "   Allowable filter words TBD\n"
+            "6. include_watchonly (bool, optional, default=false) Include transactions to watch-only addresses (see 'importaddress')\n"
+            "\nResult:\n"
+            "[\n"
+            "  {\n"
+            "  \"filename\" : {        (string) The output filename with full absolute path\n"
+            "  }\n"
+            "]\n"
+
+            "\nExamples:\n"
+            "\nList all transactions\n"
+            + HelpExampleCli("exporttransactions", "") +
+            "\nList transactions over a date range\n"
+            + HelpExampleCli("exporttransactions", "\"*\" \"\" 2020-01-01 2020-12-31") +
+            "\nAs a json rpc call\n"
+            + HelpExampleRpc("exporttransactions", "\"*\", \"\", 2020-01-01, 2020-12-31");
+    } else {
+        help_text = "exporttransactions ( \"account\" filename start end filter include_watchonly)\n"
+            "\nExports transactions between 'start' date and 'end' date matching 'categories' to a CSV file for 'account'.\n"
+            "\nArguments:\n"
+            "1. \"dummy\"      (string, optional) If set, should be \"*\" for backwards compatibility.\n"
+            "2. \"filename\"   (string, optional) The filename with path (either absolute or relative to veild) [default=<datadir>/export/transactions.csv].\n"
+            "3. \"start\"      (string, optional) The start date in the format YYYY-MM-DD [default=beginning of ISO8601 time].\n"
+            "4. \"end\"        (string, optional) The end date in the format YYYY-MM-DD\n [default=present time]."
+            "5. \"filter\"     (string, optional) A pipe(|) separated transaction filter [default=no filter]\n"
+            "   Allowable filter words TBD\n"
+            "6. include_watchonly (bool, optional, default=false) Include transactions to watch-only addresses (see 'importaddress')\n"
+            "\nResult:\n"
+            "[\n"
+            "  {\n"
+            "    \"filename\" : {        (string) The output filename with full absolute path\n"
+            "  }\n"
+            "]\n"
+
+            "\nExamples:\n"
+            "\nList all transactions\n"
+            + HelpExampleCli("exporttransactions", "") +
+            "\nList transactions over a date range\n"
+            + HelpExampleCli("exporttransactions", "\"*\" \"\" 2020-01-01 2020-12-31") +
+            "\nAs a json rpc call\n"
+            + HelpExampleRpc("exporttransactions", "\"*\", \"\", 2020-01-01, 2020-12-31");
+    }
+    if (request.fHelp || request.params.size() > 6)
+        throw std::runtime_error(help_text);
+
+    // Make sure the results are valid at least up to the most recent block
+    // the user could have gotten from another RPC command prior to now
+    pwallet->BlockUntilSyncedToCurrentChain();
+
+    // Determine export account
+    std::string strAccount = "*";
+    if (!request.params[0].isNull()) {
+        strAccount = request.params[0].get_str();
+        if (!IsDeprecatedRPCEnabled("accounts") && strAccount != "*") {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Dummy value must be set to \"*\"");
+        }
+    }
+
+    // Determine export path
+    const fs::path DEFAULT_EXPORT_DIR = GetDataDir() / "export";
+    const fs::path DEFAULT_EXPORT_PATH = DEFAULT_EXPORT_DIR / "transactions.csv";
+    std::string exportPath =
+                    (!request.params[1].isNull() && !request.params[1].get_str().empty()) ?
+                        request.params[1].get_str() : DEFAULT_EXPORT_PATH.string();
+    fs::path exportDir = fs::path(exportPath).parent_path();
+    if (!exportDir.string().empty() && !fs::exists(exportDir)) {
+        if (!fs::create_directories(exportDir))
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot create export directory " + exportDir.string());
+    }
+
+    // Determine export start and end dates
+    std::string startDateString = !request.params[2].isNull() ? request.params[2].get_str() : "";
+    std::string endDateString = !request.params[3].isNull() ? request.params[3].get_str() : "";
+    if (startDateString != "")
+         startDateString += ":00:00";
+    if (endDateString != "")
+       endDateString += ":00:00";
+    if (startDateString != "" && !ISO8601Date_Validate(startDateString))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "start date format is invalid:" + startDateString);
+    if (endDateString != "" && !ISO8601Date_Validate(endDateString))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "end date format is invalid:" + endDateString);
+    uint64_t startDate = 0;
+    uint64_t endDate = ISO8601Date_Now();
+    if (startDateString != "")
+        startDate = ISO8601Date_FromString(startDateString);
+    if (endDateString != "")
+        endDate = ISO8601Date_FromString(endDateString);
+
+    // Prepare transaction filter
+     std::string transactionFilterString = !request.params[4].isNull() ? request.params[4].get_str() : "";
+     vector<std::string> transactionFilters;
+     String_Tokenize(transactionFilterString, '|', transactionFilters);
+
+     // Prepare watchonly filter
+    isminefilter ismineFilter = ISMINE_SPENDABLE;
+    if(!request.params[5].isNull())
+        if(request.params[5].get_bool())
+            ismineFilter = ismineFilter | ISMINE_WATCH_ONLY;
+
+    // Create CSV file
+    jay::util::CSVwrite csv_write;
+    if (!csv_write.Open( exportPath, jay::util::CSVwrite::Flags::truncate ))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open transactions export file " + exportPath);
+    for (uint8_t field = 0; field < TRANSACTION_CSV_FIELD_COUNT; ++field)
+    {
+        csv_write.WriteField(CSV_HEADERS.at((TRANSACTION_CSV_FIELDS)field), false);
+    }
+    csv_write.WriteTerminator();
+
+    {
+        LOCK2(cs_main, pwallet->cs_wallet);
+        const CWallet::TxItems &txOrdered = pwallet->wtxOrdered;
+
+        for (CWallet::TxItems::const_iterator it = txOrdered.begin(); it != txOrdered.end(); ++it)
+        {
+            CWalletTx *const pwtx = (*it).second;
+            if (pwtx == nullptr)
+                continue;
+            if (pwtx->GetTxTime() < startDate)
+                continue;
+            if (pwtx->GetTxTime() > endDate)
+                break;
+            ExportTransactions(pwallet, *pwtx, strAccount, csv_write, true, transactionFilters, ismineFilter);
+        }
+    }
+
+    if (!csv_write.Close())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot close transactions export file " + exportPath);
+
+    UniValue reply(UniValue::VOBJ);
+    reply.pushKV("filename", exportPath);
+
+    return reply;
 }
 
 static UniValue listsinceblock(const JSONRPCRequest& request)
@@ -5563,6 +5986,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "dumpprivkey",                      &dumpprivkey,                   {"address"}  },
     { "wallet",             "dumpwallet",                       &dumpwallet,                    {"filename"} },
     { "wallet",             "encryptwallet",                    &encryptwallet,                 {"passphrase"} },
+    { "wallet",             "exporttransactions",               &exporttransactions,            {"account", "filename", "start", "end", "transactions"} },
     { "wallet",             "getaddressinfo",                   &getaddressinfo,                {"address"} },
     { "wallet",             "getbalance",                       &getbalance,                    {"account|dummy","minconf","include_watchonly"} },
     { "wallet",             "getspendablebalance",              &getspendablebalance,           {} },


### PR DESCRIPTION
### New Feature
Add RPC `exporttransactions` to export to a CSV file, similar to the existing `listtransactions` RPC command

### Solution
Added a well tested external CSV library to the project that will make future CSV functionality trivial in the future
Added the rpc `exporttransactions` command supporting an output filename; and filtering by account, date range, and/or basic piped separated search string

```
exporttransactions (dummy filename start end categories include_watchonly)

Exports transactions between 'start' date and 'end' date matching 'categories' to a CSV file.
Note: To export from a specified "account", restart veild with -depreciatedrpc=accounts and
use this RPC with an "account" argument

Arguments:
1. "dummy"      (string, optional) If set, should be "*" for backwards compatibility.
2. "filename"   (string, optional) The filename with path (either absolute or relative to veild) [default=<datadir>/export/transactions.csv].
3. "start"      (string, optional) The start date in the format YYYY-MM-DD [default=beginning of ISO8601 time].
4. "end"        (string, optional) The end date in the format YYYY-MM-DD
 [default=present time].5. "filter"     (string, optional) A pipe(|) separated transaction filter [default=no filter]
   Allowable filter words TBD
6. include_watchonly (bool, optional, default=false) Include transactions to watch-only addresses (see 'importaddress')
```

### Bounty Payment Address
sv1qqp6aptgvgp9t9h8sgzkqmu6cgq2e20l9x6fsl5ask7t3ygy2jagftcpq0x5z0h522ca5h06qq3hx33pke00r7gjt3j24n896gf55y68ptrmjqqqqd8lz3

### Unit Testing Results
Compare exported CSV with output of existing list transactions command. Should be identical except export CSV shows also sent basecoin transactions which were missing in listtransactions.

### Known issues
- Only basecoin transactions at this time.
- Pulls 'send' transactions from multi-destination transactions that you are a receiver.
