### PR TITLE
[Consensus] Add locking on the chain index vector.

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -16,6 +16,7 @@
  * CChain implementation
  */
 void CChain::SetTip(CBlockIndex *pindex) {
+    LOCK(cs_vchain);
     if (pindex == nullptr) {
         vChain.clear();
         return;
@@ -68,6 +69,7 @@ const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
 
 CBlockIndex* CChain::FindEarliestAtLeast(int64_t nTime) const
 {
+    LOCK(cs_vchain);
     std::vector<CBlockIndex*>::const_iterator lower = std::lower_bound(vChain.begin(), vChain.end(), nTime,
         [](CBlockIndex* pBlock, const int64_t& time) -> bool { return pBlock->GetBlockTimeMax() < time; });
     return (lower == vChain.end() ? nullptr : *lower);


### PR DESCRIPTION
### Problem
tsan identified a data race on CChain, particularly concurrent access to the underlying vector's `operator[]`, `size`, and `resize` member functions.

### Solution
Create a new lock `cs_vchain` and mark `vchain` as guarded by it, and ensure that the lock is taken prior to any use.
For the `operator==` member function, grab both the locks in a prescribed order to avoid a deadlock.

### Tested
Configured with --with-sanitizers=tsan, built with clang, run on regtest with 2 SHA mining threads enabled.