### PR TITLE
Proposed fix for (one type of) force_return errors.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2200,11 +2200,8 @@ static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const
                     entry.pushKV("account", account);
                 if (IsValidDestination(r.destination))
                 {
-                    auto item = pwallet->mapAddressBook.find(r.destination);
-                    if (item->first.type() == typeid(CKeyID))
-                        entry.pushKV("address", EncodeDestination(r.destination, false));
-                    else
-                        entry.pushKV("address", EncodeDestination(r.destination));
+                    entry.pushKV("address", EncodeDestination(
+                        r.destination, r.destination.type() != typeid(CKeyID)));
                 }
                 if (wtx.IsCoinBase())
                 {
@@ -2517,11 +2514,8 @@ static void ExportTransactions(CWallet* const pwallet, const CWalletTx& wtx, con
                     csvRecord[TRANSACTION_CSV_FIELD_ACCOUNT] = account;
                 if ( IsValidDestination(r->destination) )
                 {
-                    auto item = pwallet->mapAddressBook.find(r->destination);
-                    if (item->first.type() == typeid(CKeyID))
-                        csvRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(r->destination, false);
-                    else
-                        csvRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(r->destination);
+                    csvRecord[TRANSACTION_CSV_FIELD_ADDRESS] = EncodeDestination(
+                        r->destination, r->destination.type() != typeid(CKeyID));
                 }
                 if (wtx.IsCoinBase())
                 {


### PR DESCRIPTION
## Issue

When dealing with some orphan transactions[^1], some addresses aren't in the address map, and so when we look them up we get an invalid return value to indicate we didn't find it. However, we don't check for the sentinel value and instead try to look up its type (it's a `boost::variant`) which can assert with forced_return if the `which_` field is outside the valid range.

[^1]: This only happened for me for months-old orphan blocks, and I can't tell if the address never existed or if it got corrupted at some point.

## Fix

We don't need to look up an address in the map when all we're going to do is use the key (which must be the same type per `boost::variant`).

## Tested

Windows 10 mainnet wallet.