### PR TITLE
[Wallet][Consensus] Resolve misc clang lock annotation warnings.

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -235,6 +235,7 @@ WalletTx MakeWalletTx(CHDWallet& wallet, MapRecords_t::const_iterator irtx)
 //! Construct wallet tx status struct.
 WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
 {
+    LOCK(cs_main);
     WalletTxStatus result;
     auto mi = ::mapBlockIndex.find(wtx.hashBlock);
     CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -499,7 +499,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     if(fProofOfFullNode && !fProofOfStake)
         LogPrint(BCLog::BLOCKCREATION, "%s: A block can not be proof of full node and proof of work.\n", __func__);
     else if(fProofOfFullNode && fProofOfStake) {
-        LOCK(cs_main);
+        AssertLockHeld(cs_main);
         pblock->hashPoFN = veil::GetFullNodeHash(*pblock, pindexPrev);
     }
 


### PR DESCRIPTION
### Problem
Building with clang results in lots of warnings about lock annotations not being obeyed.

### Solution
Follow instructions on warnings:
- Replace double lock of cs_main with an assertion.
- Reorganize code to release cs_main before calling blockheaderToJSON.
- Lock cs_main before calling any of: GetBlocksToMaturity, GetAddressBalances, IsSpent, TestBlockValidity.

### Tested
Configured with --with-sanitizers=thread, built with clang, run on regtest.