### PR TITLE
[GUI] Fix: Address Book menu hover background is white and text is white

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -127,6 +127,7 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode _mode,
     if(tab == SendingTab)
         contextMenu->addAction(deleteAction);
     contextMenu->addSeparator();
+    //contextMenu->setStyleSheet("QMenu::item:selected {background-color: #bababa;}");
 
     // Connect signals for context menu actions
     connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(onCopyAddressClicked()));

--- a/src/qt/res/css/main.css
+++ b/src/qt/res/css/main.css
@@ -69,6 +69,10 @@ QLineEdit{
     padding:0px;
 }
 
+QMenu:item:selected {
+    color: #000000;
+    background-color: #6f9bf5;
+}
 
 QToolBar > QToolButton {
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34344520/112567478-46208500-8db7-11eb-926a-d2701714b72c.png)

Current (Screenshot 1 -> Screenshot 2): hovering a selection shows a blank selection due to the background and the text turning white

New (Screenshot 1 -> Screenshot 3): hovering a selection shows a grey background correctly. 
Aligns with grey #bababab used throughout the project.