### PR TITLE
[Mining] Recent mining hash speed

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -51,6 +51,7 @@ static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool 
 
 double GetHashSpeed();
 void ClearHashSpeed();
+double GetRecentHashSpeed();
 int GetMiningAlgorithm();
 bool SetMiningAlgorithm(const std::string& algo, bool fSet = true);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -378,6 +378,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
     obj.pushKV("difficulty",       (double)nDiff);
     obj.pushKV("networkhashps",    getnetworkhashps(request));
     obj.pushKV("hashspeed",        GetHashSpeed());
+    obj.pushKV("hashspeed_recent", GetRecentHashSpeed());
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain",            Params().NetworkIDString());
     obj.pushKV("warnings",         GetWarnings("statusbar"));


### PR DESCRIPTION
### Issue

In `getmininginfo`, it isn't clear that it computes the `hashspeed` by counting all hashes made since the start of hashing and dividing by the elapsed time, which tends to smooth out fluctuations but also (prior to #966) can include periods of time when the miner is off or the number of threads different.

### Solution

This adds a field to `getmininginfo` called `hashspeed_recent` which is a sum of each thread's most recent round of hashing (where a round is either a fixed number of hashes or ends with a new block).

### Tested

On regtest chain with sha256d and randomx.