### PR TITLE
[Wallet] Lock cs_wallet in additional places.

### DIFF
--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -4527,6 +4527,7 @@ bool AnonWallet::AddStealthDestinationMeta(const CKeyID& idStealth, const CKeyID
 
 bool AnonWallet::AddKeyToParent(const CKey& keySharedSecret)
 {
+    LOCK(pwalletParent->cs_wallet);
     //Since the new key is not derived through Ext, for now keep it in CWallet keystore
     bool fSuccess = true;
     if (!pwalletParent->AddKeyPubKey(keySharedSecret, keySharedSecret.GetPubKey())) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4647,6 +4647,7 @@ std::set<CTxDestination> CWallet::GetLabelAddresses(const std::string& label) co
 
 bool CReserveKey::GetReservedKey(CPubKey& pubkey, bool internal)
 {
+    LOCK(pwallet->cs_wallet);
     if (nIndex == -1)
     {
         CKeyPool keypool;
@@ -4663,14 +4664,17 @@ bool CReserveKey::GetReservedKey(CPubKey& pubkey, bool internal)
 
 void CReserveKey::KeepKey()
 {
-    if (nIndex != -1)
+    LOCK(pwallet->cs_wallet);
+    if (nIndex != -1) {
         pwallet->KeepKey(nIndex);
+    }
     nIndex = -1;
     vchPubKey = CPubKey();
 }
 
 void CReserveKey::ReturnKey()
 {
+    LOCK(pwallet->cs_wallet);
     if (nIndex != -1) {
         pwallet->ReturnKey(nIndex, fInternal, vchPubKey);
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1157,7 +1157,7 @@ public:
      *     or external keypool
      */
     bool ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fRequestedInternal);
-    void KeepKey(int64_t nIndex);
+    void KeepKey(int64_t nIndex) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey);
     bool GetKeyFromPool(CPubKey &key, bool internal = false);
     int64_t GetOldestKeyPoolTime();
@@ -1380,8 +1380,8 @@ class CReserveKey final : public CReserveScript
 {
 protected:
     CWallet* pwallet;
-    int64_t nIndex;
-    CPubKey vchPubKey;
+    int64_t nIndex GUARDED_BY(pwallet->cs_wallet);
+    CPubKey vchPubKey GUARDED_BY(pwallet->cs_wallet);
     bool fInternal;
 public:
     explicit CReserveKey(CWallet* pwalletIn)


### PR DESCRIPTION
### Problem
tsan identifies a data race within WalletBatch, commonly between KeepKey and AddToWallet.

### Solution
Declare CWallet::KeepKey as requiring `cs_wallet`, and take it before all calls as prescribed by clang. (This moved the tsan data race to the nearby fields of CReserveKey, which was mitigated by including their access within the lock.)
Add another cs_wallet use per clang warning: AddKeyPubKey requires holding mutex 'pwalletParent->cs_wallet' exclusively.

### Tested
Configured with --with-sanitizers=thread, built with clang, and run on regtest. tsan warnings for this area no longer appear.
