### PR TITLE
[Consensus][RingCT] Correctly track and test RingCT spends.

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -444,7 +444,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fSki
 }
 
 bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs,
-                              int nSpendHeight, CAmount& txfee, CAmount& nValueIn, CAmount& nValueOut)
+                              int nSpendHeight, CAmount& txfee, CAmount& nValueIn, CAmount& nValueOut, bool test_accept)
 {
     // reset per tx
     state.fHasAnonOutput = false;
@@ -463,6 +463,8 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
     std::vector<const secp256k1_pedersen_commitment*> vpCommitsIn, vpCommitsOut;
     size_t nBasecoin = 0, nCt = 0, nRingCT = 0, nZerocoin = 0;
     nValueIn = 0;
+    // keyimages for just this tx, used when test_accept=true
+    std::set<CCmpPubKey> txHaveKI;
     for (unsigned int i = 0; i < tx.vin.size(); ++i) {
 
         uint32_t nInputs, nRingSize;
@@ -473,7 +475,9 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
             for (size_t k = 0; k < nInputs; ++k) {
                 const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
 
-                if (!state.m_setHaveKI.insert(ki).second) {
+                if (test_accept
+                        ? state.m_setHaveKI.find(ki) != state.m_setHaveKI.end() && !txHaveKI.insert(ki).second
+                        : !state.m_setHaveKI.insert(ki).second) {
                     if (::Params().CheckKIenforced(nSpendHeight))
                         return state.DoS(100, false, REJECT_INVALID, "bad-anonin-dup-ki-tx-double");
                     else

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -28,11 +28,13 @@ namespace Consensus {
 /**
  * Check whether all inputs of this transaction are valid (no double spends and amounts)
  * This does not modify the UTXO set. This does not check scripts and sigs.
+ * When test_accept is false, keyimages are collected in state.m_setHaveKI to check for double spends;
+ * when test_accept is true, compares keyimages to state.m_setHaveKI but does not add this txn's keyimages.
  * @param[out] txfee Set to the transaction fee if successful.
  * Preconditions: tx.IsCoinBase() is false.
  */
 bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight,
-                   CAmount& txfee, CAmount& nValueIn, CAmount& nValueOut);
+                   CAmount& txfee, CAmount& nValueIn, CAmount& nValueOut, bool test_accept=false);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -900,7 +900,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             return state.DoS(0, false, REJECT_NONSTANDARD, "non-BIP68-final");
 
         CAmount nFees, nValueIn, nValueOut;
-        if (!Consensus::CheckTxInputs(tx, state, view, GetSpendHeight(view), nFees, nValueIn, nValueOut)) {
+        if (!Consensus::CheckTxInputs(tx, state, view, GetSpendHeight(view), nFees, nValueIn, nValueOut, test_accept)) {
             return error("%s: Consensus::CheckTxInputs: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
         }
 

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -213,7 +213,7 @@ public:
 
     void AddOutputRecordMetaData(CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend);
     bool ExpandTempRecipients(std::vector<CTempRecipient> &vecSend, std::string &sError);
-    void MarkInputsAsPendingSpend(CTransactionRecord &rtx);
+    void MarkInputsAsPendingSpend(const std::vector<COutPoint>& rtxvin);
 
     bool AddCTData(CTxOutBase *txout, CTempRecipient &r, std::string &sError);
 


### PR DESCRIPTION
## Problem

Creating multiple ringct spend transactions in a batch (as part of #970) does not work because of these two similar issues.

1.  When creating a transaction, the transaction record has dummy inputs which don't correspond to any actual output, so we don't actually track the pending spends.
2.  When verifying that we aren't double-spending any ringct output, we add every keyimage we see to the set to check against. But if we're testing that a transaction could be accepted to the mempool, then committing that transaction, the commit fails (until the next block).

## Solution

1.  Extract the spent coins' txo records to be marked as pending spend.
2.  Don't track the inputs permanently when testing that a transaction could be accepted to mempool. We still track within the transaction.

## Tested

On regtest with other changes for #970.