### PR TITLE
Add RPCs for external RandomX mining

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -128,7 +128,7 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx, bool fProofOfStake, bool fProofOfFullNode)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx, bool fProofOfStake, bool fProofOfFullNode, int nPoWType)
 {
     int64_t nTimeStart = GetTimeMicros();
     int64_t nComputeTimeStart = GetTimeMillis();
@@ -207,7 +207,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         }
     }
 
-    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), pblock->nTime, !fProofOfStake);
+    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), pblock->nTime, !fProofOfStake, nPoWType);
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (chainparams.MineBlocksOnDemand())

--- a/src/miner.h
+++ b/src/miner.h
@@ -208,7 +208,7 @@ public:
     BlockAssembler(const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true, bool fProofOfStake=false, bool fProofOfFullNode = false);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true, bool fProofOfStake=false, bool fProofOfFullNode = false, int nPoWType = 0);
 
 private:
     // utility functions

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -304,7 +304,7 @@ bool ParseInt64(const std::string& str, int64_t *out)
         n <= std::numeric_limits<int64_t>::max();
 }
 
-bool ParseUInt32(const std::string& str, uint32_t *out)
+bool ParseUInt32(const std::string& str, uint32_t *out, int base)
 {
     if (!ParsePrechecks(str))
         return false;
@@ -312,7 +312,7 @@ bool ParseUInt32(const std::string& str, uint32_t *out)
         return false;
     char *endp = nullptr;
     errno = 0; // strtoul will not set errno if valid
-    unsigned long int n = strtoul(str.c_str(), &endp, 10);
+    unsigned long int n = strtoul(str.c_str(), &endp, base);
     if(out) *out = (uint32_t)n;
     // Note that strtoul returns a *unsigned long int*, so even if it doesn't report an over/underflow
     // we still have to check that the returned value is within the range of an *uint32_t*. On 64-bit

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -93,7 +93,7 @@ bool ParseInt64(const std::string& str, int64_t *out);
  * @returns true if the entire string could be parsed as valid integer,
  *   false if not the entire string could be parsed or when overflow or underflow occurred.
  */
-bool ParseUInt32(const std::string& str, uint32_t *out);
+bool ParseUInt32(const std::string& str, uint32_t *out, int base = 10);
 
 /**
  * Convert decimal string to unsigned 64-bit integer with strict parse error feedback.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2137,7 +2137,7 @@ void ThreadScriptCheck() {
 // Protected by cs_main
 VersionBitsCache versionbitscache;
 
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, const uint32_t& blockTime, const bool& fProofOfWork)
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, const uint32_t& blockTime, const bool& fProofOfWork, int nPoWType)
 {
     LOCK(cs_main);
     int32_t nVersion = VERSIONBITS_OLD_POW_VERSION;
@@ -2146,7 +2146,11 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         nVersion = VERSIONBITS_NEW_POW_VERSION;
 
         if (fProofOfWork) {
-            if (GetMiningAlgorithm() == MINE_PROGPOW) {
+            if (nPoWType == CBlockHeader::PROGPOW_BLOCK ||
+                nPoWType == CBlockHeader::RANDOMX_BLOCK ||
+                nPoWType == CBlockHeader::SHA256D_BLOCK) {
+                nVersion |= nPoWType;
+            } else if (GetMiningAlgorithm() == MINE_PROGPOW) {
                 nVersion |= CBlockHeader::PROGPOW_BLOCK;
             } else if (GetMiningAlgorithm() == MINE_SHA256D) {
                 nVersion |= CBlockHeader::SHA256D_BLOCK;

--- a/src/validation.h
+++ b/src/validation.h
@@ -536,7 +536,7 @@ extern VersionBitsCache versionbitscache;
 /**
  * Determine what nVersion a new block should use.
  */
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, const uint32_t& blockTime, const bool& fProofOfWork);
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, const uint32_t& blockTime, const bool& fProofOfWork, int nPoWType = 0);
 
 /** Reject codes greater or equal to this can be returned by AcceptToMemPool
  * for transactions, to signal internal conditions. They cannot and should not


### PR DESCRIPTION
### Problem ###
- No external RandomX mining possible.
- Mining multiple algorithms at the same time is currently not possible.
- The algorithm `getblocktemplate` RPC uses for its blocks depends on the value the user selects for mining in the GUI of the wallet / in the config.

### Root Cause ###
Not implemented yet.

### Solution ###
The solution was to:
1. Add an `algo` parameter to the `getblocktemplate` RPC which overrides any mining algorithm specified in the config / GUI.
2. Add a new RPC `rxrpcsb` for submitting randomx blocks, analogous to `pprpcsb`.
This makes it possible to mine at the same time progpow, randomx and sha256d externally, independently of what you may additionally mine using the wallet.

### Bounty PR ###
?

### Bounty Payment Address ##
`sv1qqpjsrc60t60jhaywj5krmwla52ska70twc7wun6qnee65guxhvtxegpqwhuxypra4jn3pq86s24ryltcw6g2ss4573hyqac9u4g23m9mvxpyqqqwny49k`

### Unit Testing Results ###
Tested by mining at the same time progpow blocks with t-rex miner and randomx blocks with xmrig, where both found at least one block.