### PR TITLE
[Consensus] Update main chain POW end to supply end

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -366,7 +366,7 @@ public:
         nKernelModulus = 100;
         nCoinbaseMaturity = 100;
         nProofOfFullNodeRounds = 4;
-        nLastPOWBlock = 2000000;
+        nLastPOWBlock = 9816000; // Continue POW until supply creation ends
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
         nTimeEnforceWeightReduction = 1548619029; //Stake weight must be reduced for higher denominations
         nHeightProtocolBumpEnforcement = 86350; // 50 blocks before superblock


### PR DESCRIPTION
Per the team, POW should be extended throughout the end of the supply.

As a change to the chainparams, this will be a mandatory change--versions without this update will reject POW blocks starting in November 2022, causing a fork. It may be prudent to add a protocol version bump as well to enforce separately.