### PR TITLE
Bugfix: race condition of two threads using same RandomX VM

### DIFF
--- a/src/pow.h
+++ b/src/pow.h
@@ -23,6 +23,7 @@ class CReserveScript;
 
 extern std::vector<randomx_vm*> vecRandomXVM;
 extern bool fKeyBlockedChanged;
+extern class CCriticalSection cs_randomx_validator;
 
 arith_uint256 GetPowLimit(int nPoWType);
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&,


### PR DESCRIPTION
Race condition between https://github.com/Veil-Project/veil/blob/4107c99a2029a07f89ad0b1e0f68c03ec55b7350/src/pow.cpp#L462 and https://github.com/Veil-Project/veil/blob/4107c99a2029a07f89ad0b1e0f68c03ec55b7350/src/chain.cpp#L304
which use the same RandomX VM but the first one correctly acquires the lock `cs_randomx_validator` before, while the second doesn't acquire the lock.

This bug caused the daemon / wallet to randomly crash.