### PR TITLE
[Logging] Add missing format specifier.

### DIFF
--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -3015,7 +3015,7 @@ bool AnonWallet::PickHidingOutputs(std::vector<std::vector<int64_t> > &vMI, size
         const static size_t nMaxTries = 1000;
         for (j = 0; j < nMaxTries; ++j) {
             if (nLastRCTOutIndex <= nMinIndex) {
-                sError = strprintf("Not enough anonymous outputs exist, min: last: %d, required: %d.",
+                sError = strprintf("Not enough anonymous outputs exist, min: %d, last: %d, required: %d.",
                                    nMinIndex, nLastRCTOutIndex, nInputs * nRingSize);
                 return error("%s: %s", __func__, sError);
             }


### PR DESCRIPTION
Discovered a malformed error message during debugging. This allows the error to properly be formatted.