### PR TITLE
[Logging] Improve hash mismatch warning log message.

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -285,8 +285,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 // ignore any duplicates and mark them to be erased
                 uint256 hashBlock = diskindex.GetBlockHash();
                 if (hashBlock != key.second) {
-                    LogPrintf("%s: Skipping Block %d: %s - Block Hash does not match Index Key\n",
-                               __func__, diskindex.nStatus, hashBlock.GetHex());
+                    LogPrintf("%s: Skipping Block %d (status=%d): %s - Block Hash does not match Index Key\n",
+                               __func__, diskindex.nHeight, diskindex.nStatus, hashBlock.GetHex());
                     pcursor->Next();
                     continue;
                 }


### PR DESCRIPTION
Previously, it was logging "Block 2: ..." when 2 was the status, which is fairly misleading. Now, output both the height and the status and make clear which is which.

### Tested
Mildly, during my other regtest runs, and startup for testnet.