### PR TITLE
[RPC] Return mining addresses in listaddresses rpc command

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -732,7 +732,8 @@ static UniValue listaddresses(const JSONRPCRequest& request)
     {
         // Only get basecoin and stealth addresses
         if (!((item.first.type() == typeid(WitnessV0KeyHash)) ||
-              (item.first.type() == typeid(CStealthAddress)))) continue;
+              (item.first.type() == typeid(CStealthAddress)) ||
+              (item.first.type() == typeid(CKeyID)))) continue;
         // Only get mine
         if (!pwallet->IsMine(item.first)) continue;
         // If we're balance only, require a balance
@@ -743,9 +744,12 @@ static UniValue listaddresses(const JSONRPCRequest& request)
         if (item.first.type() == typeid(CStealthAddress)) {
             entry.pushKV("address", EncodeDestination(item.first, true));
             entry.pushKV("amount", ValueFromAmount(AnonBalances[item.first]));
-        } else {
+        } else if (item.first.type() == typeid(WitnessV0KeyHash)) {
             entry.pushKV("address", EncodeDestination(item.first));
             entry.pushKV("amount", ValueFromAmount(balances[item.first]));
+        } else {
+        	entry.pushKV("address", EncodeDestination(item.first, false));
+        	entry.pushKV("amount", ValueFromAmount(balances[item.first]));
         }
 
         entry.pushKV("label", item.second.name);


### PR DESCRIPTION
`listaddresses` RPC command now handles mining addresses in the listaddresses command

![image](https://user-images.githubusercontent.com/34344520/112764551-1354d780-8fd7-11eb-8155-b7ff50a730c7.png)

Addresses issue:  #863 
