### PR TITLE
[RPC][Wallet] Create multiple transactions with one command.

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -502,12 +502,12 @@ public:
                 break;
             }
             case OUTPUT_CT:
-                if (0 != pwalletAnon->AddBlindedInputs(wtx, rtx, recipients, !fCheckFeeOnly, nFeeRet, &coin_control, fail_reason))
+                if (0 != pwalletAnon->AddBlindedInputs(wtx, rtx, recipients, !fCheckFeeOnly, 0, nFeeRet, &coin_control, fail_reason))
                     fFailed = true;
                 break;
             case OUTPUT_RINGCT:
                 if (!pwalletAnon->AddAnonInputs(wtx, rtx, recipients, !fCheckFeeOnly, nRingSize,
-                                                nInputsPerSig, nFeeRet, &coin_control, fail_reason))
+                                                nInputsPerSig, 0, nFeeRet, &coin_control, fail_reason))
                     fFailed = true;
                 break;
             default:

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -2060,6 +2060,9 @@ int AnonWallet::AddStandardInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx,
                 if (this->HaveAddress(r.address))
                     r.isMine = true;
 
+                // Likely unnecessary.
+                if (r.nType != OUTPUT_DATA)
+                    r.nAmount = r.nAmountSelected;
                 r.ApplySubFee(nFeeRet, nSubtractFeeFromAmount, fFirst);
 
                 OUTPUT_PTR<CTxOutBase> txbout;
@@ -2394,15 +2397,65 @@ bool AnonWallet::MakeSigningKeystore(CBasicKeyStore& keystore, const CScript& sc
     return true;
 }
 
+bool AdjustOutputsForShortfall(std::vector<CTempRecipient> &vecSend, CAmount& nChange,
+    const CAmount nValueExpected, const CAmount nValueSelected, std::string& sError)
+{
+    if (vecSend.size() == 1) {
+        if (vecSend[0].nAmount < -nChange) {
+            sError = strprintf("Multi-tx cannot adjust single output: requested %d got %d needed %d short by %d.",
+                               nValueExpected, nValueSelected, nValueExpected - nValueSelected, vecSend[0].nAmount + nChange);
+            return error("%s: %s", __func__, sError);
+        }
+        vecSend[0].nAmount += nChange;
+        nChange = 0;
+    } else {
+        // Split the shortfall randomly
+        // We're effectively reaching into a bag of n marbles and pulling out nC (-nChange) of them.
+        // This is a hypergeometric distribution... let's do something faster but still pretty random.
+        // Shuffle the outputs and take a random amount from each.
+        std::vector<size_t> indexes(vecSend.size());
+        std::iota(indexes.begin(), indexes.end(), 0);  // [0, ..., n-1]
+        Shuffle(indexes.begin(), indexes.end(), FastRandomContext());
+        CAmount sub;
+        size_t i = 0;
+        for (; i < indexes.size() - 1; ++i) {
+            sub = GetRandInt(std::min(vecSend[indexes[i]].nAmount, -nChange));
+            vecSend[indexes[i]].nAmount -= sub;
+            nChange += sub;
+        }
+        // Apply the remainder to the last one, unless it doesn't have enough,
+        // in which case try on another one, etc.
+        for (; nChange < 0 && i >= 0; --i) {
+            sub = std::min(vecSend[indexes[i]].nAmount, -nChange);
+            vecSend[indexes[i]].nAmount -= sub;
+            nChange += sub;
+        }
+        // nChange should be 0 at this point, but it's survivable if we overcorrected
+        if (nChange < 0) {
+            sError = strprintf("Multi-tx undercorrected outputs: requested %d got %d needed %d short by %d.",
+                               nValueExpected, nValueSelected, nValueExpected - nValueSelected, -nChange);
+            return error("%s: %s", __func__, sError);
+        }
+    }
+    return true;
+}
+
 int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend,
-    bool sign, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError)
+    bool sign, size_t nMaximumInputs, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError)
 {
     assert(coinControl);
+
+    if (nMaximumInputs < 0 || nMaximumInputs > MAX_ANON_INPUTS) {
+        return wserrorN(1, sError, __func__, "Num inputs per transaction out of range: %d.", nMaximumInputs);
+    }
+
     nFeeRet = 0;
     CAmount nValueOutBlind;
     size_t nSubtractFeeFromAmount;
     bool fOnlyStandardOutputs, fSkipFee, fSendingOnlyBaseCoin;
     InspectOutputs(vecSend, false, nValueOutBlind, nSubtractFeeFromAmount, fOnlyStandardOutputs, fSkipFee, fSendingOnlyBaseCoin);
+
+    bool fSubtractFeeFromOutputs = nSubtractFeeFromAmount > 0;
 
     //Need count of zerocoin mint outputs in order to calculate fee correctly
     int nZerocoinMintOuts = 0;
@@ -2466,9 +2519,13 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
             txNew.vin.clear();
             txNew.vpout.clear();
             wtx.fFromMe = true;
+            // Reset adjustments
+            for (CTempRecipient& r : vecSend) {
+                r.nAmount = r.nAmountSelected;
+            }
 
             CAmount nValueToSelect = nValueOutBlind + nValueOutZerocoin;
-            if (nSubtractFeeFromAmount == 0) {
+            if (!fSubtractFeeFromOutputs) {
                 nValueToSelect += nFeeRet;
             }
 
@@ -2476,12 +2533,12 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
             if (pick_new_inputs) {
                 nValueIn = 0;
                 setCoins.clear();
-                if (!SelectBlindedCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, coinControl)) {
+                if (!SelectBlindedCoins(vAvailableCoins, nValueToSelect, nMaximumInputs, setCoins, nValueIn, coinControl)) {
                     return wserrorN(1, sError, __func__, _("Insufficient funds."));
                 }
             }
 
-            const CAmount nChange = nValueIn - nValueToSelect;
+            CAmount nChange = nValueIn - nValueToSelect;
 
             // Remove fee outputs from last round
             for (size_t i = 0; i < vecSend.size(); ++i) {
@@ -2489,6 +2546,14 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
                     vecSend.erase(vecSend.begin() + i);
                     i--;
                 }
+            }
+
+            // adjust outputs if we aren't sending enough
+            // we can reset by setting them back to nAmountSelected if necessary.
+            if (nChange < 0) {
+                // Should set nChange to 0, but a positive number is usable, too.
+                if (!AdjustOutputsForShortfall(vecSend, nChange, nValueToSelect, nValueIn, sError))
+                    return 1;  // sError is set
             }
 
             if (!coinControl->m_addChangeOutput) {
@@ -2549,10 +2614,13 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
             txNew.vpout.push_back(outFee);
 
             bool fFirst = true;
+            bool fFeesFromChange = nMaximumInputs > 0 && nChange >= MIN_FINAL_CHANGE + nFeeRet;
             for (size_t i = 0; i < vecSend.size(); ++i) {
                 auto &r = vecSend[i];
 
-                r.ApplySubFee(nFeeRet, nSubtractFeeFromAmount, fFirst);
+                // Don't take out the fee if we're in multi-tx mode and nChange is sufficient to cover the fee
+                if (!fFeesFromChange)
+                    r.ApplySubFee(nFeeRet, nSubtractFeeFromAmount, fFirst);
 
                 OUTPUT_PTR<CTxOutBase> txbout;
                 if (0 != CreateOutput(txbout, r, sError)) {
@@ -2567,8 +2635,12 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
                     nValueOutPlain += r.nAmount;
                 }
 
-                if (r.fChange && r.nType == OUTPUT_CT) {
+                if (r.fChange) {
                     nChangePosInOut = i;
+                    // Remove the fee from the change for multitx
+                    if (fFeesFromChange) {
+                        r.SetAmount(r.nAmount - nFeeRet);
+                    }
                 }
 
                 r.n = txNew.vpout.size();
@@ -2634,7 +2706,7 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
                 // selected to meet nFeeNeeded result in a transaction that
                 // requires less fee than the prior iteration.
                 if (nFeeRet > nFeeNeeded && nChangePosInOut != -1
-                    && nSubtractFeeFromAmount == 0) {
+                    && (!fSubtractFeeFromOutputs || fFeesFromChange)) {
                     auto &r = vecSend[nChangePosInOut];
 
                     CAmount extraFeePaid = nFeeRet - nFeeNeeded;
@@ -2643,7 +2715,7 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
                     nFeeRet -= extraFeePaid;
                 }
 
-                if (nSubtractFeeFromAmount) {
+                if (fSubtractFeeFromOutputs && !fFeesFromChange) {
                     if (nValueOutPlain + nFeeRet == nValueIn) {
                         // blinded input value == plain output value
                         // blinding factor will be 0 for change
@@ -2678,13 +2750,13 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
                 // Or we should have just subtracted fee from recipients and
                 // nFeeNeeded should not have changed
 
-                if (!nSubtractFeeFromAmount || !(--nSubFeeTries)) { // rangeproofs can change size per iteration
+                if (!fSubtractFeeFromOutputs || !(--nSubFeeTries)) { // rangeproofs can change size per iteration
                     return wserrorN(1, sError, __func__, _("Transaction fee and change calculation failed."));
                 }
             }
 
             // Try to reduce change to include necessary fee
-            if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
+            if (nChangePosInOut != -1 && (!fSubtractFeeFromOutputs || nMaximumInputs > 0)) {
                 auto &r = vecSend[nChangePosInOut];
 
                 CAmount additionalFeeNeeded = nFeeNeeded - nFeeRet;
@@ -2698,7 +2770,7 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
 
             // If subtracting fee from recipients, we now know what fee we
             // need to subtract, we have no reason to reselect inputs
-            if (nSubtractFeeFromAmount > 0) {
+            if (fSubtractFeeFromOutputs) {
                 pick_new_inputs = false;
             }
 
@@ -2874,7 +2946,7 @@ int AnonWallet::AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, 
 }
 
 int AnonWallet::AddBlindedInputs(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend, bool sign,
-        CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError)
+        size_t nMaximumInputs, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError)
 {
     if (vecSend.size() < 1) {
         return wserrorN(1, sError, __func__, _("Transaction must have at least one recipient."));
@@ -2888,7 +2960,7 @@ int AnonWallet::AddBlindedInputs(CWalletTx &wtx, CTransactionRecord &rtx, std::v
         }
     }
 
-    if (0 != AddBlindedInputs_Inner(wtx, rtx, vecSend, sign, nFeeRet, coinControl, sError)) {
+    if (0 != AddBlindedInputs_Inner(wtx, rtx, vecSend, sign, nMaximumInputs, nFeeRet, coinControl, sError)) {
         return 1;
     }
 
@@ -3124,7 +3196,7 @@ bool AnonWallet::IsMyAnonInput(const CTxIn& txin, COutPoint& myOutpoint)
 
 // Returns bool
 bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend,
-        bool sign, size_t nRingSize, size_t nInputsPerSig, CAmount &nFeeRet, const CCoinControl *coinControl,
+        bool sign, size_t nRingSize, size_t nInputsPerSig, size_t nMaximumInputs, CAmount &nFeeRet, const CCoinControl *coinControl,
         std::string &sError, bool fZerocoinInputs, CAmount nInputValue)
 {
     assert(coinControl);
@@ -3138,11 +3210,18 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
         return error("%s: %s", __func__, sError);
     }
 
+    if (nMaximumInputs < 0 || nMaximumInputs > MAX_ANON_INPUTS) {
+        sError = strprintf("Num inputs per transaction out of range: %d.", nMaximumInputs);
+        return error("%s: %s", __func__, sError);
+    }
+
     nFeeRet = 0;
     CAmount nValueOutAnon;
     size_t nSubtractFeeFromAmount;
     bool fOnlyStandardOutputs, fSkipFee, fSendingOnlyBaseCoin;
     InspectOutputs(vecSend, fZerocoinInputs, nValueOutAnon, nSubtractFeeFromAmount, fOnlyStandardOutputs, fSkipFee, fSendingOnlyBaseCoin);
+
+    bool fSubtractFeeFromOutputs = nSubtractFeeFromAmount > 0;
 
     //Need count of zerocoin mint outputs in order to calculate fee correctly
     int nZerocoinMintOuts = 0;
@@ -3208,6 +3287,10 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
                 return error("%s: %s", __func__, sError);
             }
             nIterations++;
+            // Reset adjustments
+            for (CTempRecipient& r : vecSend) {
+                r.nAmount = r.nAmountSelected;
+            }
 
             if (!fAlreadyHaveInputs)
                 txNew.vin.clear();
@@ -3215,7 +3298,7 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
             wtx.fFromMe = true;
 
             CAmount nValueToSelect = nValueOutAnon + nValueOutZerocoin;
-            if (nSubtractFeeFromAmount == 0) {
+            if (!fSubtractFeeFromOutputs) {
                 nValueToSelect += nFeeRet;
             }
 
@@ -3223,13 +3306,13 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
             if (!fAlreadyHaveInputs && pick_new_inputs) {
                 nValueIn = 0;
                 setCoins.clear();
-                if (!SelectBlindedCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, coinControl)) {
+                if (!SelectBlindedCoins(vAvailableCoins, nValueToSelect, nMaximumInputs, setCoins, nValueIn, coinControl)) {
                     sError = strprintf("Insufficient funds.");
                     return error("%s: %s", __func__, sError);
                 }
             }
 
-            const CAmount nChange = nValueIn - nValueToSelect;
+            CAmount nChange = nValueIn - nValueToSelect;
 
             // Remove fee outputs from last round
             for (size_t i = 0; i < vecSend.size(); ++i) {
@@ -3237,6 +3320,14 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
                     vecSend.erase(vecSend.begin() + i);
                     i--;
                 }
+            }
+
+            // adjust outputs if we aren't sending enough
+            // we can reset by setting them back to nAmountSelected if necessary.
+            if (nChange < 0) {
+                // Should set nChange to 0, but a positive number is usable, too.
+                if (!AdjustOutputsForShortfall(vecSend, nChange, nValueToSelect, nValueIn, sError))
+                    return false;  // sError is set
             }
 
             // Insert a sender-owned 0 value output that becomes the change output if needed
@@ -3300,10 +3391,13 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
             txNew.vpout.push_back(outFee);
 
             bool fFirst = true;
+            bool fFeesFromChange = nMaximumInputs > 0 && nChange >= MIN_FINAL_CHANGE + nFeeRet;
             for (size_t i = 0; i < vecSend.size(); ++i) {
                 auto &recipient = vecSend[i];
 
-                if (!fSkipFee)
+                // Don't take out the fee if a) skip fee, or
+                // b) we're in multi-tx mode and nChange is sufficient to cover the fee
+                if (!fSkipFee && !fFeesFromChange)
                     recipient.ApplySubFee(nFeeRet, nSubtractFeeFromAmount, fFirst);
 
                 OUTPUT_PTR<CTxOutBase> txbout;
@@ -3313,8 +3407,12 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
                     nValueOutPlain += recipient.nAmount;
                 }
 
-                if (recipient.fChange && recipient.nType == OUTPUT_RINGCT) {
+                if (recipient.fChange) {
                     nChangePosInOut = i;
+                    // Remove the fee from the change for multitx
+                    if (fFeesFromChange) {
+                        recipient.SetAmount(recipient.nAmount - nFeeRet);
+                    }
                 }
 
                 recipient.n = txNew.vpout.size();
@@ -3407,7 +3505,8 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
                     // prevents potential overpayment in fees if the coins
                     // selected to meet nFeeNeeded result in a transaction that
                     // requires less fee than the prior iteration.
-                    if (nFeeRet > nFeeNeeded && nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
+                    if (nFeeRet > nFeeNeeded && nChangePosInOut != -1
+                        && (!fSubtractFeeFromOutputs || fFeesFromChange)) {
                         auto &r = vecSend[nChangePosInOut];
 
                         CAmount extraFeePaid = nFeeRet - nFeeNeeded;
@@ -3422,14 +3521,14 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
                     // Or we should have just subtracted fee from recipients and
                     // nFeeNeeded should not have changed
 
-                    if (!nSubtractFeeFromAmount || !(--nSubFeeTries)) {
+                    if (!fSubtractFeeFromOutputs || !(--nSubFeeTries)) {
                         sError = strprintf("Transaction fee and change calculation failed.");
                         return error("%s: %s", __func__, sError);
                     }
                 }
 
                 // Try to reduce change to include necessary fee
-                if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
+                if (nChangePosInOut != -1 && (!fSubtractFeeFromOutputs || nMaximumInputs > 0)) {
                     auto &r = vecSend[nChangePosInOut];
                     CAmount additionalFeeNeeded = nFeeNeeded - nFeeRet;
                     if (r.nAmount >= MIN_FINAL_CHANGE + additionalFeeNeeded) {
@@ -3441,7 +3540,7 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
 
                 // If subtracting fee from recipients, we now know what fee we
                 // need to subtract, we have no reason to reselect inputs
-                if (nSubtractFeeFromAmount > 0) {
+                if (fSubtractFeeFromOutputs) {
                     pick_new_inputs = false;
                 }
 
@@ -3490,8 +3589,8 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
             if ((int)i == nChangePosInOut) {
                 // Change amount may have changed
 
-                if (r.nType != OUTPUT_RINGCT) {
-                    sError = strprintf("Change output is not RingCT type.");
+                if (r.nType != (fCTOut ? OUTPUT_CT : OUTPUT_RINGCT)) {
+                    sError = strprintf("Change output is not %s type.", fCTOut ? "CT" : "RingCT");
                     return error("%s: %s", __func__, sError);
                 }
 
@@ -3758,7 +3857,7 @@ bool AnonWallet::AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, st
 }
 
 bool AnonWallet::AddAnonInputs(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend, bool sign,
-        size_t nRingSize, size_t nSigs, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError, bool fZerocoinInputs,
+        size_t nRingSize, size_t nSigs, size_t nMaximumInputs, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError, bool fZerocoinInputs,
         CAmount nInputValue)
 {
     if (vecSend.size() < 1) {
@@ -3775,7 +3874,7 @@ bool AnonWallet::AddAnonInputs(CWalletTx &wtx, CTransactionRecord &rtx, std::vec
         }
     }
 
-    if (!AddAnonInputs_Inner(wtx, rtx, vecSend, sign, nRingSize, nSigs, nFeeRet, coinControl, sError, fZerocoinInputs, nInputValue)) {
+    if (!AddAnonInputs_Inner(wtx, rtx, vecSend, sign, nRingSize, nSigs, nMaximumInputs, nFeeRet, coinControl, sError, fZerocoinInputs, nInputValue)) {
         return false;
     }
 
@@ -5805,7 +5904,7 @@ void AnonWallet::AvailableBlindedCoins(std::vector<COutputR>& vCoins, bool fOnly
     }
 }
 
-bool AnonWallet::SelectBlindedCoins(const std::vector<COutputR> &vAvailableCoins, const CAmount &nTargetValue,
+bool AnonWallet::SelectBlindedCoins(const std::vector<COutputR> &vAvailableCoins, const CAmount &nTargetValue, size_t nMaximumCount,
         std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> > &setCoinsRet, CAmount &nValueRet, const CCoinControl *coinControl) const
 {
     std::vector<COutputR> vCoins(vAvailableCoins);
@@ -5870,13 +5969,13 @@ bool AnonWallet::SelectBlindedCoins(const std::vector<COutputR> &vAvailableCoins
     auto m_spend_zero_conf_change = pwalletParent->m_spend_zero_conf_change;
 
     bool res = nTargetValue <= nValueFromPresetInputs ||
-        SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 6, 0), vCoins, setCoinsRet, nValueRet) ||
-        SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 1, 0), vCoins, setCoinsRet, nValueRet) ||
-        (m_spend_zero_conf_change && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, 2), vCoins, setCoinsRet, nValueRet)) ||
-        (m_spend_zero_conf_change && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::min((size_t)4, max_ancestors/3), std::min((size_t)4, max_descendants/3)), vCoins, setCoinsRet, nValueRet)) ||
-        (m_spend_zero_conf_change && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, max_ancestors/2, max_descendants/2), vCoins, setCoinsRet, nValueRet)) ||
-        (m_spend_zero_conf_change && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, max_ancestors-1, max_descendants-1), vCoins, setCoinsRet, nValueRet)) ||
-        (m_spend_zero_conf_change && !fRejectLongChains && SelectCoinsMinConf(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::numeric_limits<uint64_t>::max()), vCoins, setCoinsRet, nValueRet));
+        SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 6, 0), vCoins, nMaximumCount, setCoinsRet, nValueRet) ||
+        SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 1, 0), vCoins, nMaximumCount, setCoinsRet, nValueRet) ||
+        (m_spend_zero_conf_change && SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, 2), vCoins, nMaximumCount, setCoinsRet, nValueRet)) ||
+        (m_spend_zero_conf_change && SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::min((size_t)4, max_ancestors/3), std::min((size_t)4, max_descendants/3)), vCoins, nMaximumCount, setCoinsRet, nValueRet)) ||
+        (m_spend_zero_conf_change && SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, max_ancestors/2, max_descendants/2), vCoins, nMaximumCount, setCoinsRet, nValueRet)) ||
+        (m_spend_zero_conf_change && SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, max_ancestors-1, max_descendants-1), vCoins, nMaximumCount, setCoinsRet, nValueRet)) ||
+        (m_spend_zero_conf_change && !fRejectLongChains && SelectCoinsForOneTx(nTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::numeric_limits<uint64_t>::max()), vCoins, nMaximumCount, setCoinsRet, nValueRet));
 
 
     // because SelectCoinsMinConf clears the setCoinsRet, we now add the possible inputs to the coinset
@@ -6052,7 +6151,7 @@ static void ApproximateBestSubset(std::vector<std::pair<CAmount, std::pair<MapRe
 }
 
 bool AnonWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter,
-    std::vector<COutputR> vCoins, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> >& setCoinsRet, CAmount& nValueRet) const
+    std::vector<COutputR> &vCoins, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> >& setCoinsRet, CAmount& nValueRet) const
 {
     setCoinsRet.clear();
     nValueRet = 0;
@@ -6153,6 +6252,112 @@ bool AnonWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligi
 
     return true;
 }
+
+bool AnonWallet::SelectCoinsForOneTx(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter,
+    std::vector<COutputR> &vCoins, size_t nMaximumCount, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> >& setCoinsRet, CAmount& nValueRet) const
+{
+    if (vCoins.empty())
+        return false;
+
+    if (nMaximumCount == 0)
+        return SelectCoinsMinConf(nTargetValue, eligibility_filter, vCoins, setCoinsRet, nValueRet);
+
+    setCoinsRet.clear();
+    nValueRet = 0;
+
+    // Save the smallest coin bigger than our need.
+    std::pair<CAmount, std::pair<MapRecords_t::const_iterator,unsigned int> > coinLowestLarger;
+    coinLowestLarger.first = std::numeric_limits<CAmount>::max();
+    coinLowestLarger.second.first = mapRecords.end();
+
+    // List of values less than target, sorted
+    std::multiset<std::pair<CAmount, std::pair<MapRecords_t::const_iterator, unsigned int> >, CompareValueOnly> vSortedValues;
+
+    Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
+
+    for (const auto &r : vCoins) {
+        //if (!r.fSpendable)
+        //    continue;
+        MapRecords_t::const_iterator rtxi = r.rtx;
+        const CTransactionRecord *rtx = &rtxi->second;
+
+        const CWalletTx *pcoin = pwalletParent->GetWalletTx(r.txhash);
+        if (!pcoin) {
+            if (0 != InsertTempTxn(r.txhash, rtx)
+                || !(pcoin = pwalletParent->GetWalletTx(r.txhash)))
+                return werror("%s: InsertTempTxn failed.\n", __func__);
+        }
+
+
+        if (r.nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? eligibility_filter.conf_mine : eligibility_filter.conf_theirs))
+            continue;
+
+        size_t ancestors, descendants;
+        mempool.GetTransactionAncestry(r.txhash, ancestors, descendants);
+        if (ancestors > eligibility_filter.max_ancestors || descendants > eligibility_filter.max_descendants) {
+             continue;
+        }
+
+        const COutputRecord *oR = rtx->GetOutput(r.i);
+        if (!oR) {
+            return werror("%s: GetOutput failed, %s, %d.\n", r.txhash.ToString(), r.i);
+        }
+
+        CAmount nV = oR->GetRawValue();
+
+        if (nV < nTargetValue + MIN_CHANGE) {
+            vSortedValues.emplace(std::piecewise_construct, std::make_tuple(nV), std::make_tuple(rtxi, r.i));
+        } else if (nV < coinLowestLarger.first) {
+            std::pair<CAmount,std::pair<MapRecords_t::const_iterator,unsigned int> > coin = std::make_pair(nV, std::make_pair(rtxi, r.i));
+            coinLowestLarger = coin;
+        }
+    }
+    if (coinLowestLarger.second.first != mapRecords.end())
+        vSortedValues.insert(vSortedValues.end(), coinLowestLarger);
+
+    // sliding window sum
+    // Always include the smallest coin, to avoid proliferation of dust
+    auto it = vSortedValues.begin();
+    CAmount nSlidingSum = it->first;
+    size_t nWindow = 1;
+    // first, grow the window
+    for (++it; nWindow < nMaximumCount && nSlidingSum < nTargetValue && it != vSortedValues.end(); ++nWindow, ++it) {
+        nSlidingSum += it->first;
+    }
+    // Some amount of the smallest coins fit in the window and reached the target.
+    if (nSlidingSum >= nTargetValue) {
+        for (auto coin = vSortedValues.begin(); coin != it; ++coin) {
+            setCoinsRet.push_back(coin->second);
+        }
+
+        nValueRet = nSlidingSum;
+        return true;
+    }
+    // We grew the window all the way and didn't have enough.
+    if (it == vSortedValues.end()) {
+        // Technically we might have enough with a larger smallest coin, but we're choosing to
+        // break it into multiple transactions instead, so that we don't make more dust.
+        return false;
+    }
+
+    // At this point we assume: we've selected a non-infinite window size and want to use what we can,
+    // even if it's not sufficient for the target (the caller will need to make another transaction).
+    //
+    // While we're still short, slide the window: remove the lowest coin and add the next coin.
+    auto itStart = vSortedValues.begin();
+    for (++itStart; nSlidingSum < nTargetValue && it != vSortedValues.end(); ++itStart, ++it) {
+        nSlidingSum += it->first - itStart->first;
+    }
+
+    setCoinsRet.push_back(vSortedValues.begin()->second);
+    // itStart has advanced to the first included coin, and it is one past the last included coin.
+    for (auto coin = itStart; coin != it; ++coin) {
+        setCoinsRet.push_back(coin->second);
+    }
+    nValueRet = nSlidingSum;
+    return true;
+}
+
 
 /**
  * Outpoint is spent if any non-conflicted transaction

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -227,9 +227,9 @@ public:
             CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError, bool fZerocoinInputs, CAmount nInputValue);
 
     int AddBlindedInputs(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend, bool sign,
-            CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError);
+            size_t nMaximumInputs, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError);
     int AddBlindedInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend, bool sign,
-            CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError);
+            size_t nMaximumInputs, CAmount &nFeeRet, const CCoinControl *coinControl, std::string &sError);
 
 
     bool PlaceRealOutputs(std::vector<std::vector<int64_t> > &vMI, size_t &nSecretColumn, size_t nRingSize, std::set<int64_t> &setHave,
@@ -240,10 +240,10 @@ public:
 
     bool IsMyAnonInput(const CTxIn& txin, COutPoint& myOutpoint);
     bool AddAnonInputs_Inner(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend,
-         bool sign, size_t nRingSize, size_t nInputsPerSig, CAmount &nFeeRet,
+         bool sign, size_t nRingSize, size_t nInputsPerSig, size_t nMaximumInputs, CAmount &nFeeRet,
          const CCoinControl *coinControl, std::string &sError, bool fZerocoinInputs, CAmount nInputValue);
     bool AddAnonInputs(CWalletTx &wtx, CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend,
-         bool sign, size_t nRingSize, size_t nInputsPerSig, CAmount &nFeeRet,
+         bool sign, size_t nRingSize, size_t nInputsPerSig, size_t nMaximumInputs, CAmount &nFeeRet,
          const CCoinControl *coinControl, std::string &sError, bool fZerocoinInputs = false,
          CAmount nInputValue = 0);
 
@@ -322,7 +322,10 @@ public:
      * populate vCoins with vector of available COutputs.
      */
     void AvailableBlindedCoins(std::vector<COutputR>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t& nMaximumCount = 0, const int& nMinDepth = 0, const int& nMaxDepth = 0x7FFFFFFF, bool fIncludeImmature=false) const;
-    bool SelectBlindedCoins(const std::vector<COutputR>& vAvailableCoins, const CAmount& nTargetValue, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> > &setCoinsRet, CAmount &nValueRet, const CCoinControl *coinControl = nullptr) const;
+    /**
+     * Returns a list of coins for a single transaction based on the target value and allowed number of inputs.
+     */
+    bool SelectBlindedCoins(const std::vector<COutputR>& vAvailableCoins, const CAmount& nTargetValue, size_t nMaximumCount, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> > &setCoinsRet, CAmount &nValueRet, const CCoinControl *coinControl = nullptr) const;
 
     void AvailableAnonCoins(std::vector<COutputR> &vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t& nMaximumCount = 0, const int& nMinDepth = 0, const int& nMaxDepth = 0x7FFFFFFF, bool fIncludeImmature=false) const;
 
@@ -330,7 +333,12 @@ public:
      * Return list of available coins and locked coins grouped by non-change output address.
      */
 
-    bool SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<COutputR> vCoins, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> > &setCoinsRet, CAmount &nValueRet) const;
+    bool SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<COutputR> &vCoins, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> > &setCoinsRet, CAmount &nValueRet) const;
+    /**
+     * Like SelectCoinsMinConf, but always selects at most nMaximumCount coins,
+     * with the intention of being put in a single tx that partially accomplishes the target to be sent.
+     */
+    bool SelectCoinsForOneTx(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<COutputR> &vCoins, size_t nMaximumCount, std::vector<std::pair<MapRecords_t::const_iterator,unsigned int> > &setCoinsRet, CAmount &nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <algorithm>
+
 #include <amount.h>
 #include <base58.h>
 #include <chain.h>
@@ -27,6 +29,7 @@
 #include <util/moneystr.h>
 #include <veil/ringct/anonwallet.h>
 #include <veil/ringct/anonwalletdb.h>
+#include <veil/ringct/receipt.h>
 #include <wallet/coincontrol.h>
 #include <wallet/rpcwallet.h>
 #include <chainparams.h>
@@ -284,13 +287,28 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
     std::vector<CTempRecipient> vecSend;
     std::string sError;
 
-    size_t nRingSizeOfs = 6;
+    size_t nRingSizeOfs = 99;
+    size_t nMaxInputsOfs = 99;
     size_t nTestFeeOfs = 99;
     size_t nCoinControlOfs = 99;
+
+    if (typeIn == OUTPUT_CT) {
+        nMaxInputsOfs = 6;
+    } else if (typeIn == OUTPUT_RINGCT) {
+        nRingSizeOfs = 6;
+        nMaxInputsOfs = 8;
+    }
+
+    size_t nMaxInputsPerTx = gArgs.GetBoolArg("-multitx", false) ? 32 : 0;
+    bool fSubtractFeeFromTotal = false;
 
     if (request.params[0].isArray()) {
         const UniValue &outputs = request.params[0].get_array();
 
+        nMaxInputsOfs = 7;
+        if (request.params.size() > nMaxInputsOfs) {
+            nMaxInputsPerTx = request.params[nMaxInputsOfs].get_int();
+        }
         for (size_t k = 0; k < outputs.size(); ++k) {
             if (!outputs[k].isObject()) {
                 throw JSONRPCError(RPC_TYPE_ERROR, "Not an object");
@@ -327,9 +345,10 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
             }
             nTotal += nAmount;
 
-            bool fSubtractFeeFromAmount = false;
+            bool fSubtractFeeFromAmount = nMaxInputsPerTx > 0;
             if (obj.exists("subfee")) {
                 fSubtractFeeFromAmount = obj["subfee"].get_bool();
+                fSubtractFeeFromTotal |= fSubtractFeeFromAmount;
             }
 
             if (0 != AddOutput(typeOut, vecSend, address.Get(), nAmount, fSubtractFeeFromAmount, sError)) {
@@ -353,6 +372,7 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
                 }
             }
         }
+        // Must be sendtypeto
         nRingSizeOfs = 3;
         nTestFeeOfs = 5;
         nCoinControlOfs = 6;
@@ -381,10 +401,16 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
         }
         nTotal += nAmount;
 
+        if (request.params.size() > nMaxInputsOfs) {
+            nMaxInputsPerTx = request.params[nMaxInputsOfs].get_int();
+        }
+
         bool fSubtractFeeFromAmount = false;
         if (request.params.size() > 4) {
-            fSubtractFeeFromAmount = request.params[4].get_bool();
+            fSubtractFeeFromAmount = fSubtractFeeFromTotal = request.params[4].get_bool();
         }
+        if (nMaxInputsPerTx > 0)
+            fSubtractFeeFromAmount = true;
 
         if (0 != AddOutput(typeOut, vecSend, dest, nAmount, fSubtractFeeFromAmount, sError)) {
             throw JSONRPCError(RPC_MISC_ERROR, strprintf("AddOutput failed: %s.", sError));
@@ -515,102 +541,130 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
         }
     }
 
-    CTransactionRef tx_new;
-    CWalletTx wtx(wallet.get(), tx_new);
-    CTransactionRecord rtx;
-
-    CAmount nFeeRet = 0;
-    switch (typeIn) {
-        case OUTPUT_STANDARD:
-        {
-            if (0 !=
-                pwalletAnon->AddStandardInputs(wtx, rtx, vecSend, !fCheckFeeOnly, nFeeRet, &coincontrol, sError, false, 0))
-                throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddStandardInputs failed: %s.", sError));
-            break;
+    UniValue results(UniValue::VARR);
+    CValidationState state;
+    // TODO: Surface receipt status to the caller.
+    CMultiTxReceipt receipt;
+    int nStatus = SEND_ERROR;
+    std::vector<CWalletTx> vwtx;
+    while (nTotal > 0) {
+        // Make new keys for the outputs after the first tx
+        if (!vwtx.empty()) {
+            for (auto& r : vecSend)
+                r.sEphem.MakeNewKey(true);
         }
-        case OUTPUT_CT:
-            if (0 != pwalletAnon->AddBlindedInputs(wtx, rtx, vecSend, !fCheckFeeOnly, nFeeRet, &coincontrol, sError))
-                throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddBlindedInputs failed: %s.", sError));
-            break;
-        case OUTPUT_RINGCT:
-            if (!pwalletAnon->AddAnonInputs(wtx, rtx, vecSend, !fCheckFeeOnly, nRingSize,
-                                            nInputsPerSig, nFeeRet, &coincontrol, sError))
-                throw JSONRPCError(RPC_WALLET_ERROR, sError);
-            break;
-        default:
-            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Unknown input type: %d.", typeIn));
-    }
+        // Create the transactions and add inputs
+        CTransactionRef tx_new = std::make_shared<CTransaction>();
+        CWalletTx& wtx = *vwtx.emplace(vwtx.end(), wallet.get(), tx_new);
+        CTransactionRecord rtx;
 
-    UniValue result(UniValue::VOBJ);
-    if (fCheckFeeOnly || fShowFee) {
-        result.pushKV("fee", ValueFromAmount(nFeeRet));
-        result.pushKV("bytes", (int)GetVirtualTransactionSize(*(wtx.tx)));
-
-        if (fShowHex) {
-            std::string strHex = EncodeHexTx(*(wtx.tx), RPCSerializationFlags());
-            result.pushKV("hex", strHex);
+        CAmount nFeeRet = 0;
+        // We might need to make a copy of vecSend here.
+        switch (typeIn) {
+            case OUTPUT_STANDARD:
+            {
+                if (0 !=
+                    pwalletAnon->AddStandardInputs(wtx, rtx, vecSend, !fCheckFeeOnly, nFeeRet, &coincontrol, sError, false, 0))
+                    throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddStandardInputs failed: %s.", sError));
+                break;
+            }
+            case OUTPUT_CT:
+                if (0 != pwalletAnon->AddBlindedInputs(wtx, rtx, vecSend, !fCheckFeeOnly, nMaxInputsPerTx, nFeeRet, &coincontrol, sError))
+                    throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddBlindedInputs failed: %s.", sError));
+                break;
+            case OUTPUT_RINGCT:
+                if (!pwalletAnon->AddAnonInputs(wtx, rtx, vecSend, !fCheckFeeOnly, nRingSize,
+                                                nInputsPerSig, nMaxInputsPerTx, nFeeRet, &coincontrol, sError))
+                    throw JSONRPCError(RPC_WALLET_ERROR, sError);
+                break;
+            default:
+                throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Unknown input type: %d.", typeIn));
         }
 
-        UniValue objChangedOutputs(UniValue::VOBJ);
-        std::map<std::string, CAmount> mapChanged; // Blinded outputs are split, join the values for display
-        for (const auto &r : vecSend) {
-            if (!r.fChange && r.nAmount != r.nAmountSelected) {
-                std::string sAddr = CBitcoinAddress(r.address).ToString();
-                if (mapChanged.count(sAddr)) {
-                    mapChanged[sAddr] += r.nAmount;
-                } else {
-                    mapChanged[sAddr] = r.nAmount;
+        // subtract total sent from nTotal
+        for (auto& r : vecSend) {
+            if (!r.fChange)
+                nTotal -= r.nAmount;
+        }
+        if (fSubtractFeeFromTotal)
+            nTotal -= nFeeRet;
+
+        UniValue result(UniValue::VOBJ);
+
+        // Report fee for this transaction
+        if (fCheckFeeOnly || fShowFee) {
+            result.pushKV("fee", ValueFromAmount(nFeeRet));
+            result.pushKV("bytes", (int)GetVirtualTransactionSize(*(wtx.tx)));
+
+            if (fShowHex) {
+                std::string strHex = EncodeHexTx(*(wtx.tx), RPCSerializationFlags());
+                result.pushKV("hex", strHex);
+            }
+
+            UniValue objChangedOutputs(UniValue::VOBJ);
+            std::map<std::string, CAmount> mapChanged; // Blinded outputs are split, join the values for display
+            for (const auto &r : vecSend) {
+                if (!r.fChange && r.nAmount != r.nAmountSelected) {
+                    std::string sAddr = CBitcoinAddress(r.address).ToString();
+                    if (mapChanged.count(sAddr)) {
+                        mapChanged[sAddr] += r.nAmount;
+                    } else {
+                        mapChanged[sAddr] = r.nAmount;
+                    }
                 }
             }
+
+            for (const auto &v : mapChanged) {
+                objChangedOutputs.pushKV(v.first, v.second);
+            }
+
+            result.pushKV("outputs_fee", objChangedOutputs);
         }
 
-        for (const auto &v : mapChanged) {
-            objChangedOutputs.pushKV(v.first, v.second);
+        receipt.AddTransaction(tx_new, rtx);
+        if (fShowFee) {
+            result.pushKV("txid", wtx.GetHash().GetHex());
+            results.push_back(result);
+        } else {
+            results.push_back(wtx.GetHash().GetHex());
         }
 
-        result.pushKV("outputs_fee", objChangedOutputs);
-        if (fCheckFeeOnly) {
-            return result;
+        // Update amounts left to be sent.
+        for (auto& r : vecSend) {
+            if (!r.fChange)
+                r.nAmount = r.nAmountSelected = std::max<CAmount>(r.nAmountSelected - r.nAmount, 0);
         }
+
+        // We did a partial test in PreAcceptMempoolTx (anonwallet.cpp), but we need to do the full one
+        LOCK(cs_main);
+        if (!AcceptToMemoryPool(mempool, state, wtx.tx, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */,
+                                false /* bypass_limits */, maxTxFee, true /* test accept */)) {
+            // failed mempool validation for one of the transactions so no partial transaction is being committed
+            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Transaction failed accept to memory pool"));
+        }
+    }
+
+    if (fCheckFeeOnly) {
+        return results;
     }
 
     int64_t nComputeTimeFinish = GetTimeMillis();
 
-    CValidationState state;
-    CReserveKey reservekey(wallet.get());
-   // if (typeIn == OUTPUT_STANDARD && typeOut == OUTPUT_STANDARD) {
-        if (!wallet->CommitTransaction(wtx.tx, wtx.mapValue, wtx.vOrderForm, &reservekey, g_connman.get(), state, nComputeTimeFinish - nComputeTimeStart)) {
+    // Commit transactions
+    for (int i = 0; i < vwtx.size(); ++i) {
+        CReserveKey reservekey(wallet.get());
+        if (!wallet->CommitTransaction(vwtx[i].tx, vwtx[i].mapValue, vwtx[i].vOrderForm, &reservekey, g_connman.get(), state, nComputeTimeFinish - nComputeTimeStart)) {
+            receipt.SetStatus(
+                    "Error: The transaction was rejected! This might happen if some of the coins in your wallet "
+                    "were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy "
+                    "but not marked as spent here.", nStatus);
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Transaction commit failed: %s", FormatStateMessage(state)));
         }
-    //} else {
-      //  if (!wallet->CommitTransaction(wtx, rtx, reservekey, g_connman.get(), state)) {
-        //    throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Transaction commit failed: %s", FormatStateMessage(state)));
-        //}
-    //}
-
-    /*
-    UniValue vErrors(UniValue::VARR);
-    if (!state.IsValid()) // Should be caught in CommitTransaction
-    {
-        // This can happen if the mempool rejected the transaction.  Report
-        // what happened in the "errors" response.
-        vErrors.push_back(strprintf("Error: The transaction was rejected: %s", FormatStateMessage(state)));
-
-        UniValue result(UniValue::VOBJ);
-        result.pushKV("txid", wtx.GetHash().GetHex());
-        result.pushKV("errors", vErrors);
-        return result;
-    };
-    */
-
-    //pwalletAnon->PostProcessTempRecipients(vecSend);
-
-    if (fShowFee) {
-        result.pushKV("txid", wtx.GetHash().GetHex());
-        return result;
     }
 
-    return wtx.GetHash().GetHex();
+    receipt.SetStatus("Transactions successful.", SEND_OKAY);
+
+    return results;
 }
 
 static const char *TypeToWord(OutputTypes type)
@@ -651,6 +705,8 @@ static std::string SendHelp(std::shared_ptr<CWallet> pwallet, OutputTypes typeIn
     rv = cmd + " \"address\" amount ( \"comment\" \"comment-to\" subtractfeefromamount \"narration\"";
     if (typeIn == OUTPUT_RINGCT)
         rv += " ringsize inputs_per_sig";
+    if (typeIn == OUTPUT_CT || typeIn == OUTPUT_RINGCT)
+        rv += " inputs_per_tx";
     rv += ")\n";
 
     rv += "\nSend an amount of ";
@@ -671,11 +727,20 @@ static std::string SendHelp(std::shared_ptr<CWallet> pwallet, OutputTypes typeIn
             "5. subtractfeefromamount  (boolean, optional, default=false) The fee will be deducted from the amount being sent.\n"
             "                            The recipient will receive less " + CURRENCY_UNIT + " than you enter in the amount field.\n"
             "6. \"narration\"   (string, optional) Up to 24 characters sent with the transaction.\n"
-                                                                                                                                                                                 "                            The narration is stored in the blockchain and is sent encrypted when destination is a stealth address and uncrypted otherwise.\n";
+                                                                                                                               "                            The narration is stored in the blockchain and is sent encrypted when destination is a stealth address and uncrypted otherwise.\n";
     if (typeIn == OUTPUT_RINGCT)
         rv +=
                 "7. ringsize        (int, optional, default=4).\n"
-                "8. inputs_per_sig  (int, optional, default=32).\n";
+                "8. inputs_per_sig  (int, optional, default=32).\n"
+                "9. inputs_per_tx   (int, optional, default=0, max=32). Allows sending in multiple transactions if necessary.\n"
+                "                            If 0, will attempt to accomplish in one transaction.\n"
+                "                            If greater than 0, may use multiple transactions,\n"
+                "                            and will sweep dust into change using extra input slots if possible.\n";
+    else if (typeIn == OUTPUT_CT)
+        rv += "7. inputs_per_tx   (int, optional, default=0, max=32). Allows sending in multiple transactions if necessary.\n"
+              "                            If 0, will attempt to accomplish in one transaction.\n"
+              "                            If greater than 0, may use multiple transactions,\n"
+              "                            and will sweep dust into change using extra input slots if possible.\n";
 
     rv +=
             "\nResult:\n"
@@ -703,7 +768,7 @@ static UniValue sendstealthtobasecoin(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 6)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 7)
         throw std::runtime_error(SendHelp(wallet, OUTPUT_CT, OUTPUT_STANDARD));
 
     return SendToInner(request, OUTPUT_CT, OUTPUT_STANDARD);
@@ -714,7 +779,7 @@ static UniValue sendstealthtostealth(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 6)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 7)
         throw std::runtime_error(SendHelp(wallet, OUTPUT_CT, OUTPUT_CT));
 
     return SendToInner(request, OUTPUT_CT, OUTPUT_CT);
@@ -725,7 +790,7 @@ static UniValue sendstealthtoringct(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 6)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 7)
         throw std::runtime_error(SendHelp(wallet, OUTPUT_CT, OUTPUT_RINGCT));
 
     return SendToInner(request, OUTPUT_CT, OUTPUT_RINGCT);
@@ -737,7 +802,7 @@ static UniValue sendringcttobasecoin(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 9)
         throw std::runtime_error(SendHelp(wallet, OUTPUT_RINGCT, OUTPUT_STANDARD));
 
     return SendToInner(request, OUTPUT_RINGCT, OUTPUT_STANDARD);
@@ -748,7 +813,7 @@ static UniValue sendringcttostealth(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 9)
         throw std::runtime_error(SendHelp(wallet, OUTPUT_RINGCT, OUTPUT_CT));
 
     return SendToInner(request, OUTPUT_RINGCT, OUTPUT_CT);
@@ -759,7 +824,7 @@ static UniValue sendringcttoringct(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 9)
         throw std::runtime_error(SendHelp(wallet, OUTPUT_RINGCT, OUTPUT_RINGCT));
 
     return SendToInner(request, OUTPUT_RINGCT, OUTPUT_RINGCT);
@@ -770,9 +835,9 @@ UniValue sendtypeto(const JSONRPCRequest &request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet.get(), request.fHelp))
         return NullUniValue;
-    if (request.fHelp || request.params.size() < 3 || request.params.size() > 9)
+    if (request.fHelp || request.params.size() < 3 || request.params.size() > 10)
         throw std::runtime_error(
-                "sendtypeto \"typein\" \"typeout\" [{address: , amount: , narr: , subfee:},...] (\"comment\" \"comment-to\" ringsize inputs_per_sig test_fee coin_control)\n"
+                "sendtypeto \"typein\" \"typeout\" [{address: , amount: , narr: , subfee:},...] (\"comment\" \"comment-to\" ringsize inputs_per_sig test_fee coin_control inputs_per_tx)\n"
                 "\nSend basecoin to multiple outputs.\n"
                 + HelpRequiringPassphrase(wallet.get()) +
                 "\nArguments:\n"
@@ -806,6 +871,10 @@ UniValue sendtypeto(const JSONRPCRequest &request)
                 "           \"CONSERVATIVE\"\n"
                 "     \"feeRate\"                (numeric, optional, default not set: makes wallet determine the fee) Set a specific feerate (" + CURRENCY_UNIT + " per KB)\n"
                 "   }\n"
+                "10. inputs_per_tx  (int, optional, default=0). Allows sending in multiple transactions if necessary.\n"
+                "                            If 0, will attempt to accomplish in one transaction.\n"
+                "                            If greater than 0, may use multiple transactions,\n"
+                "                            and will sweep dust into change using extra input slots if possible.\n"
                 "\nResult:\n"
                 "\"txid\"              (string) The transaction id.\n"
                 "\nExamples:\n"
@@ -1607,7 +1676,7 @@ static UniValue fundrawtransactionfrom(const JSONRPCRequest& request)
             //if (!pwallet->AddAnonInputs(wtx, rtx, vecSend, false, nFee, &coinControl, sError))
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddAnonInputs failed: %s.", sError));
         } else if (sInputType == "blind") {
-            if (0 != pAnonWallet->AddBlindedInputs(wtx, rtx, vecSend, false, nFee, &coinControl, sError)) {
+            if (0 != pAnonWallet->AddBlindedInputs(wtx, rtx, vecSend, false, 0, nFee, &coinControl, sError)) {
                 throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddBlindedInputs failed: %s.", sError));
             }
         } else {

--- a/src/veil/ringct/temprecipient.cpp
+++ b/src/veil/ringct/temprecipient.cpp
@@ -8,7 +8,6 @@
 bool CTempRecipient::ApplySubFee(CAmount nFee, size_t nSubtractFeeFromAmount, bool &fFirst)
 {
     if (nType != OUTPUT_DATA) {
-        nAmount = nAmountSelected;
         if (fSubtractFeeFromAmount && !fExemptFeeSub) {
             nAmount -= nFee / nSubtractFeeFromAmount; // Subtract fee equally from each selected recipient
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6366,12 +6366,12 @@ bool CWallet::CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransa
 
     if (inputtype == OUTPUT_RINGCT)  {
         // default parameters for ring sig
-        if (!pAnonWalletMain->AddAnonInputs(wtx, rtx, vecSend, true, Params().DefaultRingSize(), /**nInputsPerSig**/ 32, nFeeRet, &cControl, sError)) {
+        if (!pAnonWalletMain->AddAnonInputs(wtx, rtx, vecSend, true, Params().DefaultRingSize(), /**nInputsPerSig**/ 32, 0, nFeeRet, &cControl, sError)) {
             strFailReason = strprintf("Failed to add ringctinputs: %s", sError);
             return false;
         }
     } else if (inputtype == OUTPUT_CT) {
-        if (0 != pAnonWalletMain->AddBlindedInputs(wtx, rtx, vecSend, true, nFeeRet, &cControl, sError)) {
+        if (0 != pAnonWalletMain->AddBlindedInputs(wtx, rtx, vecSend, true, 0, nFeeRet, &cControl, sError)) {
             strFailReason = strprintf("Failed to add ringctinputs: %s", sError);
             return false;
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -140,6 +140,13 @@ enum ZerocoinSpendStatus {
     ZSPEND_PREPARED = 17                        // No error thus far, but spending not yet fully finished
 };
 
+// Possible states for MultiTx send
+// TODO: Merge with ZerocoinSpendStatus
+enum MultiTxStatus {
+    SEND_OKAY = 0,                              // No error
+    SEND_ERROR = 1,                             // Unspecified class of errors, more details are (hopefully) in the returning text
+};
+
 //! Default for -addresstype
 constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::BECH32};
 


### PR DESCRIPTION
## Details

RPC send commands have a new argument `inputs_per_tx` that controls whether the amount specified can be split across multiple transactions. This value ranges from 0 (default) to 32 (an upper bound designed to prevent transactions larger than can be accepted). When set to 0, attempts to fit the send in one transaction as per previous behavior.

The sends are interpreted to mean that the recipient will receive the sent amount, but under the hood the transactions are created as if `subtractfeefromamount` was specified. In particular, if the send needs to be split into `n > 1` transactions, the outputs of the first `n - 1` are randomly reduced to account for the fee (and the shortfall from the inputs).

Coins are selected using a sliding window that prioritizes cleaning up small utxos (dust) over using fewer inputs, and thus transactions built this way will tend toward having more inputs. This is beneficial for ringct staking (keeping larger coins intact and reducing the amount of small utxos). The smallest utxo is always included if possible to prevent the amount of small utxos from increasing with usage.

## Tested
On regtest some months ago.