### PR TITLE
[Utils] Templatify AssertLockHeld to placate clang warning

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -152,7 +152,7 @@ std::string LocksHeld()
     return result;
 }
 
-void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
+void _AssertLockHeld(const char* pszName, const char* pszFile, int nLine, void* cs)
 {
     for (const std::pair<void*, CLockLocation>& i : g_lockstack)
         if (i.first == cs)

--- a/src/sync.h
+++ b/src/sync.h
@@ -74,14 +74,21 @@ public:
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false);
 void LeaveCritical();
 std::string LocksHeld();
-void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) ASSERT_EXCLUSIVE_LOCK(cs);
 void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs);
 void DeleteLock(void* cs);
+
+void _AssertLockHeld(const char* pszName, const char* pszFile, int nLine, void* cs);
+template <typename T>
+void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, T* cs) ASSERT_EXCLUSIVE_LOCK(cs) {
+    _AssertLockHeld(pszName, pszFile, nLine, (void*)cs);
+}
 #else
 void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 void static inline LeaveCritical() {}
-void static inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) ASSERT_EXCLUSIVE_LOCK(cs) {}
-void static inline AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
+template <typename T>
+void static inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, T* cs) ASSERT_EXCLUSIVE_LOCK(cs) {}
+template <typename T>
+void static inline AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, T* cs) {}
 void static inline DeleteLock(void* cs) {}
 #endif
 #define AssertLockHeld(cs) AssertLockHeldInternal(#cs, __FILE__, __LINE__, &cs)


### PR DESCRIPTION
By changing the type of the lock from void* (which has no capability) to the actual type (which does).

(Templates more or less have to be defined in a header, included in a header, or specializations explicitly declared in a header, so the actual implementation here is to call the original function that took a void*.)

### Test Results

Built and run veild/veil-cli with clang. Built veild/veil-cli with clang with `-DDEBUG_LOCKORDER`.