### PR TITLE
Fix errors compiling for OSX catalina

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -541,6 +541,7 @@ case $host in
            LIBS="$LIBS -L$bdb_prefix/lib"
          fi
          if test x$qt5_prefix != x; then
+           CPPFLAGS="$CPPFLAGS -I$qt5_prefix/include"
            PKG_CONFIG_PATH="$qt5_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
@@ -568,7 +569,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
-     CPPFLAGS="$CPPFLAGS -DMAC_OSX"
+     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0" 
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *android*)

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_64_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](https://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent qrencode gmp
+    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt@5 libevent qrencode gmp
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
@@ -38,7 +38,7 @@ you can use [the installation script included in contrib/](/contrib/install_db4.
 like so
 
 ```shell
-./contrib/install_db4.sh .
+CFLAGS="-Wno-error=implicit-function-declaration"  ./contrib/install_db4.sh .
 ```
 
 from the root of the repository.

--- a/src/qt/macdarkmode.mm
+++ b/src/qt/macdarkmode.mm
@@ -19,19 +19,19 @@ bool isDarkMode()
 // the NSAppearance property.
 //
 // That is to say, the interface is only available on 10.14+.
-@interface NSApplication (NSAppearanceCustomization) <NSAppearanceCustomization>
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wavailability"
-@property (nullable, strong) NSAppearance *appearance;
-@property (readonly, strong) NSAppearance *effectiveAppearance;
-#pragma clang diagnostic pop
-@end
+//@interface NSApplication (NSAppearanceCustomization) <NSAppearanceCustomization>
+//#pragma clang diagnostic push
+//#pragma clang diagnostic ignored "-Wavailability"
+//@property (nullable, strong) NSAppearance *appearance;
+//@property (readonly, strong) NSAppearance *effectiveAppearance;
+//#pragma clang diagnostic pop
+//@end
 
-void disableDarkMode()
-{
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,14,0}])
-    {
-        NSApp.appearance = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
-    }
-}
+//void disableDarkMode()
+//{
+//    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,14,0}])
+//    {
+//        NSApp.appearance = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
+//    }
+//}
 

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -27,18 +27,11 @@ bool dockClickHandler(id self,SEL _cmd,...) {
 }
 
 void setupDockClickHandler() {
-    Class cls = objc_getClass("NSApplication");
-    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
 
-    if (appInst != nullptr) {
-        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
-        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
+        Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
+
         SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
-        if (class_getInstanceMethod(delClass, shouldHandle))
-            class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
-        else
-            class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
-    }
+        class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
 
 

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -7,6 +7,7 @@
 #include <qt/clientmodel.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 

--- a/src/qt/veil.cpp
+++ b/src/qt/veil.cpp
@@ -319,11 +319,15 @@ BitcoinApplication::BitcoinApplication(interfaces::Node& node, int &argc, char *
 
 void BitcoinApplication::setupPlatformStyle()
 {
+// This causes compatibility issues with macOS 10.14+
+// Disabling of dark mode may already be handled in info.plist.in section NSRequiresAquaSystemAppearance
+#if 0
 #if defined(Q_OS_MAC)
     // This is a work around for our not having as yet any "Dark Mode" compatible
     // stylesheets.  Enforce the use of known-good Aqua style on systems that support
     // the NSAppearance property.
     disableDarkMode();
+#endif
 #endif
 
     // UI per-platform customization


### PR DESCRIPTION
Push Summary
Fix compilation issue on MacOS 10.15 Catalina machine.

Root Cause
Changes in XCode 11 Objective-C Runtime caused an error building on
MacOS 10.15 Catalina machine.  
Updated instruction on how to build berkeley DB for macOS 10.15 Catalina.

Solution
Ported solution from bitcoin PR 16720.

Bounty PR
Bounty Payment Address
sv1qqp6aptgvgp9t9h8sgzkqmu6cgq2e20l9x6fsl5ask7t3ygy2jagftcpq0x5z0h522ca5h06qq3hx33pke00r7gjt3j24n896gf55y68ptrmjqqqqd8lz3

Unit Testing Results
