### PR TITLE
[Build] Fix OSX Github Action

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -138,6 +138,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y python3-setuptools libcap-dev zlib1g-dev cmake
+        sudo -H pip install setuptools
     - name: Get macOS SDK
       run: |
         mkdir -p depends/sdk-sources


### PR DESCRIPTION
### Problem
Github Action for OSX started failing

### Root Cause
Not sure what exactly changed, but the build of the native_biplist for MacOSX started failing due to a missing ez_setup.

### Solution
Since native_biplist is using python instead of python3, needed to install the python setuptools

### Testing
If the PR completes all actions, it will be merged into master
