### PR TITLE
[GUI][Zerocoin] transaction list - handle receive from zerocoin transactions

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
 // Copyright (c) 2011-2019 The Particl developers
-// Copyright (c) 2018-2019 Veil developers
+// Copyright (c) 2018-2021 Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -411,7 +411,11 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
             if (wtx.txout_address_is_mine[i]) {
                 // Received by Bitcoin Address
                 sub.type = TransactionRecord::RecvWithAddress;
-                sub.address = EncodeDestination(wtx.txout_address[i]);
+                bool fBech32 = false;    
+                if (boost::get<CScriptID>(&wtx.txout_address[i])){
+                    fBech32 = true;
+                }            
+                sub.address = EncodeDestination(wtx.txout_address[i], fBech32);
             } else {
                 // Received by IP connection (deprecated features), or a multisignature or other non-simple transaction
                 sub.type = TransactionRecord::RecvFromOther;


### PR DESCRIPTION
### Problem ###
The wallet transaction list was updated to show the correct address #898 
Zerocoins sent to a bv1 address were causing the force_return error. The address format is bech32 however the decode method  was trying to decode the address as bech32 = false. 

### Root Cause ###
The address format is bech32 however the decode method  was trying to decode the address as bech32 = false. 

### Solution ###
Decode the address using the correct format.

### Unit Testing Results ###
1. Create a new wallet
2. Get a basecoin address
3. Spend Zerocoins from a different wallet to the basecoin address
4. Verfiy the tx(s) are confirmed in the new wallet
5. Restart the wallet(veil-qt) with -reindex-chainstate
6. Verify the force_return error does not occur