### PR TITLE
[Core] Properly shut down veild if init fails.

### DIFF
--- a/src/veild.cpp
+++ b/src/veild.cpp
@@ -199,6 +199,7 @@ static bool AppInit(int argc, char* argv[])
 
     if (!fRet)
     {
+        StartShutdown();
         Interrupt();
     } else {
         WaitForShutdown();


### PR DESCRIPTION
### Problem ###
veild doesn't shut down properly if it fails during init.

### Root Cause ###
Background threads were hanging after being interrupted, because they were looking to `ShutdownRequested()`, which was only being set by `StartShutdown()` on SIGTERM.

### Solution ###
Solution is to call `StartShutdown()` when veild fails init and goes to interrupt running threads.

### PR ###
#934 

### Testing ###
Set `autospend=1` and `autospendaddress=<basecoin address>` (or make a similar error that should cause it to close with an error on startup) in your veil.conf and run veild with `-printtoconsole`.