### PR TITLE
[Logging][Mining] Add BCLog::MINING category.

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -123,6 +123,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::BLOCKCREATION, "blockcreation"},
     {BCLog::CHAINSCORE, "chainscore"},
     {BCLog::STAGING, "staging"},
+    {BCLog::MINING, "mining"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -57,6 +57,7 @@ namespace BCLog {
         BLOCKCREATION = (1 << 22),
         CHAINSCORE = (1 << 23),
         STAGING     = (1 << 24),
+        MINING      = (1 << 25),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1011,7 +1011,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                     ++pblock->nNonce;
                 }
             } else {
-                LogPrintf("%s: Unknown hashing algorithm found!\n");
+                LogPrintf("%s: Unknown hashing algorithm found!\n", __func__);
                 return;
             }
 
@@ -1023,8 +1023,8 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                 if (!nTimeDuration) nTimeDuration = 1;
                 nHashSpeed = arith_uint256(nHashes/1000/nTimeDuration).getdouble();
             }
-            LogPrint(BCLog::BLOCKCREATION, "%s: PoW Hashspeed %d kh/s\n", __func__, nHashSpeed);
 
+            LogPrint(BCLog::MINING, "%s: PoW Hashspeed %d kh/s\n", __func__,  nHashSpeed);
             if (nTries == nInnerLoopCount) {
                 continue;
             }
@@ -1032,7 +1032,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
 
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr)) {
-            LogPrint(BCLog::BLOCKCREATION, "%s : Failed to process new block\n", __func__);
+            LogPrint(BCLog::MINING, "%s: Failed to process new block\n", __func__);
             continue;
         }
 
@@ -1142,8 +1142,8 @@ void BitcoinRandomXMiner(std::shared_ptr<CReserveScript> coinbaseScript, int vm_
                 nHashSpeed = arith_uint256(nHashes/nTimeDuration).getdouble();
             }
         }
-        LogPrint(BCLog::BLOCKCREATION, "%s: RandomX PoW Hashspeed %d hashes/s\n", __func__, nHashSpeed);
 
+        LogPrint(BCLog::MINING, "%s: RandomX PoW Hashspeed %d hashes/s\n", __func__, nHashSpeed);
         if (nTries == nInnerLoopCount) {
             continue;
         }
@@ -1155,7 +1155,7 @@ void BitcoinRandomXMiner(std::shared_ptr<CReserveScript> coinbaseScript, int vm_
 
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr)) {
-            LogPrint(BCLog::BLOCKCREATION, "%s: Failed to process new block\n", __func__);
+            LogPrint(BCLog::MINING, "%s: Failed to process new block\n", __func__);
             continue;
         }
 


### PR DESCRIPTION
### Problem ###
Mining code uses the `BLOCKCREATION` logging category, which includes logging about difficulty targets, staking, zerocoins, etc, making it harder to investigate mining-specific issues.

### Root Cause ###
Using the `BLOCKCREATION` category for lots of different information.

### Solution ###
Adds a new logging category `MINING` to aid debugging mining specifically
without including block template creation logs that may be noisier.

Converts most logs in BitcoinMiner and RandomXMiner to use this category
instead of `BLOCKCREATION`.

Fixes one unlikely logging statement to include the function name.

### Bounty Payment Address ###
`sv1qqpswvjy7s9yrpcmrt3fu0kd8rutrdlq675ntyjxjzn09f965z9dutqpqgg85esvg8mhmyka5kq5vae0qnuw4428vs9d2gu4nz643jv5a72wkqqq73mnxr`

### Unit Testing Results ###
Tested by running and sending the command `logging [\"mining\"]` to enable.