### PR TITLE
[Trivial] Fix clang warning: 'csize' not initialized.

### DIFF
--- a/src/veil/lru_cache.h
+++ b/src/veil/lru_cache.h
@@ -45,7 +45,7 @@ private:
     CCriticalSection cs_mycache;
 
 public:
-    SimpleLRUCache(int s) : csize(s < 1 ? 10 : s), keyValuesMap(csize) {}
+    SimpleLRUCache(int s) : csize(s < 1 ? 10 : s), keyValuesMap(s < 1 ? 10 : s) {}
 
     void set(const K key, const V value) {
         LOCK(cs_mycache);


### PR DESCRIPTION
Initialize the `keyValueMap` directly from `s` instead.