### PR TITLE
[Chain] Keep hashAccumulators more up-to-date.

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -254,14 +254,16 @@ const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* 
 void CBlockIndex::AddAccumulator(libzerocoin::CoinDenomination denom, CBigNum bnAccumulator)
 {
     mapAccumulatorHashes[denom] = SerializeHash(bnAccumulator);
+    hashAccumulators = SerializeHash(mapAccumulatorHashes);
 }
 
 void CBlockIndex::AddAccumulator(AccumulatorMap mapAccumulator)
 {
     for(libzerocoin::CoinDenomination denom : libzerocoin::zerocoinDenomList) {
         CBigNum bnAccumulator = mapAccumulator.GetValue(denom);
-        AddAccumulator(denom, bnAccumulator);
+        mapAccumulatorHashes[denom] = SerializeHash(bnAccumulator);
     }
+    hashAccumulators = SerializeHash(mapAccumulatorHashes);
 }
 
 uint256 CBlockIndex::GetRandomXPoWHash() const

--- a/src/chain.h
+++ b/src/chain.h
@@ -384,7 +384,7 @@ public:
 
         block.hashMerkleRoot = hashMerkleRoot;
         block.hashWitnessMerkleRoot = hashWitnessMerkleRoot;
-        block.hashAccumulators = SerializeHash(mapAccumulatorHashes);
+        block.hashAccumulators = hashAccumulators;
         //ProgPow
         block.nNonce64       = nNonce64;
         block.mixHash        = mixHash;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -324,6 +324,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
                 // zerocoin
                 pindexNew->mapAccumulatorHashes = diskindex.mapAccumulatorHashes;
+                pindexNew->hashAccumulators = diskindex.hashAccumulators;
                 pindexNew->mapZerocoinSupply = diskindex.mapZerocoinSupply;
                 pindexNew->vMintDenominationsInBlock = diskindex.vMintDenominationsInBlock;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2759,6 +2759,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         return state.DoS(100, error("%s: Failed to calculate new zerocoin supply for block=%s height=%d", __func__,
                                     block.GetHash().GetHex(), pindex->nHeight), REJECT_INVALID);
     pindex->mapAccumulatorHashes = block.mapAccumulatorHashes;
+    pindex->hashAccumulators = block.hashAccumulators;
 
     // track money supply and mint amount info
     CAmount nMoneySupplyPrev = pindex->pprev ? pindex->pprev->nMoneySupply : 0;


### PR DESCRIPTION
### Problem

Issue #942:
Orphaned blocks sometimes had inconsistent hashes between block index hash (generally the cached value) and the disk index hash (produced by taking a new hash of the data). On closer inspection, `hashAccumulators` was the only differing value.

### Solution

Make sure `hashAccumulators` is set or copied appropriately where relevant, particularly when `mapAccumulatorHashes` is set but not changed. The main culprit is likely `LoadBlockIndexGuts`, since it would be very easy to forget to update `hashAccumulators` before writing it out again.

Plus we use `hashAccumulators` instead of recalculating the map's hash as described in #942.

### Testing

On regtest, with lots of extra debug warnings in `WriteBatchSync` about bad hashes, minted zerocoins in forks, confirmed this makes the debug warnings go away.