### PR TITLE
[WIP][Staking][GUI] Check for at least 1 mature zerocoin instead of no immature zerocoin

### DIFF
--- a/src/qt/veil/veilstatusbar.cpp
+++ b/src/qt/veil/veilstatusbar.cpp
@@ -74,8 +74,11 @@ void VeilStatusBar::setStakingText() {
         }
     }
     bool fStakingActive = false;
+    auto pwallet = GetMainWallet();
+
+    //if at least 1 mature zerocoin, staking is active
     if (nTimeLastHashing)
-        fStakingActive = GetAdjustedTime() + MAX_FUTURE_BLOCK_TIME - nTimeLastHashing < ACTIVE_STAKING_MAX_TIME;
+    	fStakingActive = pwallet->GetZerocoinBalance(true) > 0;
 	
     WalletModel::EncryptionStatus eStatus = this->walletModel->getEncryptionStatus();
 
@@ -93,7 +96,7 @@ void VeilStatusBar::setStakingText() {
             int64_t zerocoin_balance = balances.zerocoin_balance;
 
 	    if (0.0 < zerocoin_balance) {
-                ui->checkStaking->setText("Enabling...");
+                ui->checkStaking->setText("Waiting for zerocoin to mature...");
             }else{
                 ui->checkStaking->setText("You need some zerocoin");
             }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3442,7 +3442,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     }
     bool fStakingActive = false;
     if (nTimeLastHashing)
-        fStakingActive = GetAdjustedTime() + MAX_FUTURE_BLOCK_TIME - nTimeLastHashing < 70;
+    	fStakingActive = pwallet->GetZerocoinBalance(true) > 0;
 
     obj.pushKV("staking_active", fStakingActive);
 


### PR DESCRIPTION
Reference Issue #889 

-Change status bar logic to display `Staking Enabled` correctly:
     **Previous:** display `Enabling...` if there are 1 or more immature zerocoin in the wallet.
     **New:** display `Enabling...` if there are exactly 0 mature zerocoin in the wallet.
-Replace `Enabling...` text with `Waiting for zerocoin to mature...` text