### PR TITLE
[Logging] Define a STAKING log category.

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -124,6 +124,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::CHAINSCORE, "chainscore"},
     {BCLog::STAGING, "staging"},
     {BCLog::MINING, "mining"},
+    {BCLog::STAKING, "staking"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -58,6 +58,7 @@ namespace BCLog {
         CHAINSCORE = (1 << 23),
         STAGING     = (1 << 24),
         MINING      = (1 << 25),
+        STAKING     = (1 << 26),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -515,7 +515,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         }
         auto spend = TxInToZerocoinSpend(pblock->vtx[1]->vin[0]);
         if (!spend) {
-            LogPrint(BCLog::BLOCKCREATION, "%s: failed to get spend for txin", __func__);
+            LogPrint(BCLog::STAKING, "%s: failed to get spend for txin", __func__);
             return nullptr;
         }
 
@@ -525,17 +525,17 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 #ifdef ENABLE_WALLET
         if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET) || !pwalletMain->GetZerocoinKey(bnSerial, key)) {
 #endif
-            LogPrint(BCLog::BLOCKCREATION, "%s: Failed to get zerocoin key from wallet!\n", __func__);
+            LogPrint(BCLog::STAKING, "%s: Failed to get zerocoin key from wallet!\n", __func__);
             return nullptr;
 #ifdef ENABLE_WALLET
         }
 #endif
 
         if (!key.Sign(pblock->GetHash(), pblock->vchBlockSig)) {
-            LogPrint(BCLog::BLOCKCREATION, "%s: Failed to sign block hash\n", __func__);
+            LogPrint(BCLog::STAKING, "%s: Failed to sign block hash\n", __func__);
             return nullptr;
         }
-        LogPrint(BCLog::BLOCKCREATION, "%s: FOUND STAKE!!\n block: \n%s\n", __func__, pblock->ToString());
+        LogPrint(BCLog::STAKING, "%s: FOUND STAKE!!\n block: \n%s\n", __func__, pblock->ToString());
     }
 
     if (pindexPrev && pindexPrev != chainActive.Tip()) {
@@ -932,7 +932,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                 auto it = mapStakeHashCounter.find(nHeight);
                 if (it != mapStakeHashCounter.end() && it->second != nStakeHashesLast) {
                     nStakeHashesLast = it->second;
-                    LogPrint(BCLog::BLOCKCREATION, "%s: Tried %d stake hashes for block %d last=%d\n", __func__, nStakeHashesLast, nHeight+1, mapHashedBlocks.at(hashBestBlock));
+                    LogPrint(BCLog::STAKING, "%s: Tried %d stake hashes for block %d last=%d\n", __func__, nStakeHashesLast, nHeight+1, mapHashedBlocks.at(hashBestBlock));
                 }
                 // wait half of the nHashDrift with max wait of 3 minutes
                 int rand = GetRandInt(20); // add small randomness to prevent all nodes from being on too similar of timing

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3908,7 +3908,7 @@ bool CWallet::CreateCoinStake(const CBlockIndex* pindexBest, unsigned int nBits,
                 LOCK(cs_main);
                 //Double check that this will pass time requirements
                 if (nTxNewTime <= nTimeMinBlock) {
-                    LogPrint(BCLog::BLOCKCREATION, "CreateCoinStake() : kernel found, but it is too far in the past \n");
+                    LogPrint(BCLog::STAKING, "%s : kernel found, but it is too far in the past \n", __func__);
                     continue;
                 }
                 nHeight = chainActive.Height();
@@ -4008,7 +4008,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<ZerocoinStake> >& listI
         }
     }
 
-    LogPrint(BCLog::BLOCKCREATION, "%s: FOUND %d STAKABLE ZEROCOINS\n", __func__, listInputs.size());
+    LogPrint(BCLog::STAKING, "%s: FOUND %d STAKABLE ZEROCOINS\n", __func__, listInputs.size());
 
     return true;
 }


### PR DESCRIPTION
### Problem ###
`BLOCKCREATION` is a very noisy log category. It includes DarkGravityWave logs (which are noisy), staking messages, and generic block creation logs.

### Root Cause ###
Not enough log categories.

### Solution ###
Added a new log category specific to staking. Staking-relevant messages that were previously `BLOCKCREATION` have been moved over.

### Bounty PR ###
None

### Bounty Payment Address ##
`sv1qqpswvjy7s9yrpcmrt3fu0kd8rutrdlq675ntyjxjzn09f965z9dutqpqgg85esvg8mhmyka5kq5vae0qnuw4428vs9d2gu4nz643jv5a72wkqqq73mnxr`

### Unit Testing Results ###
Tested on win10 x64 WLS Ubuntu 20.04: built and ran unittests individually, comparing results to a previous master commit.