### PR TITLE
[Zerocoin][Validation] Cache checksum heights

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,6 +1022,6 @@ add_executable(veil
         src/versionbits.h
         src/walletinitinterface.h
         src/warnings.cpp
-        src/warnings.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/veil/zerocoin/lrucache.h src/veil/zerocoin/lrucache.cpp src/veil/zerocoin/precompute.h src/veil/zerocoin/precompute.cpp src/libzerocoin/PubcoinSignature.h src/libzerocoin/PubcoinSignature.cpp src/test/zerocoin_pubcoinsig_tests.cpp src/veil/invalid_list.h src/veil/invalid_list.cpp)
+        src/warnings.h src/veil/lru_cache.h src/veil/zerocoin/spendreceipt.h src/veil/ringct/temprecipient.h src/veil/ringct/temprecipient.cpp src/veil/zerocoin/spendreceipt.cpp src/veil/ringct/outputrecord.cpp src/veil/ringct/outputrecord.h src/wallet/walletbalances.h src/veil/ringct/transactionrecord.h src/veil/zerocoin/mintmeta.h src/test/zerocoin_zkp_tests.cpp src/veil/zerocoin/lrucache.h src/veil/zerocoin/lrucache.cpp src/veil/zerocoin/precompute.h src/veil/zerocoin/precompute.cpp src/libzerocoin/PubcoinSignature.h src/libzerocoin/PubcoinSignature.cpp src/test/zerocoin_pubcoinsig_tests.cpp src/veil/invalid_list.h src/veil/invalid_list.cpp)
 
 qt5_use_modules(veil Core Widgets Gui)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -192,6 +192,7 @@ BITCOIN_CORE_H = \
   veil/dandelioninventory.h \
   veil/invalid.h \
   veil/invalid_list.h \
+  veil/lru_cache.h \
   veil/proofoffullnode/proofoffullnode.h \
   veil/proofofstake/kernel.h \
   veil/proofofstake/blockvalidation.h \

--- a/src/veil/lru_cache.h
+++ b/src/veil/lru_cache.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef VEIL_LRU_CACHE_H
+#define VEIL_LRU_CACHE_H
+
+#include "sync.h"
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+namespace veil {
+
+/**
+ * The SimpleLRUCache is a fixed-size key-value map that automatically
+ * evicts the least-recently-used item when a new item is added while the cache is full.
+ *
+ * This is a naive, non-optimized implementation of an LRU cache that uses an
+ * internal mutex to prevent concurrent access.
+ *
+ * K must be a hashable type, but you can define your own Hash for it, or equivalently implement
+ * std::hash<K> for your type. It must be a default-constructible struct or class
+ * defining std::size_t operator()(const K&) const, e.g.
+ *
+ * namespace std {
+ * template<> struct hash<MyType>
+ * {
+ *     std::size_t operator()(const MyType& m) const {
+ *         return std::hash<std::string>()(m.ImportantString()) ^ m.ImportantInteger;
+ *     }
+ * };
+ * }
+ * SimpleLRUCache<MyType, MyValue> cache(100);
+ */
+template<typename K, typename V = K, class Hash = std::hash<K>>
+class SimpleLRUCache
+{
+
+private:
+    std::list<K> items;
+    std::unordered_map<K, std::pair<V, typename std::list<K>::iterator>, Hash> keyValuesMap;
+    int csize;
+    CCriticalSection cs_mycache;
+
+public:
+    SimpleLRUCache(int s) : csize(s < 1 ? 10 : s), keyValuesMap(csize) {}
+
+    void set(const K key, const V value) {
+        LOCK(cs_mycache);
+        auto pos = keyValuesMap.find(key);
+        if (pos == keyValuesMap.end()) {
+            items.push_front(key);
+            keyValuesMap[key] = { value, items.begin() };
+            if (keyValuesMap.size() > csize) {
+                keyValuesMap.erase(items.back());
+                items.pop_back();
+            }
+        } else {
+            items.erase(pos->second.second);
+            items.push_front(key);
+            keyValuesMap[key] = { value, items.begin() };
+        }
+    }
+
+    bool get(const K key, V &value) {
+        LOCK(cs_mycache);
+        auto pos = keyValuesMap.find(key);
+        if (pos == keyValuesMap.end())
+            return false;
+        items.erase(pos->second.second);
+        items.push_front(key);
+        keyValuesMap[key] = { pos->second.first, items.begin() };
+        value = pos->second.first;
+        return true;
+    }
+};
+
+} // namespace veil
+
+#endif // VEIL_LRU_CACHE_H


### PR DESCRIPTION
### Problem ###
While mining SHA256D, the wallet periodically gets stuck, failing to stay caught up with the chain, **even with #915**. (At the same time, the mining significantly slows down.)

### Root Cause ###
Lock contention; the cs_main lock is held throughout critical parts of block template creation, done independently per mining thread. The intermittent stuckness appears correlated with large numbers of txins during zerocoin spend validation. This requires determining the height of an accumulator hash, which is done by searching through all the blocks in the chain starting from genesis, for every txin. My debug logs (with -debug=bench) show very consistent examples like `- Verify 646 txins: 17392.00ms (26.923ms/txin)`.

### Solution ###
Since the height of a particular hash-denomination pair is not going to change, we can cache it. One mining thread will still have to find the height to begin with, but all the other threads will not need to. (Also, hashes may persist to be reused in later blocks; there are likely multiple coins of the same denom with the same accumulator hash.)

Adds a SimpleLRUCache template based on 7c9e97a3a83c and uses it to store checksum heights. I chose a somewhat arbitrary size for it that should be large enough for significant spends.

This results in a **significant** speedup of zerocoin spend validation (alternately got `- Verify 101 txins: 1.00ms (0.010ms/txin)` , `- Verify 101 txins: 0.00ms (0.000ms/txin)` on one block). Vastly improves #862 alongside #915--I can confirm it still gets stuck without #915.

### Bounty PR ###
#862

### Bounty Payment Address ##
`sv1qqpswvjy7s9yrpcmrt3fu0kd8rutrdlq675ntyjxjzn09f965z9dutqpqgg85esvg8mhmyka5kq5vae0qnuw4428vs9d2gu4nz643jv5a72wkqqq73mnxr`

### Testing ###
testnet: built with `-with-sanitizers=thread -O0 -g` and run with 3/4 threads mining sha256d, and spending tons of 10s at once to stress-test this section.
mainnet: running 12 threads sha256d, built with #915 and `-O3` and

```patch
diff --git a/src/validation.cpp b/src/validation.cpp
index f92427109..a2a2c9ef5 100644
--- a/src/validation.cpp
+++ b/src/validation.cpp              
@@ -2863,0 +2895,2 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         return state.DoS(100, error("%s: CheckQueue failed", __func__), REJECT_INVALID, "block-validation-failed");

     int64_t nTime4 = GetTimeMicros(); nTimeVerify += nTime4 - nTime2;
+    if (nInputs > 20)
+        LogPrintf("    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs (%.2fms/blk)]\n", nInputs - 1, MILLI * (nTime4 - nTime2), nInputs <= 1 ? 0 : MILLI * (nTime4 - nTime2) / (nInputs-1), nTimeVerify * MICRO, nTimeVerify * MILLI / nBlocksTotal);
     LogPrint(BCLog::BENCH, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs (%.2fms/blk)]\n", nInputs - 1, MILLI * (nTime4 - nTime2), nInputs <= 1 ? 0 : MILLI * (nTime4 - nTime2) / (nInputs-1), nTimeVerify * MICRO, nTimeVerify * MILLI / nBlocksTotal); 
```
for simple performance monitoring.