### PR TITLE
[Mining] Clear the calculated hash speed at mining start.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4989,6 +4989,7 @@ UniValue generatecontinuous(const JSONRPCRequest& request)
         result.pushKV("threads", 0);
         result.pushKV("message", "Mining stopped");
     } else {
+        ClearHashSpeed();
         result.pushKV("threads", nThreads);
         if (sWarning.compare(""))
             result.pushKV("message", strprintf("Warning: %s", sWarning.c_str()));


### PR DESCRIPTION
This avoids having the hash speed affected by a gap in mining
or a change in the number of mining threads, without requiring
users to call `setminingalgo` on the same algorithm.