### PR TITLE
Correct progress display on searchdeterministiczerocoin

### DIFF
--- a/src/veil/zerocoin/zwallet.cpp
+++ b/src/veil/zerocoin/zwallet.cpp
@@ -392,7 +392,9 @@ bool CzWallet::DeterministicSearch(int nCountStart, int nCountEnd, int* nThreade
                 }
             }
 
-            int percentageDone = std::max(1, std::min(99, (int)((progress_current - progress_begin) / (progress_end - progress_begin) * 100)));
+            // items complete = progress_current
+            // items total = progress_end - progress_begin
+            int percentageDone = std::max(1, std::min(99, (int)(progress_current / (progress_end - progress_begin) * 100)));
             uiInterface.ShowProgress(_("Searching..."), percentageDone, 0);
         }
         if (nThreadedProgress == nullptr) {


### PR DESCRIPTION
## Issue

The progress bar shown in veil-qt on running `searchdeterministiczerocoin` works fine when starting from 0, but is stuck at 1% for other starting values.

## Solution

The progress items of the individual threads have already accounted for their start points, so we don't need to subtract the overall start point again.

## Testing

Run e.g. `searchdeterministiczerocoin` 100 100 2.