### PR TITLE
[RPC] Return mining addresses in listaddresses RPC command

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -731,7 +731,6 @@ static UniValue listaddresses(const JSONRPCRequest& request)
     for (const auto& item: pwallet->mapAddressBook)
     {
         // Only get basecoin and stealth addresses
-    	//
         if (!((item.first.type() == typeid(WitnessV0KeyHash)) ||
               (item.first.type() == typeid(CStealthAddress)) ||
 			  (item.first.type() == typeid(CKeyID)))) continue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -731,8 +731,10 @@ static UniValue listaddresses(const JSONRPCRequest& request)
     for (const auto& item: pwallet->mapAddressBook)
     {
         // Only get basecoin and stealth addresses
+    	//
         if (!((item.first.type() == typeid(WitnessV0KeyHash)) ||
-              (item.first.type() == typeid(CStealthAddress)))) continue;
+              (item.first.type() == typeid(CStealthAddress)) ||
+			  (item.first.type() == typeid(CKeyID)))) continue;
         // Only get mine
         if (!pwallet->IsMine(item.first)) continue;
         // If we're balance only, require a balance
@@ -743,9 +745,12 @@ static UniValue listaddresses(const JSONRPCRequest& request)
         if (item.first.type() == typeid(CStealthAddress)) {
             entry.pushKV("address", EncodeDestination(item.first, true));
             entry.pushKV("amount", ValueFromAmount(AnonBalances[item.first]));
-        } else {
+        } else if (item.first.type() == typeid(WitnessV0KeyHash)) {
             entry.pushKV("address", EncodeDestination(item.first));
             entry.pushKV("amount", ValueFromAmount(balances[item.first]));
+        } else {
+        	entry.pushKV("address", EncodeDestination(item.first, false));
+        	entry.pushKV("amount", ValueFromAmount(balances[item.first]));
         }
 
         entry.pushKV("label", item.second.name);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -733,7 +733,7 @@ static UniValue listaddresses(const JSONRPCRequest& request)
         // Only get basecoin and stealth addresses
         if (!((item.first.type() == typeid(WitnessV0KeyHash)) ||
               (item.first.type() == typeid(CStealthAddress)) ||
-			  (item.first.type() == typeid(CKeyID)))) continue;
+              (item.first.type() == typeid(CKeyID)))) continue;
         // Only get mine
         if (!pwallet->IsMine(item.first)) continue;
         // If we're balance only, require a balance


### PR DESCRIPTION
`listaddresses` RPC command now handles mining addresses in the listaddresses command

#863 

![image](https://user-images.githubusercontent.com/34344520/112764551-1354d780-8fd7-11eb-8155-b7ff50a730c7.png)

