### PR TITLE
[RPC][Trivial] Tweak exportzerocoins example to be sensible

### DIFF
--- a/src/wallet/rpczerocoin.cpp
+++ b/src/wallet/rpczerocoin.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2019 The PIVX developers
-// Copyright (c) 2019-2020 The Veil developers
+// Copyright (c) 2019-2021 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -1080,7 +1080,7 @@ UniValue exportzerocoins(const JSONRPCRequest& request)
                                             "]\n"
 
                                             "\nExamples:\n" +
-                HelpExampleCli("exportzerocoins", "false 5") + HelpExampleRpc("exportzerocoins", "false 5"));
+                HelpExampleCli("exportzerocoins", "false 10") + HelpExampleRpc("exportzerocoins", "false 10"));
 
     LOCK2(cs_main, pwallet->cs_wallet);
 


### PR DESCRIPTION
### Problem
exportzerocoins help gives an example with a denomination of 5; which doesn't make any sense.

```
Examples:
> veil-cli exportzerocoins false 5
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "exportzerocoins", "params": [false 5] }' -H 'content-type: text/plain;' http://127.0.0.1:58812/
```

### Solution
Tweak it to show an example of 10

```
Examples:
> veil-cli exportzerocoins false 10
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "exportzerocoins", "params": [false 10] }' -H 'content-type: text/plain;' http://127.0.0.1:58812/
```