### PR TITLE
[Mining] Use -miningaddress for in-wallet mining.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1933,6 +1933,17 @@ bool AppInitMain()
         // Link thread groups
         LinkAutoSpendThreadGroup(&threadGroupAutoSpend);
 
+        // Validate wallet mining address.
+        std::string sAddress = gArgs.GetArg("-miningaddress", "");
+        if (!sAddress.empty()) {
+            CTxDestination dest = DecodeDestination(sAddress);
+
+            auto pt = GetMainWallet();
+            if (pt && pt->IsMine(dest) != ISMINE_SPENDABLE) {
+                return InitError(strprintf(_("Invalid -miningaddress: '%s' not owned by wallet"), sAddress));
+            }
+        }
+
         // Start wallet CPU mining if the -gen=<n> parameter is given
         int nThreads = gArgs.GetArg("-gen", 0);
         if (nThreads) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4702,7 +4702,7 @@ void CWallet::MarkReserveKeysAsUsed(int64_t keypool_id)
     }
 }
 
-void CWallet::GetScriptForMining(std::shared_ptr<CReserveScript> &script)
+void CWallet::GetScriptForMiningReserveKey(std::shared_ptr<CReserveScript> &script)
 {
     std::shared_ptr<CReserveKey> rKey = std::make_shared<CReserveKey>(this);
     CPubKey pubkey;
@@ -4711,6 +4711,19 @@ void CWallet::GetScriptForMining(std::shared_ptr<CReserveScript> &script)
 
     script = rKey;
     script->reserveScript = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
+}
+
+void CWallet::GetScriptForMining(std::shared_ptr<CReserveScript> &script)
+{
+    std::string sAddress = gArgs.GetArg("-miningaddress", "");
+    if (!sAddress.empty()) {
+        CTxDestination dest = DecodeDestination(sAddress);
+
+        script = std::make_shared<CReserveScript>();
+        script->reserveScript = GetScriptForDestination(dest);
+        return;
+    }
+    return GetScriptForMiningReserveKey(script);
 }
 
 void CWallet::LockCoin(const COutPoint& output)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1221,6 +1221,7 @@ public:
 
     const std::string& GetLabelName(const CScript& scriptPubKey) const;
 
+    void GetScriptForMiningReserveKey(std::shared_ptr<CReserveScript> &script);
     void GetScriptForMining(std::shared_ptr<CReserveScript> &script);
 
     unsigned int GetKeyPoolSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)


### PR DESCRIPTION
### Problem ###
`-miningaddress` is used for rpc progpow gpu mining, but ignored for in-wallet mining such as for RandomX and SHA256D.

### Root Cause ###
It's just not looking at the config value when it sets up the block script.

### Solution ###
When the wallet attempts to retrieve a mining address, prefer the configured value for `-miningaddress`, falling back to the previous address generation from the wallet keys.

Disallows stealth addresses as per current behavior validating `-miningaddress` at startup and in rpc mining.

Performs an additional safety check that the wallet actually owns the given address, falling back to a random wallet address otherwise (preserving current behavior).

### Bounty PR ###
#867

### Bounty Payment Address ##
`sv1qqpswvjy7s9yrpcmrt3fu0kd8rutrdlq675ntyjxjzn09f965z9dutqpqgg85esvg8mhmyka5kq5vae0qnuw4428vs9d2gu4nz643jv5a72wkqqq73mnxr`

### Testing Results ###
Tested on win10 x64 mining RandomX on testnet: both with basecoin and "mining" addresses.
Tested on win10 veild, veil-qt: Using a testnet basecoin address that was not mine. Successfully produced an error and exited.

![RandomX mining results](https://user-images.githubusercontent.com/518709/113928978-5582d380-97a4-11eb-990c-d0fac159ac20.png)
