### PR TITLE
[Wallet] If nautomintdenom is set, prioritize its use

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1757,9 +1757,10 @@ bool AppInitMain()
 
 
     // Automint denom
-    if(nPreferredDenom == DEFAULT_AUTOMINT_DENOM) {
+    if(gArgs.IsArgSet("-nautomintdenom")){
         nPreferredDenom = gArgs.GetArg("-nautomintdenom", DEFAULT_AUTOMINT_DENOM);
         if(nPreferredDenom != 10 && nPreferredDenom != 100 && nPreferredDenom != 1000 && nPreferredDenom != 10000){
+        	LogPrintf("Invalid -nautomintdenom value set: %d. Defaulting to : %d\n", nPreferredDenom, DEFAULT_AUTOMINT_DENOM);
             nPreferredDenom = DEFAULT_AUTOMINT_DENOM;
         }
     }

--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -649,12 +649,15 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    // Preferences check
-    // If the UI settings have a different value than the server args then use the UI settings.
-    QSettings* settings = getSettings();
-    int tempPref = settings->value("nAutomintDenom").toInt();
-    if(tempPref != nPreferredDenom && tempPref != 0){
-        nPreferredDenom = tempPref;
+    // Automint denom
+    // If nautomintdenom is set, use it
+    // Else use saved UI settings
+    if(!gArgs.IsArgSet("-nautomintdenom")){
+    	QSettings* settings = getSettings();
+    	int tempPref = settings->value("nAutomintDenom").toInt();
+		if(tempPref != nPreferredDenom && tempPref != 0){
+			nPreferredDenom = tempPref;
+		}
     }
 
     // Now that the QApplication is setup and we have parsed our parameters, we can set the platform style

--- a/src/qt/veil/forms/settingsminting.ui
+++ b/src/qt/veil/forms/settingsminting.ui
@@ -293,7 +293,31 @@ font-size:14px;</string>
               </property>
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Every 5 minutes the wallet will try to 
-&lt;br&gt;mint new zerocoins of the seleted denom&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;br&gt;mint new zerocoins of the selected denom&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelAutomintConfig">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color:#ff7575;
+font-size:14px;font-weight:bold;</string>
+              </property>
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Automint control setting has been given to 
+               &lt;br&gt;your Veil configuration file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>

--- a/src/qt/veil/settings/settingsminting.cpp
+++ b/src/qt/veil/settings/settingsminting.cpp
@@ -53,6 +53,15 @@ SettingsMinting::SettingsMinting(QWidget *parent, WalletView *mainWindow, Wallet
         ui->btnSendMint->setEnabled(true);
     }
 
+    //retrieved saved settings if nautomintdenom is not in use
+    QSettings* settings = getSettings();
+    if (!gArgs.IsArgSet("-nautomintdenom") && settings->contains("nAutomintDenom")){
+		int tempPref = settings->value("nAutomintDenom").toInt();
+		if(tempPref != nPreferredDenom && tempPref != 0){
+			nPreferredDenom = tempPref;
+		}
+	}
+
     switch (nPreferredDenom){
         case 10:
             ui->radioButton10->setChecked(true);
@@ -81,13 +90,23 @@ SettingsMinting::SettingsMinting(QWidget *parent, WalletView *mainWindow, Wallet
     connect(ui->btnEsc,SIGNAL(clicked()),this, SLOT(close()));
     connect(ui->btnSendMint,SIGNAL(clicked()),this, SLOT(btnMint()));
     connect(ui->editAmount, SIGNAL(returnPressed()), this, SLOT(btnMint()));
-    connect(ui->radioButton10, SIGNAL(toggled(bool)), this, SLOT(onCheck10Clicked(bool)));
-    connect(ui->radioButton100, SIGNAL(toggled(bool)), this, SLOT(onCheck100Clicked(bool)));
-    connect(ui->radioButton1000, SIGNAL(toggled(bool)), this, SLOT(onCheck1000Clicked(bool)));
-    connect(ui->radioButton100000, SIGNAL(toggled(bool)), this, SLOT(onCheck100000Clicked(bool)));
+    if(gArgs.IsArgSet("-nautomintdenom")){
+    	ui->labelAutomintConfig->setVisible(true);
+    	ui->radioButton10->setEnabled(0);
+    	ui->radioButton100->setEnabled(0);
+    	ui->radioButton1000->setEnabled(0);
+    	ui->radioButton100000->setEnabled(0);
+    	ui->checkAutomintInstant->setEnabled(0);
+    }
+    else{
+    	ui->labelAutomintConfig->setVisible(false);
+    	connect(ui->radioButton10, SIGNAL(toggled(bool)), this, SLOT(onCheck10Clicked(bool)));
+    	connect(ui->radioButton100, SIGNAL(toggled(bool)), this, SLOT(onCheck100Clicked(bool)));
+    	connect(ui->radioButton1000, SIGNAL(toggled(bool)), this, SLOT(onCheck1000Clicked(bool)));
+    	connect(ui->radioButton100000, SIGNAL(toggled(bool)), this, SLOT(onCheck100000Clicked(bool)));
+    	connect(ui->checkAutomintInstant, SIGNAL(toggled(bool)), this, SLOT(onCheckFullMintClicked(bool)));
+    }
     connect(ui->editAmount, SIGNAL(textChanged(const QString &)), this, SLOT(mintAmountChange(const QString &)));
-
-    connect(ui->checkAutomintInstant, SIGNAL(toggled(bool)), this, SLOT(onCheckFullMintClicked(bool)));
 
 }
 


### PR DESCRIPTION
nPreferredDenom == DEFAULT_AUTOMINT_DENOM is actually false because:
nPreferredDenom is 10
DEFAULT_AUTOMINT_DENOM is 1000

This code change just wraps the 2 nPreferredDenom inits based on if nautomindenom is set or not in the config.

The real existing issue is in veil.cpp which occurs after init.cpp and overwrites the logic in veil.cpp for nautomintdenom anyway when it pulls from QT getSettings()

Easiest way to test is to compare this code vs. existing 
use a fresh wallet or re-build/remake from code and config file nautomintdenom value is not used on initial startup

### Release Note
[GUI] Users that have set their desired zerocoin automint denomination via the GUI and in the veil.conf file will now find the configuration file setting is used over the GUI setting.  If the veil configuration file has an automint denom setting, the GUI controls are now disabled and the user informed.
