### PR TITLE
Fix wrong CT / RingCT amounts in transaction history when wallet locked

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1225,14 +1225,14 @@ void BitcoinGUI::showEvent(QShowEvent *event)
 }
 
 #ifdef ENABLE_WALLET
-void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName)
+void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, bool amountLocked, const QString& type, const QString& address, const QString& label, const QString& walletName)
 {
     if(!enableWallet)
         return;
 
     // On new transaction, make an info balloon
     QString msg = tr("Date: %1\n").arg(date) +
-                  tr("Amount: %1\n").arg(BitcoinUnits::formatWithUnit(unit, amount, true));
+                  tr("Amount: %1\n").arg(!amountLocked ? BitcoinUnits::formatWithUnit(unit, amount, true) : tr("Hidden"));
     if (m_node.getWallets().size() > 1 && !walletName.isEmpty()) {
         msg += tr("Wallet: %1\n").arg(walletName);
     }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -269,7 +269,7 @@ public Q_SLOTS:
     void optionsClicked();
 
     /** Show incoming transaction notification for new transactions. */
-    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName);
+    void incomingTransaction(const QString& date, int unit, const CAmount& amount, bool amountLocked, const QString& type, const QString& address, const QString& label, const QString& walletName);
 
     /** Encrypt every wallet **/
     bool encryptWallet(bool encrypt);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -89,7 +89,8 @@ public:
        
         // Format the amount.
         qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
-        QString amountText = BitcoinUnits::formatWithUnit(unit, amount, true, BitcoinUnits::separatorAlways);
+        bool amountLocked = index.data(TransactionTableModel::AmountLockedRole).toBool();
+        QString amountText = !amountLocked ? BitcoinUnits::formatWithUnit(unit, amount, true, BitcoinUnits::separatorAlways) : tr("Hidden");
 
         // Get the width of the amount string
         QFontMetrics fm(painter->fontMetrics());
@@ -163,7 +164,10 @@ public:
         }
 
         // TODO: Change this balance calculation
-        if(amount < 0) {
+        if(amountLocked) {
+            foreground = COLOR_UNCONFIRMED;
+        }
+        else if(amount < 0) {
             foreground = COLOR_NEGATIVE;
         }
         else if(!confirmed) {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -325,8 +325,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     sub.address = strAddress;
 
                     // Value is blinded so must come from outputrecord
-                    if (precord)
+                    if (precord) {
                         sub.credit = precord->GetAmount();
+                        sub.status.isLocked = precord->nFlags & ORF_LOCKED;
+                    }
                 }
 
                 if (strAddress.empty())

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -65,11 +65,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 outputType = OutputTypes::OUTPUT_RINGCT;
             };
 
-            if (nFlags & ORF_OWNED)
+            if (r.nFlags & ORF_OWNED)
                 sub.credit += r.GetRawValue();
-            if (nFlags & ORF_FROM)
+            if (r.nFlags & ORF_FROM)
                 sub.debit -= r.GetRawValue();
         };
+        sub.status.isLocked = nFlags & ORF_LOCKED;
 
         if (sub.debit != 0)
             sub.debit -= wtx.ct_fee.second;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -25,7 +25,7 @@ class TransactionStatus
 public:
     TransactionStatus():
         countsForBalance(false), sortKey(""),
-        matures_in(0), status(Unconfirmed), depth(0), open_for(0), cur_num_blocks(-1)
+        matures_in(0), status(Unconfirmed), depth(0), open_for(0), cur_num_blocks(-1), needsUpdate(false), isLocked(false)
     { }
 
     enum Status {
@@ -65,6 +65,8 @@ public:
     int cur_num_blocks;
 
     bool needsUpdate;
+
+    bool isLocked;
 };
 
 /** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -106,7 +106,7 @@ public:
         int upperIndex = (upper - cachedWallet.begin());
         bool inModel = (lower != upper);
 
-        if(status == CT_UPDATED)
+        if(status == CT_UPDATED || status == CT_UPDATED_FULL)
         {
             if(showTransaction && !inModel)
                 status = CT_NEW; /* Not in model, but want to show, treat as new */
@@ -120,6 +120,23 @@ public:
 
         switch(status)
         {
+        case CT_UPDATED_FULL:
+        case CT_DELETED:
+            if(!inModel)
+            {
+                const char *statusStr = status == CT_DELETED ? "CT_DELETED" : "CT_UPDATED_FULL";
+                qWarning() << "TransactionTablePriv::updateWallet: Warning: Got " << statusStr << ", but transaction is not in model";
+                break;
+            }
+            // Removed -- remove entire transaction from table
+            parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex-1);
+            cachedWallet.erase(lower, upper);
+            parent->endRemoveRows();
+            if (status == CT_DELETED)
+                break;
+            // Fall through is intentional here to prevent code duplication, since CT_UPDATED_FULL
+            // is equivalent to first CT_DELETED and then CT_NEW.
+            inModel = false;
         case CT_NEW:
             if(inModel)
             {
@@ -150,17 +167,6 @@ public:
                     parent->endInsertRows();
                 }
             }
-            break;
-        case CT_DELETED:
-            if(!inModel)
-            {
-                qWarning() << "TransactionTablePriv::updateWallet: Warning: Got CT_DELETED, but transaction is not in model";
-                break;
-            }
-            // Removed -- remove entire transaction from table
-            parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex-1);
-            cachedWallet.erase(lower, upper);
-            parent->endRemoveRows();
             break;
         case CT_UPDATED:
             // Miscellaneous updates -- nothing to do, status update will take care of this, and is only computed for
@@ -553,7 +559,12 @@ QVariant TransactionTableModel::txWatchonlyDecoration(const TransactionRecord *w
 
 QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
 {
-    QString tooltip = formatTxStatus(rec) + QString("\n") + formatTxType(rec);
+    QString tooltip;
+    if (rec->status.isLocked) {
+        tooltip += tr("Unlock wallet to see hidden amount");
+        tooltip += "\n";
+    }
+    tooltip += formatTxStatus(rec) + QString("\n") + formatTxType(rec);
     if(rec->type==TransactionRecord::RecvFromOther || rec->type==TransactionRecord::SendToOther ||
        rec->type==TransactionRecord::SendToAddress || rec->type==TransactionRecord::RecvWithAddress)
     {
@@ -657,6 +668,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
     case AmountRole:
         return qint64(rec->credit + rec->debit);
+    case AmountLockedRole:
+        return rec->status.isLocked;
     case FeeRole:
         return "Fee " + ( rec->getFee() == 0 ? "0.00 VEIL" : BitcoinUnits::formatWithUnit(BitcoinUnits::VEIL, rec->getFee(), false, BitcoinUnits::separatorAlways)) ;
     case TxHashRole:

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -60,6 +60,8 @@ public:
         LabelRole,
         /** Net amount of transaction */
         AmountRole,
+        /** Is transaction amount locked */
+        AmountLockedRole,
         /** Transaction hash */
         TxHashRole,
         /** Transaction data, hex-encoded */

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -124,7 +124,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         connect(this, SIGNAL(encryptionStatusChanged()), gui, SLOT(updateWalletStatus()));
 
         // Pass through transaction notifications
-        connect(this, SIGNAL(incomingTransaction(QString,int,CAmount,QString,QString,QString,QString)), gui, SLOT(incomingTransaction(QString,int,CAmount,QString,QString,QString,QString)));
+        connect(this, SIGNAL(incomingTransaction(QString,int,CAmount,bool,QString,QString,QString,QString)), gui, SLOT(incomingTransaction(QString,int,CAmount,bool,QString,QString,QString,QString)));
 
         // Connect HD enabled state signal
         connect(this, SIGNAL(hdEnabledStatusChanged()), gui, SLOT(updateWalletStatus()));
@@ -195,10 +195,11 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
     qint64 amount = ttm->index(start, TransactionTableModel::Amount, parent).data(Qt::EditRole).toULongLong();
     QString type = ttm->index(start, TransactionTableModel::Type, parent).data().toString();
     QModelIndex index = ttm->index(start, 0, parent);
+    bool amountLocked = ttm->data(index, TransactionTableModel::AmountLockedRole).toBool();
     QString address = ttm->data(index, TransactionTableModel::AddressRole).toString();
     QString label = ttm->data(index, TransactionTableModel::LabelRole).toString();
 
-    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, label, walletModel->getWalletName());
+    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, amountLocked, type, address, label, walletModel->getWalletName());
 }
 
 void WalletView::gotoOverviewPage()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -160,7 +160,7 @@ Q_SIGNALS:
     /** HD-Enabled status of wallet changed (only possible during startup) */
     void hdEnabledStatusChanged();
     /** Notify that a new transaction appeared */
-    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName);
+    void incomingTransaction(const QString& date, int unit, const CAmount& amount, bool amountLocked, const QString& type, const QString& address, const QString& label, const QString& walletName);
     /** Notify that the out of sync warning icon has been pressed */
     void outOfSyncWarningClicked();
 

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -23,6 +23,7 @@ enum ChangeType
 {
     CT_NEW,
     CT_UPDATED,
+    CT_UPDATED_FULL,
     CT_DELETED
 };
 

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -5021,7 +5021,8 @@ void AnonWallet::RescanWallet()
         CTransactionRecord* txrecord = &mi->second;
 
         int nHeightTx = 0;
-        if (!IsTransactionInChain(txid, nHeightTx, Params().GetConsensus())) {
+        bool isTransactionInChain = IsTransactionInChain(txid, nHeightTx, Params().GetConsensus());
+        if (!isTransactionInChain) {
             //This particular transaction never made it into the chain. If it is a certain amount of time old, delete it.
             if (GetTime() - txrecord->nTimeReceived > 60*20) {
                 //20 minutes too old?
@@ -5045,142 +5046,143 @@ void AnonWallet::RescanWallet()
                     }
                 }
                 setErase.emplace(txid);
+                continue;
             }
-        } else {
-            // Check outputs for inconsistencies
-            CTransactionRef txRef;
-            uint256 hashBlock;
-            if (!GetTransaction(txid, txRef, Params().GetConsensus(), hashBlock, true))
+        }
+
+        // Check outputs for inconsistencies
+        CTransactionRef txRef;
+        uint256 hashBlock;
+        if (!GetTransaction(txid, txRef, Params().GetConsensus(), hashBlock, true))
+            continue;
+
+        bool transactionUpdated = false;
+        for (auto it = txrecord->vout.begin(); it != txrecord->vout.end(); it++) {
+            bool fUpdated = false;
+            if (txRef->vpout.size() < static_cast<unsigned int>(it->n + 1))
                 continue;
 
-            bool transactionUpdated = false;
-            for (auto it = txrecord->vout.begin(); it != txrecord->vout.end(); it++) {
-                bool fUpdated = false;
-                if (txRef->vpout.size() < static_cast<unsigned int>(it->n + 1))
-                    continue;
-
-                auto pout = txRef->vpout[it->n];
-                if (it->scriptPubKey.empty()) {
-                    CStoredTransaction stx;
-                    if (it->nType == OUTPUT_CT) {
-                        OwnBlindOut(&wdb, txid, (CTxOutCT*)pout.get(), *(it), stx, fUpdated);
-                    } else if (it->nType == OUTPUT_RINGCT) {
-                        OwnAnonOut(&wdb, txid, (CTxOutRingCT*)pout.get(), *(it), stx, fUpdated);
-                    }
-                    if (fUpdated)
-                        LogPrintf("%s: Updating scriptpubkey for %s\n", __func__, COutPoint(txid, it->n).ToString());
+            auto pout = txRef->vpout[it->n];
+            if (it->scriptPubKey.empty()) {
+                CStoredTransaction stx;
+                if (it->nType == OUTPUT_CT) {
+                    OwnBlindOut(&wdb, txid, (CTxOutCT*)pout.get(), *(it), stx, fUpdated);
+                } else if (it->nType == OUTPUT_RINGCT) {
+                    OwnAnonOut(&wdb, txid, (CTxOutRingCT*)pout.get(), *(it), stx, fUpdated);
                 }
+                if (fUpdated)
+                    LogPrintf("%s: Updating scriptpubkey for %s\n", __func__, COutPoint(txid, it->n).ToString());
+            }
 
-                // Check that the record's type is correct
-                if (it->nType != pout->GetType()) {
-                    it->nType = pout->GetType();
-                    fUpdated = true;
-                    LogPrintf("%s: Updated txout type for %s\n", __func__, COutPoint(txid, it->n).ToString());
+            // Check that the record's type is correct
+            if (it->nType != pout->GetType()) {
+                it->nType = pout->GetType();
+                fUpdated = true;
+                LogPrintf("%s: Updated txout type for %s\n", __func__, COutPoint(txid, it->n).ToString());
 
-                    if (it->IsBasecoin()) {
-                        // clear scriptpubkey info on basecoin. Don't need redundant storing.
-                        it->scriptPubKey.clear();
+                if (it->IsBasecoin()) {
+                    // clear scriptpubkey info on basecoin. Don't need redundant storing.
+                    it->scriptPubKey.clear();
+                }
+            }
+
+            // If value is marked as 0, check blind to make sure it is actually 0
+            if ((it->nFlags & ORF_OWNED) && it->GetAmount() == 0) {
+                int64_t nValue = 0;
+                uint256 blind;
+                bool fBlindsSuccess = true;
+                if (it->nType == OUTPUT_CT) {
+                    auto pout = (CTxOutCT*) txRef->vpout[it->n].get();
+                    CKeyID idKey;
+                    if (!KeyIdFromScriptPubKey(pout->scriptPubKey, idKey))
+                        continue;
+                    if (GetCTBlinds(idKey, pout->vData, &pout->commitment, pout->vRangeproof, blind, nValue)) {
+                        if (nValue != 0) {
+                            fUpdated = true;
+                            LogPrintf("%s: Recovered %s that was marked as 0 \n", __func__, FormatMoney(nValue));
+                        }
+                        fBlindsSuccess = true;
+                    }
+                } else if (it->nType == OUTPUT_RINGCT) {
+                    auto pout = (CTxOutRingCT*) txRef->vpout[it->n].get();
+                    if (GetCTBlinds(pout->pk.GetID(), pout->vData, &pout->commitment, pout->vRangeproof, blind, nValue)) {
+                        if (nValue != 0) {
+                            fUpdated = true;
+                            LogPrintf("%s: Recovered %s that was marked as 0 \n", __func__, FormatMoney(nValue));
+                        }
+                        fBlindsSuccess = true;
                     }
                 }
-
-                // If value is marked as 0, check blind to make sure it is actually 0
-                if ((it->nFlags & ORF_OWNED) && it->GetAmount() == 0) {
-                    int64_t nValue = 0;
-                    uint256 blind;
-                    bool fBlindsSuccess = true;
-                    if (it->nType == OUTPUT_CT) {
-                        auto pout = (CTxOutCT*) txRef->vpout[it->n].get();
-                        CKeyID idKey;
-                        if (!KeyIdFromScriptPubKey(pout->scriptPubKey, idKey))
-                            continue;
-                        if (GetCTBlinds(idKey, pout->vData, &pout->commitment, pout->vRangeproof, blind, nValue)) {
-                            if (nValue != 0) {
-                                fUpdated = true;
-                                LogPrintf("%s: Recovered %s that was marked as 0 \n", __func__, FormatMoney(nValue));
-                            }
-                            fBlindsSuccess = true;
-                        }
-                    } else if (it->nType == OUTPUT_RINGCT) {
-                        auto pout = (CTxOutRingCT*) txRef->vpout[it->n].get();
-                        if (GetCTBlinds(pout->pk.GetID(), pout->vData, &pout->commitment, pout->vRangeproof, blind, nValue)) {
-                            if (nValue != 0) {
-                                fUpdated = true;
-                                LogPrintf("%s: Recovered %s that was marked as 0 \n", __func__, FormatMoney(nValue));
-                            }
-                            fBlindsSuccess = true;
-                        }
-                    }
-                    //Failed to decrypt blinds. This could happen if a 0 value output is added. Double check.
-                    if (!fBlindsSuccess) {
-                        auto nValueIn = txrecord->GetOwnedValueIn();
-                        if (nValueIn == 0) {
-                            //Maybe not correctly marked as 0 in, update this.
-                            for (auto& in : txrecord->vin) {
-                                auto mi = mapRecords.find(in.hash);
-                                if (mi != mapRecords.end()) {
-                                    auto prevout = mi->second.GetOutput(in.n);
-                                    if (!prevout)
-                                        continue;
-                                    nValueIn += prevout->GetAmount();
-                                }
-                            }
-
-                            if (nValueIn > 0) {
-                                txrecord->SetOwnedValueIn(nValueIn);
-                                LogPrintf("%s: Updated owned value in for %s\n", __func__, txid.GetHex());
-                                fUpdated = true;
+                //Failed to decrypt blinds. This could happen if a 0 value output is added. Double check.
+                if (!fBlindsSuccess) {
+                    auto nValueIn = txrecord->GetOwnedValueIn();
+                    if (nValueIn == 0) {
+                        //Maybe not correctly marked as 0 in, update this.
+                        for (auto& in : txrecord->vin) {
+                            auto mi = mapRecords.find(in.hash);
+                            if (mi != mapRecords.end()) {
+                                auto prevout = mi->second.GetOutput(in.n);
+                                if (!prevout)
+                                    continue;
+                                nValueIn += prevout->GetAmount();
                             }
                         }
-                        auto nValueOut = txrecord->GetValueSent(/*fExternalOnly*/false);
-                        auto nFee = txrecord->nFee;
-                        if (nValueIn - nFee - nValueOut > 0)
-                            LogPrintf("%s: Failed to get blinds for output %s %s %s valuein:%s valueout:%s fee=%s\n",
-                                      __func__, txid.GetHex(), COutPoint(txid, it->n).ToString(), it->ToString(),
-                                      FormatMoney(nValueIn), FormatMoney(nValueOut), FormatMoney(nFee));
-                    }
 
-                    it->SetValue(nValue);
-                }
-
-                // Check if it has the correct is_spent status //todo ringct outputs
-                if ((it->nFlags & ORF_OWNED)) {
-                    if (it->nType == OUTPUT_CT) {
-                        bool isSpentOnChain = !view.HaveCoin(COutPoint(txid, it->n));
-                        if (isSpentOnChain != it->IsSpent()) {
-                            it->MarkSpent(isSpentOnChain);
+                        if (nValueIn > 0) {
+                            txrecord->SetOwnedValueIn(nValueIn);
+                            LogPrintf("%s: Updated owned value in for %s\n", __func__, txid.GetHex());
                             fUpdated = true;
                         }
-                    } else if (it->nType == OUTPUT_RINGCT) {
-                        auto txout = (CTxOutRingCT*)pout.get();
-                        CKeyID idk = txout->pk.GetID();
-                        CKey key;
-                        if (GetKey(idk, key)) {
-                            // Keyimage is required for the tx hash
-                            CCmpPubKey ki;
-                            if (secp256k1_get_keyimage(secp256k1_ctx_blind, ki.ncbegin(), txout->pk.begin(), key.begin()) == 0) {
-                                // Double check key image is not used...
-                                uint256 txhashKI;
-                                if (pblocktree->ReadRCTKeyImage(ki, txhashKI)) {
-                                    COutPoint out;
-                                    if (wdb.ReadAnonKeyImage(ki, out)) {
-                                        MarkOutputSpent(out, true);
-                                        LogPrintf("%s: marking ringct output %s:%d spent\n", __func__, txid.GetHex(), it->n);
-                                    }
+                    }
+                    auto nValueOut = txrecord->GetValueSent(/*fExternalOnly*/false);
+                    auto nFee = txrecord->nFee;
+                    if (nValueIn - nFee - nValueOut > 0)
+                        LogPrintf("%s: Failed to get blinds for output %s %s %s valuein:%s valueout:%s fee=%s\n",
+                                  __func__, txid.GetHex(), COutPoint(txid, it->n).ToString(), it->ToString(),
+                                  FormatMoney(nValueIn), FormatMoney(nValueOut), FormatMoney(nFee));
+                }
+
+                it->SetValue(nValue);
+            }
+
+            // Check if it has the correct is_spent status //todo ringct outputs
+            if (isTransactionInChain && (it->nFlags & ORF_OWNED)) {
+                if (it->nType == OUTPUT_CT) {
+                    bool isSpentOnChain = !view.HaveCoin(COutPoint(txid, it->n));
+                    if (isSpentOnChain != it->IsSpent()) {
+                        it->MarkSpent(isSpentOnChain);
+                        fUpdated = true;
+                    }
+                } else if (it->nType == OUTPUT_RINGCT) {
+                    auto txout = (CTxOutRingCT*)pout.get();
+                    CKeyID idk = txout->pk.GetID();
+                    CKey key;
+                    if (GetKey(idk, key)) {
+                        // Keyimage is required for the tx hash
+                        CCmpPubKey ki;
+                        if (secp256k1_get_keyimage(secp256k1_ctx_blind, ki.ncbegin(), txout->pk.begin(), key.begin()) == 0) {
+                            // Double check key image is not used...
+                            uint256 txhashKI;
+                            if (pblocktree->ReadRCTKeyImage(ki, txhashKI)) {
+                                COutPoint out;
+                                if (wdb.ReadAnonKeyImage(ki, out)) {
+                                    MarkOutputSpent(out, true);
+                                    LogPrintf("%s: marking ringct output %s:%d spent\n", __func__, txid.GetHex(), it->n);
                                 }
                             }
                         }
                     }
                 }
-
-                if (fUpdated) {
-                    wdb.WriteTxRecord(txid, *txrecord);
-                    transactionUpdated = true;
-                }
             }
 
-            if (transactionUpdated) {
-                pwalletParent->NotifyTransactionChanged(pwalletParent.get(), txid, CT_UPDATED_FULL);
+            if (fUpdated) {
+                wdb.WriteTxRecord(txid, *txrecord);
+                transactionUpdated = true;
             }
+        }
+
+        if (transactionUpdated) {
+            pwalletParent->NotifyTransactionChanged(pwalletParent.get(), txid, CT_UPDATED_FULL);
         }
     }
 

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -4020,7 +4020,7 @@ bool AnonWallet::MakeDefaultAccount(const CExtKey& extKeyMaster)
     return true;
 }
 
-bool AnonWallet::UnlockWallet(const CExtKey& keyMasterIn)
+bool AnonWallet::UnlockWallet(const CExtKey& keyMasterIn, bool fRescan)
 {
     if (!SetMasterKey(keyMasterIn))
         return false;
@@ -4035,8 +4035,10 @@ bool AnonWallet::UnlockWallet(const CExtKey& keyMasterIn)
     }
     }
 
-    LOCK2(cs_main, pwalletParent->cs_wallet);
-    RescanWallet<RESCAN_WALLET_LOCKED_ONLY>();
+    if (fRescan) {
+        LOCK2(cs_main, pwalletParent->cs_wallet);
+        RescanWallet<RESCAN_WALLET_LOCKED_ONLY>();
+    }
 
     return true;
 }

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -5459,7 +5459,7 @@ int AnonWallet::OwnAnonOut(AnonWalletDB *pwdb, const uint256 &txhash, const CTxO
     CKeyID idStealthDestination = pout->pk.GetID();
     CKey key;
     if (IsLocked()) {
-        if (!HaveKeyID(idStealthDestination))
+        if (!HaveKeyID(idStealthDestination) && !HaveAddress(idStealthDestination))
             return 0;
 
         rout.nFlags |= ORF_OWNED;

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -258,7 +258,7 @@ public:
     bool MakeDefaultAccount(const CExtKey& extKeyMaster);
     bool CreateStealthChangeAccount(AnonWalletDB* wdb);
     bool SetMasterKey(const CExtKey& keyMasterIn);
-    bool UnlockWallet(const CExtKey& keyMasterIn);
+    bool UnlockWallet(const CExtKey& keyMasterIn, bool fRescan = true);
     bool LoadAccountCounters();
     bool LoadKeys();
     CKeyID GetSeedHash() const;

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -301,6 +301,12 @@ public:
     bool ScanForOwnedOutputs(const CTransaction &tx, size_t &nCT, size_t &nRingCT, mapValue_t &mapNarr);
     bool AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     void MarkOutputSpent(const COutPoint& outpoint, bool isSpent);
+
+    enum RescanWalletType {
+      RESCAN_WALLET_FULL,
+      RESCAN_WALLET_LOCKED_ONLY,
+    };
+    template<RescanWalletType = RESCAN_WALLET_FULL>
     void RescanWallet() EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletParent->cs_wallet);
 
     int InsertTempTxn(const uint256 &txid, const CTransactionRecord *rtx) const;
@@ -364,6 +370,7 @@ public:
     mutable MapWallet_t mapTempWallet;
 
     MapRecords_t mapRecords;
+    std::set<uint256> mapLockedRecords; // Keep track of locked transactions (hidden value) for faster unlocking
     RtxOrdered_t rtxOrdered;
     mutable MapRecords_t mapTempRecords; // Hack for sending unmined inputs through fundrawtransactionfrom
 

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -301,7 +301,7 @@ public:
     bool ScanForOwnedOutputs(const CTransaction &tx, size_t &nCT, size_t &nRingCT, mapValue_t &mapNarr);
     bool AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     void MarkOutputSpent(const COutPoint& outpoint, bool isSpent);
-    void RescanWallet();
+    void RescanWallet() EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletParent->cs_wallet);
 
     int InsertTempTxn(const uint256 &txid, const CTransactionRecord *rtx) const;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -537,7 +537,7 @@ bool CWallet::UnlockZerocoinWallet()
     return true;
 }
 
-bool CWallet::UnlockAnonWallet()
+bool CWallet::UnlockAnonWallet(bool fAnonRescan)
 {
     CExtKey keyAnonMaster;
     if (!GetAnonWalletSeed(keyAnonMaster))
@@ -548,11 +548,11 @@ bool CWallet::UnlockAnonWallet()
     if (idDerived != idSeedDB)
         return error("%s: derived anon wallet key %s does not match expected key %s", __func__, idDerived.GetHex(), idSeedDB.GetHex());
 
-    pAnonWalletMain->UnlockWallet(keyAnonMaster);
+    pAnonWalletMain->UnlockWallet(keyAnonMaster, fAnonRescan);
     return true;
 }
 
-bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool fUnlockForStakingOnly)
+bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool fUnlockForStakingOnly, bool fAnonRescan)
 {
     CCrypter crypter;
     CKeyingMaterial _vMasterKey;
@@ -581,7 +581,7 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool fUnlockForSta
             return error("%s: failed to load hd chain from database", __func__);
         if (!UnlockZerocoinWallet())
             return error("%s: failed to unlock zerocoin wallet", __func__);
-        if (!UnlockAnonWallet())
+        if (!UnlockAnonWallet(fAnonRescan))
             return error("%s: failed to unlock anon wallet", __func__);
     }
 
@@ -875,7 +875,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         encrypted_batch = nullptr;
 
         CCryptoKeyStore::Lock();
-        CWallet::Unlock(strWalletPassphrase, false);
+        CWallet::Unlock(strWalletPassphrase, false, false);
 
         // if we are using HD, replace the HD seed with a new one
 //        if (CWallet::IsHDEnabled()) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1044,9 +1044,9 @@ public:
     int64_t nRelockTime = 0;
 
     bool LockWallet();
-    bool Unlock(const SecureString& strWalletPassphrase, bool fUnlockForStakingOnly);
+    bool Unlock(const SecureString& strWalletPassphrase, bool fUnlockForStakingOnly, bool fAnonRescan = true);
     bool UnlockZerocoinWallet();
-    bool UnlockAnonWallet();
+    bool UnlockAnonWallet(bool fAnonRescan = true);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
 
     void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
### Problem
When receiving a CT transaction while the wallet is locked (or unlocked for staking only), the amount displayed in the transaction history is wrong, and keeps wrong until a `rescanringctwallet` rpc is called and the wallet is restarted.

### Root Cause
- More concretely the wrong amount showed is -1 satoshi per output in the transaction, which comes from the default value in the following line: https://github.com/Veil-Project/veil/blob/7c8bee132ea6305b29a613679b7591a27d8edbd8/src/veil/ringct/outputrecord.h#L43
- Furthermore, for the case when the transaction contained a change output, there was a bug in the way the GUI calculates the transaction amount, which resulted in that default -1 satoshi also being added for the change output (which isn't owned by the receiving wallet), thus the final amount was in this case always displayed as 1 satoshi less than the actual transaction was.
- For incoming RingCT transactions the `ORF_OWNED` flag was not set correctly, leading to RingCT transactions being showed as "(n/a)" in the transaction history, if they arrived while the wallet was locked.

### Solution
- When a CT transaction arrives while the wallet is locked (or unlocked for staking only):
  - Instead of a wrong amount show **"Hidden"** in the transaction history entry.
  - In the tooltip of the transaction row show the message **"Unlock wallet to see hidden amount"**.
  - In the "Incoming transaction" GUI notification also show "Hidden" instead of a wrong amount.
- Fix `rescanringctwallet` to properly update corresponding entries in the transaction history GUI.
- Keep track of locked transactions and when the wallet is then unlocked, automatically do a **partial `rescanringctwallet`** which only rescans those tracked locked transactions, and thus should be fast also for wallets having a very long transaction history.

### Bounty Payment Address
`sv1qqpjsrc60t60jhaywj5krmwla52ska70twc7wun6qnee65guxhvtxegpqwhuxypra4jn3pq86s24ryltcw6g2ss4573hyqac9u4g23m9mvxpyqqqwny49k`

### Testing Results
- Tested by sending basecoin/CT/RingCT from one testnet wallet to CT/RingCT of another testnet wallet, where the received amount showed up first as "Hidden" and once the wallet was unlocked, it showed the correct amount.
- Tested unlocking of the wallet while the transactions are still unconfirmed.
- Tested restarting the wallet between transaction arrival and unlocking of the wallet (state consistency across wallet restarts).

Fixes #922, #668