### PR TITLE
[Trivial] Fix a size_t reference for clang 13

### DIFF
--- a/src/veil/mnemonic/dictionary.h
+++ b/src/veil/mnemonic/dictionary.h
@@ -7,7 +7,7 @@
 /**
  * A valid mnemonic dictionary has exactly this many words.
  */
-static constexpr size_t dictionary_size = 2048;
+static constexpr std::size_t dictionary_size = 2048;
 
 /**
  * Dictionary definitions for creating mnemonics.


### PR DESCRIPTION
This was the only one necessary to build veild. I imagine any others have a `using` directive somewhere in their includes.