### PR TITLE
Refactor ZC-specific staking functionality.

### DIFF
--- a/src/veil/proofofstake/stakeinput.cpp
+++ b/src/veil/proofofstake/stakeinput.cpp
@@ -166,6 +166,21 @@ CAmount ZerocoinStake::GetValue()
     return denom * COIN;
 }
 
+CAmount ZerocoinStake::GetWeight()
+{
+    if (denom == libzerocoin::CoinDenomination::ZQ_ONE_HUNDRED) {
+        //10% reduction
+        return (denom * COIN * 9) / 10;
+    } else if (denom == libzerocoin::CoinDenomination::ZQ_ONE_THOUSAND) {
+        //20% reduction
+        return (denom * COIN * 8) / 10;
+    } else if (denom == libzerocoin::CoinDenomination::ZQ_TEN_THOUSAND) {
+        //30% reduction
+        return (denom * COIN * 7) / 10;
+    }
+    return denom * COIN;
+}
+
 int ZerocoinStake::HeightToModifierHeight(int nHeight)
 {
     //Nearest multiple of KernelModulus that is over KernelModulus bocks deep in the chain
@@ -275,6 +290,13 @@ bool ZerocoinStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CA
 
     return true;
 #endif
+}
+
+bool ZerocoinStake::CompleteTx(CWallet* pwallet, CMutableTransaction& txNew)
+{
+    if (!MarkSpent(pwallet, txNew.GetHash()))
+        return error("%s: failed to mark mint as used\n", __func__);
+    return true;
 }
 
 bool ZerocoinStake::GetTxFrom(CTransaction& tx)

--- a/src/veil/proofofstake/stakeinput.h
+++ b/src/veil/proofofstake/stakeinput.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2019 The PIVX developers
-// Copyright (c) 2019 The Veil developers
+// Copyright (c) 2019-2022 The Veil developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,14 +25,17 @@ protected:
 public:
     virtual ~CStakeInput(){};
     virtual CBlockIndex* GetIndexFrom() = 0;
-    virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = uint256()) = 0;
     virtual bool GetTxFrom(CTransaction& tx) = 0;
     virtual CAmount GetValue() = 0;
-    virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
+    virtual CAmount GetWeight() = 0;
     virtual bool GetModifier(uint64_t& nStakeModifier, const CBlockIndex* pindexChainPrev) = 0;
     virtual bool IsZerocoins() = 0;
     virtual CDataStream GetUniqueness() = 0;
     libzerocoin::CoinDenomination GetDenomination() {return denom;};
+
+    virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = uint256()) = 0;
+    virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
+    virtual bool CompleteTx(CWallet* pwallet, CMutableTransaction& txNew) = 0;
 };
 
 
@@ -60,12 +63,15 @@ public:
     CBlockIndex* GetIndexFrom() override;
     bool GetTxFrom(CTransaction& tx) override;
     CAmount GetValue() override;
+    CAmount GetWeight() override;
     bool GetModifier(uint64_t& nStakeModifier, const CBlockIndex* pindexChainPrev) override;
     CDataStream GetUniqueness() override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = uint256()) override;
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
-    bool MarkSpent(CWallet* pwallet, const uint256& txid);
+    bool CompleteTx(CWallet* pwallet, CMutableTransaction& txNew) override;
     bool IsZerocoins() override { return true; }
+
+    bool MarkSpent(CWallet* pwallet, const uint256& txid);
     int GetChecksumHeightFromMint();
     int GetChecksumHeightFromSpend();
     uint256 GetChecksum();


### PR DESCRIPTION
In preparation for defining a RingCTStakeInput type, move more zerocoin-specific stuff behind a CStakeInput interface.

Namely:
* Getting the weight of the stake coin.
* Finishing up the transaction creation (RingCT may have more to do than zerocoin here).

Also moved a variable `nCredit` that needs to be reset on each loop into the loop.

Not tested beyond compiling.