### PR TITLE
[Utils] Use gmtime_s with _WIN32

### DIFF
--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -79,7 +79,7 @@ void MilliSleep(int64_t n)
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
     gmtime_s(&ts, &time_val);
 #else
     gmtime_r(&time_val, &ts);
@@ -90,7 +90,7 @@ std::string FormatISO8601DateTime(int64_t nTime) {
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
     gmtime_s(&ts, &time_val);
 #else
     gmtime_r(&time_val, &ts);
@@ -101,7 +101,7 @@ std::string FormatISO8601Date(int64_t nTime) {
 std::string FormatISO8601Time(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
     gmtime_s(&ts, &time_val);
 #else
     gmtime_r(&time_val, &ts);


### PR DESCRIPTION
### Problem ###
Following the build instructions for WSL with Ubuntu 20.04 resulted in this error:

```
utiltime.cpp: In function ‘std::string FormatISO8601DateTime(int64_t)’:
utiltime.cpp:85:5: error: ‘gmtime_r’ was not declared in this scope; did you mean ‘gmtime_s’?
   85 |     gmtime_r(&time_val, &ts);
      |     ^~~~~~~~
      |     gmtime_s 
```

Manually changing `gmtime_r` to `gmtime_s` results in a further warning because the arguments are reversed, a sign that we're building with the Windows version that the code uses when `_MSC_VER` is set.

### Root Cause ###
WSL with Ubuntu 20.04 is not building with msvc but with mingw.

### Solution ###
Use the Windows version of this code when either `_MSC_VER` or `__MINGW64__` is set.

(**Note**: I also needed to change the build command `make HOST=x86_64-w64-mingw32` to `CC_FOR_BUILD=x86_64-linux-gnu-gcc make HOST=x86_64-w64-mingw32` in order to build gmp, but I was not sure if I should update the docs.)

### Bounty PR ###
None

### Bounty Payment Address ##
`sv1qqpswvjy7s9yrpcmrt3fu0kd8rutrdlq675ntyjxjzn09f965z9dutqpqgg85esvg8mhmyka5kq5vae0qnuw4428vs9d2gu4nz643jv5a72wkqqq73mnxr`

### Unit Testing Results ###
Tested on win64 mingw WSL/Ubuntu 20.04 by building successfully and running unittests successfully compared to master.