### PR TITLE
[Consensus] Protect mapBlockIndex with its own mutex

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -179,7 +179,7 @@ enum BlockMemFlags: uint32_t {
 class CBlockIndex
 {
 public:
-    //! pointer to the hash of the block, if any. Memory is owned by this CBlockIndex
+    //! pointer to the hash of the block, if any. Memory is owned by mapBlockIndex
     const uint256* phashBlock;
 
     //! pointer to the index of the predecessor of this block

--- a/src/chain.h
+++ b/src/chain.h
@@ -180,91 +180,103 @@ class CBlockIndex
 {
 public:
     //! pointer to the hash of the block, if any. Memory is owned by mapBlockIndex
-    const uint256* phashBlock;
+    const uint256* phashBlock{nullptr};
 
     //! pointer to the index of the predecessor of this block
-    CBlockIndex* pprev;
+    CBlockIndex* pprev{nullptr};
 
     //! pointer to the index of some further predecessor of this block
-    CBlockIndex* pskip;
+    CBlockIndex* pskip{nullptr};
 
     //! height of the entry in the chain. The genesis block has height 0
-    int nHeight;
+    int nHeight{0};
 
     //! money supply tracking
-    int64_t nMoneySupply;
+    int64_t nMoneySupply{0};
 
     //! zerocoin mint supply tracking
-    int64_t nMint;
+    int64_t nMint{0};
 
     //! Which # file this block is stored in (blk?????.dat)
-    int nFile;
+    int nFile{0};
 
     //! Byte offset within blk?????.dat where this block's data is stored
-    unsigned int nDataPos;
+    unsigned int nDataPos{0};
 
     //! Byte offset within rev?????.dat where this block's undo data is stored
-    unsigned int nUndoPos;
+    unsigned int nUndoPos{0};
 
     //! (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
-    arith_uint256 nChainWork;
+    arith_uint256 nChainWork{};
 
     //! (memory only) Total amount of work (only looking at PoW) in the chain up to and including this block
-    arith_uint256 nChainPoW;
+    arith_uint256 nChainPoW{};
 
     //! Number of transactions in this block.
     //! Note: in a potential headers-first mode, this number cannot be relied upon
-    unsigned int nTx;
+    unsigned int nTx{0};
 
     //! (memory only) Number of transactions in the chain up to and including this block.
     //! This value will be non-zero only if and only if transactions for this block and all its parents are available.
     //! Change to 64-bit type when necessary; won't happen before 2030
-    unsigned int nChainTx;
+    unsigned int nChainTx{0};
 
-    int64_t nAnonOutputs; // last index
+    int64_t nAnonOutputs{0}; // last index
 
     //! Verification status of this block. See enum BlockStatus
-    uint32_t nStatus;
+    uint32_t nStatus{0};
 
-    bool fProofOfStake;
-    bool fProofOfFullNode;
+    bool fProofOfStake{false};
+    bool fProofOfFullNode{false};
 
     //! Funds sent into the network to serve as an additional reward to stakers and miners
-    CAmount nNetworkRewardReserve;
+    CAmount nNetworkRewardReserve{0};
 
     //! block header
-    int32_t nVersion;
-    uint256 hashVeilData;
-    uint32_t nTime;
-    uint32_t nBits;
-    uint32_t nNonce;
+    int32_t nVersion{0};
+    uint256 hashVeilData{};
+    uint32_t nTime{0};
+    uint32_t nBits{0};
+    uint32_t nNonce{0};
 
     //! ProgPow Header items
     // Height was already in the CBlockIndex
-    uint64_t nNonce64;
-    uint256 mixHash;
+    uint64_t nNonce64{0};
+    uint256 mixHash{};
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
-    int32_t nSequenceId;
+    int32_t nSequenceId{0};
 
     //! zerocoin specific fields
     std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
     std::vector<libzerocoin::CoinDenomination> vMintDenominationsInBlock;
 
     //! (memory only) Maximum nTime in the chain up to and including this block.
-    unsigned int nTimeMax;
+    unsigned int nTimeMax{0};
 
     //! Hash value for the accumulator. Can be used to access the zerocoindb for the accumulator value
     std::map<libzerocoin::CoinDenomination ,uint256> mapAccumulatorHashes;
 
-    uint256 hashMerkleRoot;
-    uint256 hashWitnessMerkleRoot;
-    uint256 hashPoFN;
-    uint256 hashAccumulators;
+    uint256 hashMerkleRoot{};
+    uint256 hashWitnessMerkleRoot{};
+    uint256 hashPoFN{};
+    uint256 hashAccumulators{};
 
     //! vector that holds a proof of stake proof hash if the block has one. If not, its empty and has less memory
     //! overhead than an empty uint256
     std::vector<unsigned char> vHashProof;
+
+    void ResetMaps()
+    {
+        for (auto& denom : libzerocoin::zerocoinDenomList) {
+            mapAccumulatorHashes[denom] = uint256();
+        }
+
+        // Start supply of each denomination with 0s
+        for (auto& denom : libzerocoin::zerocoinDenomList) {
+            mapZerocoinSupply.insert(std::make_pair(denom, 0));
+        }
+    }
 
     void SetNull()
     {
@@ -301,14 +313,7 @@ public:
         hashWitnessMerkleRoot = uint256();
         hashAccumulators = uint256();
 
-        for (auto& denom : libzerocoin::zerocoinDenomList) {
-            mapAccumulatorHashes[denom] = uint256();
-        }
-
-        // Start supply of each denomination with 0s
-        for (auto& denom : libzerocoin::zerocoinDenomList) {
-            mapZerocoinSupply.insert(std::make_pair(denom, 0));
-        }
+        ResetMaps();
 
         vMintDenominationsInBlock.clear();
 
@@ -327,27 +332,23 @@ public:
 
     CBlockIndex()
     {
-        SetNull();
+        ResetMaps();
     }
 
     explicit CBlockIndex(const CBlockHeader& block)
+        : nHeight{static_cast<int>(block.nHeight)},
+          nVersion{block.nVersion},
+          hashVeilData{block.hashVeilData},
+          nTime{block.nTime},
+          nBits{block.nBits},
+          nNonce{block.nNonce},
+          nNonce64{block.nNonce64},
+          mixHash{block.mixHash},
+          hashMerkleRoot{block.hashMerkleRoot},
+          hashWitnessMerkleRoot{block.hashWitnessMerkleRoot},
+          hashAccumulators{block.hashAccumulators}
     {
-        SetNull();
-
-        nVersion       = block.nVersion;
-        hashVeilData   = block.hashVeilData;
-        hashMerkleRoot = block.hashMerkleRoot;
-        hashWitnessMerkleRoot = block.hashWitnessMerkleRoot;
-        hashAccumulators = block.hashAccumulators;
-        nTime          = block.nTime;
-        nBits          = block.nBits;
-        nNonce         = block.nNonce;
-        nMint          = 0;
-
-        //ProgPow
-        nNonce64       = block.nNonce64;
-        mixHash        = block.mixHash;
-        nHeight        = block.nHeight;
+        ResetMaps();
     }
 
     CDiskBlockPos GetBlockPos() const {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -194,11 +194,7 @@ void BaseIndex::ChainStateFlushed(const CBlockLocator& locator)
     }
 
     const uint256& locator_tip_hash = locator.vHave.front();
-    const CBlockIndex* locator_tip_index;
-    {
-        LOCK(cs_main);
-        locator_tip_index = LookupBlockIndex(locator_tip_hash);
-    }
+    const CBlockIndex* locator_tip_index = LookupBlockIndex(locator_tip_hash);
 
     if (!locator_tip_index) {
         FatalError("%s: First block (hash=%s) in locator was not found",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1602,10 +1602,13 @@ bool AppInitMain()
                     break;
                 }
 
-                // If the loaded chain has a wrong genesis, bail out immediately
-                // (we're likely using a testnet datadir, or the other way around).
-                if (!mapBlockIndex.empty() && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
-                    return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
+                {
+                    LOCK(cs_mapblockindex);
+                    // If the loaded chain has a wrong genesis, bail out immediately
+                    // (we're likely using a testnet datadir, or the other way around).
+                    if (!mapBlockIndex.empty() && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
+                        return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
+                    }
                 }
 
                 // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
@@ -1835,14 +1838,12 @@ bool AppInitMain()
 
     // ********************************************************* Step 12: start node
 
-    int chain_active_height;
-
     //// debug print
     {
-        LOCK(cs_main);
+        LOCK(cs_mapblockindex);
         LogPrintf("mapBlockIndex.size() = %u\n", mapBlockIndex.size());
-        chain_active_height = chainActive.Height();
     }
+    int chain_active_height = chainActive.Height();
     LogPrintf("nBestHeight = %d\n", chain_active_height);
 
     if (gArgs.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -237,8 +237,7 @@ WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
 {
     LOCK(cs_main);
     WalletTxStatus result;
-    auto mi = ::mapBlockIndex.find(wtx.hashBlock);
-    CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;
+    CBlockIndex* block = LookupBlockIndex(wtx.hashBlock);
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max());
     result.blocks_to_maturity = wtx.GetBlocksToMaturity();
     result.depth_in_main_chain = wtx.GetDepthInMainChain();
@@ -256,9 +255,8 @@ WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
 WalletTxStatus MakeWalletTxStatus(AnonWallet* pAnonWallet, const uint256 &hash, const CTransactionRecord &rtx)
 {
     WalletTxStatus result;
-    auto mi = ::mapBlockIndex.find(rtx.blockHash);
 
-    CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;
+    CBlockIndex* block = LookupBlockIndex(rtx.blockHash);
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max()),
 
             result.blocks_to_maturity = 0;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,13 +168,13 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     CMutableTransaction txCoinStake;
     CBlockIndex* pindexPrev;
+    //Do not pass in the chain tip, because it can change. Instead pass the blockindex directly from mapblockindex, which is const.
+    auto pindexTip = chainActive.Tip();
+    if (!pindexTip)
+        return nullptr;
+    auto hashBest = pindexTip->GetBlockHash();
     {
-        LOCK(cs_main);
-        //Do not pass in the chain tip, because it can change. Instead pass the blockindex directly from mapblockindex, which is const.
-        auto pindexTip = chainActive.Tip();
-        if (!pindexTip)
-            return nullptr;
-        auto hashBest = pindexTip->GetBlockHash();
+        LOCK(cs_mapblockindex);
         pindexPrev = mapBlockIndex.at(hashBest);
     }
     if (fProofOfStake && pindexPrev->nHeight + 1 >= Params().HeightPoSStart()) {

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -565,14 +565,15 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             uint256 hashBlock;
             if (!GetTransaction(txid, txRef, Params().GetConsensus(), hashBlock, true))
                 continue;
-            auto it = mapBlockIndex.find(hashBlock);
-            if (it == mapBlockIndex.end())
+
+            CBlockIndex* block = LookupBlockIndex(hashBlock);
+            if (block == nullptr)
                 continue;
 
-            if (!chainActive.Contains(it->second))
+            if (!chainActive.Contains(block))
                 continue;
 
-            nDepth = chainActive.Height() - it->second->nHeight + 1;
+            nDepth = chainActive.Height() - block->nHeight + 1;
         }
 
         if (nDepth < 1)
@@ -888,15 +889,15 @@ void CoinControlDialog::updateView(int nCoinType)
                 if (!GetTransaction(txid, txRef, Params().GetConsensus(), hashBlock, true))
                     continue;
 
-                auto it = mapBlockIndex.find(hashBlock);
-                if (it == mapBlockIndex.end())
+                CBlockIndex* block = LookupBlockIndex(hashBlock);
+                if (block == nullptr)
                     continue;
 
-                if (!chainActive.Contains(it->second))
+                if (!chainActive.Contains(block))
                     continue;
 
-                nDepth = chainActive.Height() - it->second->nHeight + 1;
-                nTimeTx = it->second->GetBlockTime();
+                nDepth = chainActive.Height() - block->nHeight + 1;
+                nTimeTx = block->GetBlockTime();
             }
 
             for (unsigned int i = 0; i < txRecord.vout.size(); i++) {
@@ -1062,15 +1063,15 @@ void CoinControlDialog::updateView(int nCoinType)
                 if (!GetTransaction(mint.txid, txRef, Params().GetConsensus(), hashBlock, true))
                     continue;
 
-                auto it = mapBlockIndex.find(hashBlock);
-                if (it == mapBlockIndex.end())
+                CBlockIndex* block = LookupBlockIndex(hashBlock);
+                if (block == nullptr)
                     continue;
 
-                if (!chainActive.Contains(it->second))
+                if (!chainActive.Contains(block))
                     continue;
 
-                nDepth = chainActive.Height() - it->second->nHeight + 1;
-                nTimeTx = it->second->GetBlockTime();
+                nDepth = chainActive.Height() - block->nHeight + 1;
+                nTimeTx = block->GetBlockTime();
             }
 
             // increase the count for each denom we see

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -960,35 +960,27 @@ static UniValue getblockheader(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
         );
 
-    const CBlockIndex* pChainTip;
-    const CBlockIndex* pblockindex;
-    {
-        LOCK(cs_main);
+    std::string strHash = request.params[0].get_str();
+    uint256 hash(uint256S(strHash));
 
-        std::string strHash = request.params[0].get_str();
-        uint256 hash(uint256S(strHash));
+    bool fVerbose = true;
+    if (!request.params[1].isNull())
+        fVerbose = request.params[1].get_bool();
 
-        bool fVerbose = true;
-        if (!request.params[1].isNull())
-            fVerbose = request.params[1].get_bool();
-
-        pblockindex = LookupBlockIndex(hash);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
-
-        if (!fVerbose)
-        {
-            CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
-            ssBlock << pblockindex->GetBlockHeader();
-            std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
-            return strHex;
-        }
-
-        pChainTip = chainActive.Tip();
+    const CBlockIndex* pblockindex = LookupBlockIndex(hash);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
 
-    return blockheaderToJSON(pChainTip, pblockindex);
+    if (!fVerbose)
+    {
+        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
+        ssBlock << pblockindex->GetBlockHeader();
+        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+        return strHex;
+    }
+
+    return blockheaderToJSON(chainActive.Tip(), pblockindex);
 }
 
 static CBlock GetBlockChecked(const CBlockIndex* pblockindex)
@@ -1072,20 +1064,14 @@ static UniValue getblock(const JSONRPCRequest& request)
             verbosity = request.params[1].get_bool() ? 1 : 0;
     }
 
-    CBlock block;
-    const CBlockIndex* pblockindex;
-    const CBlockIndex* tip;
-    {
-        LOCK(cs_main);
-        pblockindex = LookupBlockIndex(hash);
-        tip = chainActive.Tip();
+    const CBlockIndex* pblockindex = LookupBlockIndex(hash);
+    const CBlockIndex* tip = chainActive.Tip();
 
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
-
-        block = GetBlockChecked(pblockindex);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
+
+    CBlock block = GetBlockChecked(pblockindex);
 
     if (verbosity <= 0)
     {
@@ -1138,10 +1124,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
 
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     stats.hashBlock = pcursor->GetBestBlock();
-    {
-        LOCK(cs_main);
-        stats.nHeight = LookupBlockIndex(stats.hashBlock)->nHeight;
-    }
+    stats.nHeight = LookupBlockIndex(stats.hashBlock)->nHeight;
     ss << stats.hashBlock;
     uint256 prevkey;
     std::map<uint32_t, Coin> outputs;
@@ -1609,11 +1592,14 @@ static UniValue getchaintips(const JSONRPCRequest& request)
     std::set<const CBlockIndex*> setOrphans;
     std::set<const CBlockIndex*> setPrevs;
 
-    for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex)
     {
-        if (!chainActive.Contains(item.second)) {
-            setOrphans.insert(item.second);
-            setPrevs.insert(item.second->pprev);
+        LOCK(cs_mapblockindex);
+        for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex)
+        {
+            if (!chainActive.Contains(item.second)) {
+                setOrphans.insert(item.second);
+                setPrevs.insert(item.second->pprev);
+            }
         }
     }
 
@@ -1721,14 +1707,10 @@ static UniValue preciousblock(const JSONRPCRequest& request)
 
     std::string strHash = request.params[0].get_str();
     uint256 hash(uint256S(strHash));
-    CBlockIndex* pblockindex;
 
-    {
-        LOCK(cs_main);
-        pblockindex = LookupBlockIndex(hash);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
+    CBlockIndex* pblockindex = LookupBlockIndex(hash);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
 
     CValidationState state;
@@ -1759,13 +1741,13 @@ static UniValue invalidateblock(const JSONRPCRequest& request)
     uint256 hash(uint256S(strHash));
     CValidationState state;
 
+    CBlockIndex* pblockindex = LookupBlockIndex(hash);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+    }
+
     {
         LOCK(cs_main);
-        CBlockIndex* pblockindex = LookupBlockIndex(hash);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
-
         InvalidateBlock(state, Params(), pblockindex);
     }
 
@@ -1798,13 +1780,13 @@ static UniValue reconsiderblock(const JSONRPCRequest& request)
     std::string strHash = request.params[0].get_str();
     uint256 hash(uint256S(strHash));
 
+    CBlockIndex* pblockindex = LookupBlockIndex(hash);
+    if (!pblockindex) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+    }
+
     {
         LOCK(cs_main);
-        CBlockIndex* pblockindex = LookupBlockIndex(hash);
-        if (!pblockindex) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        }
-
         ResetBlockFailureFlags(pblockindex);
     }
 
@@ -1846,11 +1828,9 @@ static UniValue getchaintxstats(const JSONRPCRequest& request)
     int blockcount = 30 * 24 * 60 * 60 / Params().GetConsensus().nPowTargetSpacing; // By default: 1 month
 
     if (request.params[1].isNull()) {
-        LOCK(cs_main);
         pindex = chainActive.Tip();
     } else {
         uint256 hash = uint256S(request.params[1].get_str());
-        LOCK(cs_main);
         pindex = LookupBlockIndex(hash);
         if (!pindex) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
@@ -2007,8 +1987,6 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockstats", "1000 '[\"minfeerate\",\"avgfeerate\"]'")
         );
     }
-
-    LOCK(cs_main);
 
     CBlockIndex* pindex;
     if (request.params[0].isNum()) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -993,25 +993,19 @@ static UniValue pprpcsb(const JSONRPCRequest& request) {
     blockptr->mixHash = calculated_mix_hash;
 
     uint256 hash = blockptr->GetHash();
-    {
-        LOCK(cs_main);
-        const CBlockIndex* pindex = LookupBlockIndex(hash);
-        if (pindex) {
-            if (pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
-                return "duplicate";
-            }
-            if (pindex->nStatus & BLOCK_FAILED_MASK) {
-                return "duplicate-invalid";
-            }
+    const CBlockIndex* pindex = LookupBlockIndex(hash);
+    if (pindex) {
+        if (pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
+            return "duplicate";
+        }
+        if (pindex->nStatus & BLOCK_FAILED_MASK) {
+            return "duplicate-invalid";
         }
     }
 
-    {
-        LOCK(cs_main);
-        const CBlockIndex* pindex = LookupBlockIndex(blockptr->hashPrevBlock);
-        if (pindex) {
-            UpdateUncommittedBlockStructures(*blockptr, pindex, Params().GetConsensus());
-        }
+    pindex = LookupBlockIndex(blockptr->hashPrevBlock);
+    if (pindex) {
+        UpdateUncommittedBlockStructures(*blockptr, pindex, Params().GetConsensus());
     }
 
     bool new_block;
@@ -1069,25 +1063,19 @@ static UniValue submitblock(const JSONRPCRequest& request)
     }
 
     uint256 hash = block.GetHash();
-    {
-        LOCK(cs_main);
-        const CBlockIndex* pindex = LookupBlockIndex(hash);
-        if (pindex) {
-            if (pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
-                return "duplicate";
-            }
-            if (pindex->nStatus & BLOCK_FAILED_MASK) {
-                return "duplicate-invalid";
-            }
+    const CBlockIndex* pindex = LookupBlockIndex(hash);
+    if (pindex) {
+        if (pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
+            return "duplicate";
+        }
+        if (pindex->nStatus & BLOCK_FAILED_MASK) {
+            return "duplicate-invalid";
         }
     }
 
-    {
-        LOCK(cs_main);
-        const CBlockIndex* pindex = LookupBlockIndex(block.hashPrevBlock);
-        if (pindex) {
-            UpdateUncommittedBlockStructures(block, pindex, Params().GetConsensus());
-        }
+    pindex = LookupBlockIndex(block.hashPrevBlock);
+    if (pindex) {
+        UpdateUncommittedBlockStructures(block, pindex, Params().GetConsensus());
     }
 
     bool new_block;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -51,8 +51,6 @@ static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& 
     TxToUniv(tx, uint256(), vTxRingCtInputs, entry, true, RPCSerializationFlags());
 
     if (!hashBlock.IsNull()) {
-        LOCK(cs_main);
-
         entry.pushKV("blockhash", hashBlock.GetHex());
         CBlockIndex* pindex = LookupBlockIndex(hashBlock);
         if (pindex) {
@@ -164,8 +162,6 @@ static UniValue getrawtransaction(const JSONRPCRequest& request)
     }
 
     if (!request.params[2].isNull()) {
-        LOCK(cs_main);
-
         uint256 blockhash = ParseHashV(request.params[2], "parameter 3");
         blockindex = LookupBlockIndex(blockhash);
         if (!blockindex) {
@@ -248,7 +244,6 @@ static UniValue gettxoutproof(const JSONRPCRequest& request)
     CBlockIndex* pblockindex = nullptr;
     uint256 hashBlock;
     if (!request.params[1].isNull()) {
-        LOCK(cs_main);
         hashBlock = uint256S(request.params[1].get_str());
         pblockindex = LookupBlockIndex(hashBlock);
         if (!pblockindex) {
@@ -272,8 +267,6 @@ static UniValue gettxoutproof(const JSONRPCRequest& request)
     if (g_txindex && !pblockindex) {
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
-
-    LOCK(cs_main);
 
     if (pblockindex == nullptr)
     {
@@ -328,8 +321,6 @@ static UniValue verifytxoutproof(const JSONRPCRequest& request)
     std::vector<unsigned int> vIndex;
     //if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) != merkleBlock.header.hashMerkleRoot)
     //    return res;
-
-    LOCK(cs_main);
 
     const CBlockIndex* pindex = LookupBlockIndex(merkleBlock.header.GetHash());
     if (!pindex || !chainActive.Contains(pindex) || pindex->nTx == 0) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -154,7 +154,9 @@ extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
 extern std::atomic_bool g_is_mempool_loaded;
 typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
-extern BlockMap& mapBlockIndex;
+// Only protects the map, not any attributes of its contents.
+extern CCriticalSection& cs_mapblockindex;
+extern BlockMap& mapBlockIndex GUARDED_BY(cs_mapblockindex);
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockWeight;
 extern const std::string strMessageMagic;
@@ -309,7 +311,7 @@ uint64_t CalculateCurrentUsage();
 /**
  *  Mark one block file as pruned.
  */
-void PruneOneBlockFile(const int fileNumber);
+void PruneOneBlockFile(const int fileNumber) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**
  *  Actually unlink the specified files
@@ -484,7 +486,7 @@ bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
 inline CBlockIndex* LookupBlockIndex(const uint256& hash)
 {
-    AssertLockHeld(cs_main);
+    LOCK(cs_mapblockindex);
     BlockMap::const_iterator it = mapBlockIndex.find(hash);
     return it == mapBlockIndex.end() ? nullptr : it->second;
 }

--- a/src/veil/zerocoin/accumulators.cpp
+++ b/src/veil/zerocoin/accumulators.cpp
@@ -396,7 +396,10 @@ bool GenerateAccumulatorWitness(const PublicCoin &coin, Accumulator& accumulator
         if (!IsBlockHashInChain(hashBlock, nHeightTest))
             return error("%s: mint tx %s is not in chain", __func__, txid.GetHex());
 
-        nHeightMintAdded = mapBlockIndex[hashBlock]->nHeight;
+        {
+            LOCK(cs_mapblockindex);
+            nHeightMintAdded = mapBlockIndex[hashBlock]->nHeight;
+        }
 
         //get the checkpoint added at the next multiple of 10
         int nHeightCheckpoint = nHeightMintAdded + (10 - (nHeightMintAdded % 10));

--- a/src/veil/zerocoin/zchain.cpp
+++ b/src/veil/zerocoin/zchain.cpp
@@ -203,9 +203,14 @@ void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMin
             continue;
         }
 
-        if (!mapBlockIndex.count(hashBlock)) {
-            vMissingMints.push_back(meta);
-            continue;
+        int nHeight;
+        {
+            LOCK(cs_mapblockindex);
+            if (!mapBlockIndex.count(hashBlock)) {
+                vMissingMints.push_back(meta);
+                continue;
+            }
+            nHeight = mapBlockIndex[hashBlock]->nHeight;
         }
 
         //see if this mint is spent
@@ -245,12 +250,12 @@ void FindMints(std::vector<CMintMeta> vMintsToFind, std::vector<CMintMeta>& vMin
         }
 
         // if meta data is correct, then no need to update
-        if (meta.txid == txHash && meta.nHeight == mapBlockIndex[hashBlock]->nHeight && meta.isUsed == fSpent)
+        if (meta.txid == txHash && meta.nHeight == nHeight && meta.isUsed == fSpent)
             continue;
 
         //mark this mint for update
         meta.txid = txHash;
-        meta.nHeight = mapBlockIndex[hashBlock]->nHeight;
+        meta.nHeight = nHeight;
         meta.isUsed = fSpent;
         LogPrintf("%s: found updates for pubcoinhash = %s\n", __func__, meta.hashPubcoin.GetHex());
 

--- a/src/veil/zerocoin/ztracker.cpp
+++ b/src/veil/zerocoin/ztracker.cpp
@@ -434,7 +434,12 @@ bool CzTracker::UpdateStatusInternal(const std::set<uint256>& setMempool, const 
         }
 
         // An orphan tx if hashblock is in mapBlockIndex but not in chain active
-        if (mapBlockIndex.count(hashBlock) && !chainActive.Contains(mapBlockIndex.at(hashBlock))) {
+        bool orphaned;
+        {
+            LOCK(cs_mapblockindex);
+            orphaned = mapBlockIndex.count(hashBlock) && !chainActive.Contains(mapBlockIndex.at(hashBlock));
+        }
+        if (orphaned) {
             LogPrintf("%s : Found orphaned mint txid=%s\n", __func__, mint.txid.GetHex());
             mint.isUsed = false;
             mint.nHeight = 0;

--- a/src/veil/zerocoin/zwallet.cpp
+++ b/src/veil/zerocoin/zwallet.cpp
@@ -252,8 +252,11 @@ void CzWallet::SyncWithChain(bool fGenerateMintPool)
                 }
 
                 CBlockIndex* pindex = nullptr;
-                if (mapBlockIndex.count(hashBlock))
-                    pindex = mapBlockIndex.at(hashBlock);
+                {
+                    LOCK(cs_mapblockindex);
+                    if (mapBlockIndex.count(hashBlock))
+                        pindex = mapBlockIndex.at(hashBlock);
+                }
 
                 if (!setAddedTx.count(txHash)) {
                     CBlock block;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2392,8 +2392,6 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     // the user could have gotten from another RPC command prior to now
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    LOCK2(cs_main, pwallet->cs_wallet);
-
     const CBlockIndex* pindex = nullptr;    // Block index of the specified block or the common ancestor, if the block provided was in a deactivated chain.
     const CBlockIndex* paltindex = nullptr; // Block index of the specified block, even if it's in a deactivated chain.
     int target_confirms = 1;
@@ -2432,6 +2430,8 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     int depth = pindex ? (1 + chainActive.Height() - pindex->nHeight) : -1;
 
     UniValue transactions(UniValue::VARR);
+
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     for (const std::pair<const uint256, CWalletTx>& pairWtx : pwallet->mapWallet) {
         CWalletTx tx = pairWtx.second;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -204,7 +204,7 @@ static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64
     SetMockTime(mockTime);
     CBlockIndex* block = nullptr;
     if (blockTime > 0) {
-        LOCK(cs_main);
+        LOCK(cs_mapblockindex);
         auto inserted = mapBlockIndex.emplace(GetRandHash(), new CBlockIndex);
         assert(inserted.second);
         const uint256& hash = inserted.first->first;


### PR DESCRIPTION
### Problem
tsan identified a data race on CChainState, particularly between AcceptBlock and ActivateBestChain (used often by the miner threads).

### Solution
Mark `mapBlockIndex` as guarded by `cs_mapblockindex`, and ensure that the lock is taken prior to any use. Some code has been reorganized slightly to reduce the time spent holding the lock and avoid locking a second time for the same information.

Move many lookups to use LookupBlockIndex, which grabs the lock itself, and remove lots of cs_main uses that would have otherwise blocked only for LookupBlockIndex.

### Tested
Original: Configured with --with-sanitizers=tsan, built with clang, run on regtest with 2 SHA mining threads enabled.
With cs_mapblockindex: configured --with-sanitizers=tsan, built with clang, run on testnet to catch up and mine 2 sha threads.