### PR TITLE
[Refactor] Split ZerocoinSpendReceipt into a generic Receipt.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -207,6 +207,7 @@ BITCOIN_CORE_H = \
   veil/ringct/keyutil.h \
   veil/ringct/outputrecord.h \
   veil/ringct/rctindex.h \
+  veil/ringct/receipt.h \
   veil/ringct/rpcanonwallet.h \
   veil/ringct/stealth.h \
   veil/ringct/temprecipient.h \
@@ -350,11 +351,12 @@ libbitcoin_wallet_a_SOURCES = \
   veil/zerocoin/spendreceipt.cpp \
   veil/zerocoin/ztracker.cpp \
   veil/zerocoin/zwallet.cpp \
-  veil/ringct/temprecipient.cpp \
   veil/ringct/anonwalletdb.cpp \
   veil/ringct/anonwallet.cpp \
   veil/ringct/outputrecord.cpp \
+  veil/ringct/receipt.cpp \
   veil/ringct/rpcanonwallet.cpp \
+  veil/ringct/temprecipient.cpp \
   $(BITCOIN_CORE_H)
 
 if TARGET_ARM64

--- a/src/veil/ringct/receipt.cpp
+++ b/src/veil/ringct/receipt.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-2019 The PIVX developers
+// Copyright (c) 2019-2021 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <veil/ringct/receipt.h>
+#include <veil/ringct/transactionrecord.h>
+
+
+void CMultiTxReceipt::SetStatus(std::string strStatus, int nStatus)
+{
+    strStatusMessage = strStatus;
+    this->nStatus = nStatus;
+}
+
+CTransactionRecord CMultiTxReceipt::GetTransactionRecord(const int n) const
+{
+    if (!mapRecords.count(n))
+        return CTransactionRecord();
+    return mapRecords.at(n);
+}
+
+void CMultiTxReceipt::AddTransaction(CTransactionRef& txRef, const CTransactionRecord& rtx)
+{
+    auto n = vtx.size();
+    mapRecords.emplace(n, rtx);
+    vtx.emplace_back(txRef);
+}
+
+std::string CMultiTxReceipt::GetStatusMessage()
+{
+    return strStatusMessage;
+}

--- a/src/veil/ringct/receipt.h
+++ b/src/veil/ringct/receipt.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2019 The PIVX developers
+// Copyright (c) 2019-2021 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef VEIL_RECEIPT_H
+#define VEIL_RECEIPT_H
+
+#include <veil/ringct/temprecipient.h>
+#include <veil/ringct/transactionrecord.h>
+
+class CMultiTxReceipt
+{
+protected:
+    std::string strStatusMessage;
+    int nStatus;
+    std::map<int, CTransactionRecord> mapRecords; // key:tx's spot in vtx
+    std::vector<CTransactionRef> vtx;
+
+public:
+    void AddTransaction(CTransactionRef& txRef, const CTransactionRecord& rtx);
+    void SetStatus(std::string strStatus, int nStatus);
+    std::string GetStatusMessage();
+    std::vector<CTransactionRef> GetTransactions() const { return vtx; }
+    CTransactionRecord GetTransactionRecord(int n) const;
+};
+
+#endif //VEIL_RECEIPT_H

--- a/src/veil/zerocoin/spendreceipt.cpp
+++ b/src/veil/zerocoin/spendreceipt.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <veil/zerocoin/spendreceipt.h>
+#include <veil/ringct/receipt.h>
 #include <veil/ringct/transactionrecord.h>
 
 void CZerocoinSpendReceipt::AddSpend(const CZerocoinSpend& spend)
@@ -31,26 +32,6 @@ std::vector<CZerocoinSpend> CZerocoinSpendReceipt::GetSpends_back()
 
 void CZerocoinSpendReceipt::SetStatus(std::string strStatus, int nStatus, int nNeededSpends)
 {
-    strStatusMessage = strStatus;
-    this->nStatus = nStatus;
+    CMultiTxReceipt::SetStatus(strStatus, nStatus);
     this->nNeededSpends = nNeededSpends;
-}
-
-CTransactionRecord CZerocoinSpendReceipt::GetTransactionRecord(const int n) const
-{
-    if (!mapRecords.count(n))
-        return CTransactionRecord();
-    return mapRecords.at(n);
-}
-
-void CZerocoinSpendReceipt::AddTransaction(CTransactionRef& txRef, const CTransactionRecord& rtx)
-{
-    auto n = vtx.size();
-    mapRecords.emplace(n, rtx);
-    vtx.emplace_back(txRef);
-}
-
-std::string CZerocoinSpendReceipt::GetStatusMessage()
-{
-    return strStatusMessage;
 }

--- a/src/veil/zerocoin/spendreceipt.h
+++ b/src/veil/zerocoin/spendreceipt.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2019 The PIVX developers
-// Copyright (c) 2019 The Veil developers
+// Copyright (c) 2019-2021 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,30 +7,21 @@
 #define VEIL_SPENDRECEIPT_H
 
 #include <primitives/zerocoin.h>
+#include <veil/ringct/receipt.h>
 #include <veil/ringct/temprecipient.h>
 #include <veil/ringct/transactionrecord.h>
 
-class CTransactionRecord;
-
-class CZerocoinSpendReceipt
+class CZerocoinSpendReceipt : public CMultiTxReceipt
 {
 private:
-    std::string strStatusMessage;
-    int nStatus;
     int nNeededSpends;
     std::map<int, std::vector<CZerocoinSpend>> mapSpends; // key:tx's spot in vtx
-    std::map<int, CTransactionRecord> mapRecords; // key:tx's spot in vtx
-    std::vector<CTransactionRef> vtx;
 
 public:
     void AddSpend(const CZerocoinSpend& spend);
-    void AddTransaction(CTransactionRef& txRef, const CTransactionRecord& rtx);
     std::vector<CZerocoinSpend> GetSpends(int n);
     std::vector<CZerocoinSpend> GetSpends_back();
     void SetStatus(std::string strStatus, int nStatus, int nNeededSpends = 0);
-    std::string GetStatusMessage();
-    std::vector<CTransactionRef> GetTransactions() const { return vtx; }
-    CTransactionRecord GetTransactionRecord(int n) const;
 };
 
 #endif //VEIL_SPENDRECEIPT_H


### PR DESCRIPTION
This makes it easier to organize multiple transactions into a single receipt regardless of whether it's a zerocoin spend or something else. (#970)