### PR TITLE
[Mining] IncrementExtraNonce without cs_main

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -247,7 +247,7 @@ bool GenerateActive();
 void setGenerate(bool fGenerate);
 
 /** Modify the extranonce in a block */
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
+void IncrementExtraNonce(CBlock* pblock, unsigned int nHeight, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlock* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScript> coinbaseScript);
 void ThreadStakeMiner();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -220,10 +220,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
-        {
-            LOCK(cs_main);
-            IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
-        }
+        IncrementExtraNonce(pblock, chainActive.Height(), nExtraNonce);
 
         // This will check if the key block needs to change and will take down the cache and vm, and spin up the new ones
         CheckIfValidationKeyShouldChangeAndUpdate(GetKeyBlock(pblock->nHeight));

--- a/src/test/test_veil.cpp
+++ b/src/test/test_veil.cpp
@@ -155,11 +155,8 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     for (const CMutableTransaction& tx : txns)
         block.vtx.push_back(MakeTransactionRef(tx));
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
-    {
-        LOCK(cs_main);
-        unsigned int extraNonce = 0;
-        IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
-    }
+    unsigned int extraNonce = 0;
+    IncrementExtraNonce(&block, chainActive.Height(), extraNonce);
 
     while (!CheckProofOfWork(block.GetX16RTPoWHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 


### PR DESCRIPTION
### Problem ###
While mining SHA256D, the wallet periodically gets stuck, failing to stay caught up with the chain. (At the same time, the mining significantly slows down.)

### Root Cause ###
Lock contention; SHA256D is very fast, completing its loop in subsecond time on a modern cpu, meaning every thread goes through lock-heavy sections of the block template creation code multiple times per second. In comparison, RandomX on the same machine takes minutes to complete its loop, usually being interrupted by the creation of a new block instead of reaching the maximal number of attempts.

### Solution (partial) ###
Reduce lock contention on `cs_main`. The nonce setup prior to running the hashes includes grabbing `cs_main` to perform `IncrementExtraNonce`. It takes this lock to safely get the chain tip and then to safely compare the current thread's `prevHeaderHash` against a static value, resetting the nonce to 0 and updating the static value if it doesn't match.

However, it only uses the chain tip for its height, which we can get without a lock.

Second, the nonce being reset to 0 is thread-local; other threads are not affected by the first thread to reach this part in a new block. Also, the nonce base is constantly increasing in a separate section, so there does not really appear to be a requirement that nonces start from 0 on a new block; the lock on `nNonce_base` already assures us that we get a unique number for each thread. As such, I believe we can safely remove the nonce reset here. (I think we can also remove the extra increment, but I've left it in for now.)

Cleanup: Also removes one extraneous copy of the nonce into a thread local variable
(there were previously two, and I suspect the extra was already being optimized away).

### Bounty PR ###
#862

### Bounty Payment Address ##
`sv1qqpswvjy7s9yrpcmrt3fu0kd8rutrdlq675ntyjxjzn09f965z9dutqpqgg85esvg8mhmyka5kq5vae0qnuw4428vs9d2gu4nz643jv5a72wkqqq73mnxr`

### Unit Testing Results ###
`test_veil.exe` appears to crash on my system, so manually ran all the tests via a script and compared to master. No differences.
