### PR TITLE
[Trivial] Add config include for building DEBUG_LOCKCONTENTION

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -4,6 +4,10 @@
 
 #include <sync.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config/veil-config.h>
+#endif
+
 #include <logging.h>
 #include <utilstrencodings.h>
 


### PR DESCRIPTION
config/veil-config.h includes `HAVE_THREAD_LOCAL`, without which `DEBUG_LOCKCONTENTION` will fail to build due to the `static_assert`.

This allows building with `./configure CPPFLAGS="-DDEBUG_LOCKCONTENTION"` without manually adding `-DHAVE_THREAD_LOCAL` (when thread_local exists, of course).

### Tested ###
Built via `./configure --with-incompatible-bdb CPPFLAGS="-DDEBUG_LOCKCONTENTION"` on Fedora, `CONFIG_SITE=$PWD/depends/x64_64-w64-mingw32/share/config.site ./configure --prefix=/ CPPFLAGS="-DDEBUG_LOCKCONTENTION"` on WSL Ubuntu 20.04