### PR TITLE
[GUI] Move menu to cursor location instead of far right of the rectangle

### DIFF
--- a/src/qt/veil/addressesmenu.cpp
+++ b/src/qt/veil/addressesmenu.cpp
@@ -19,9 +19,14 @@ AddressesMenu::AddressesMenu(const QString _type, const QModelIndex &_index, QWi
     mainWindow(_mainWindow),
     index(_index),
     type(_type),
-    model(_model)
+    model(_model),
+	timeoutTimer(0)
+
 {
     ui->setupUi(this);
+
+    timeoutTimer = new QTimer(this);
+    connect(timeoutTimer, SIGNAL(timeout()), this, SLOT(hide()));
 
     connect(ui->btnCopy,SIGNAL(clicked()),this,SLOT(onBtnCopyAddressClicked()));
     connect(ui->btnDelete,SIGNAL(clicked()),this,SLOT(onBtnDeleteAddressClicked()));
@@ -81,7 +86,15 @@ void AddressesMenu::setInitData(const QModelIndex &_index, AddressTableModel *_m
 }
 
 void AddressesMenu::showEvent(QShowEvent *event){
-    QTimer::singleShot(3500, this, SLOT(hide()));
+	timeoutTimer->start(3500);
+}
+
+void AddressesMenu::enterEvent(QEvent *event){
+	timeoutTimer->stop();
+}
+
+void AddressesMenu::leaveEvent(QEvent *event){
+	hide();
 }
 
 AddressesMenu::~AddressesMenu() {

--- a/src/qt/veil/addressesmenu.h
+++ b/src/qt/veil/addressesmenu.h
@@ -35,7 +35,9 @@ public:
     ~AddressesMenu();
 
 public Q_SLOTS:
-    virtual void showEvent(QShowEvent *event) override;
+	virtual void showEvent(QShowEvent *event) override;
+	virtual void enterEvent(QEvent *event) override;
+	virtual void leaveEvent(QEvent *event) override;
 
 private Q_SLOTS:
     void onBtnCopyAddressClicked();
@@ -48,6 +50,7 @@ private:
     QModelIndex index;
     QString type;
     AddressTableModel *model;
+    QTimer *timeoutTimer;
 };
 
 #endif // ADDRESSESMENU_H

--- a/src/qt/veil/addresseswidget.cpp
+++ b/src/qt/veil/addresseswidget.cpp
@@ -256,17 +256,25 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
 
     listView->setCurrentIndex(updatedIndex);
     QRect rect = listView->visualRect(index);
-    QPoint pos = rect.topRight();
-    pos.setX(pos.x() - (DECORATION_SIZE * 2));
-    pos.setY(pos.y() + (DECORATION_SIZE));
+
     const QString constType = type;
-    if(!this->menu) this->menu = new AddressesMenu(constType , updatedIndex, this, this->mainWindow, this->model);
+    if(!this->menu) this->menu = new AddressesMenu(constType , updatedIndex, mainWindow->getGUI(), this->mainWindow, this->model);
     else {
-        this->menu->hide();
         this->menu->setInitData(updatedIndex, this->model, constType);
     }
+
+    QPoint pos = mainWindow->getGUI()->mapFromGlobal(QCursor::pos());
+
+	if(pos.x()+menu->width()>mainWindow->getGUI()->width()){
+		pos.setX(pos.x() - menu->width());
+	}
+	if(pos.y()+menu->height()>mainWindow->getGUI()->height()){
+		pos.setY(pos.y() - menu->height());
+	}
+
     menu->move(pos);
     menu->show();
+    menu->raise();
 }
 
 void AddressesWidget::initAddressesView(){


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/34344520/112564208-3b62f180-8db1-11eb-88ca-37ea1ff52649.png)

**After:**
![image](https://user-images.githubusercontent.com/34344520/112563958-b7106e80-8db0-11eb-82f4-4955d45f89ef.png)

Previous code moved the selection menu to the far top right of the screen.
Instead, the  selection menu should intuitively be right next to where you click.