### PR TITLE
[Chain] Eliminate unnecessary overhead testing for stale block indexes.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2061,5 +2061,10 @@ bool AppInitMain()
         InitRandomXLightCache(chainActive.Height());
     }
 
+    // Check for stale block indexes every five minutes
+    scheduler.scheduleEvery([]{
+        PruneStaleBlockIndexes();
+    }, DEFAULT_INDEXCHECK_INTERVAL * 1000);
+
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3633,6 +3633,9 @@ void PruneStaleBlockIndexes()
     // This isn't going to change while we're processing, so just leave and try again later.
     if (!pindexBestHeader) return;
 
+    // This won't change during InitialBlockDownload either.
+    if (IsInitialBlockDownload()) return;
+
     uint32_t irrelevantIndexes = 0;
     int64_t lowestPrunedHeight = -1;
     int64_t currentHeight;
@@ -3834,8 +3837,6 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
     if (!FlushStateToDisk(chainparams, state, FlushStateMode::PERIODIC)) {
         return false;
     }
-
-    PruneStaleBlockIndexes();
 
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -111,6 +111,8 @@ static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 6;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 6;
+/** Time to wait (in seconds) between checking for stale block indexes. */
+static const unsigned int DEFAULT_INDEXCHECK_INTERVAL = 60 * 5;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 /** Block download timeout base, expressed in millionths of the block interval (i.e. 10 min) */
@@ -535,6 +537,8 @@ int GetSpendHeight(const CCoinsViewCache& inputs);
 static bool isPowTimeStampActive() { return (chainActive.Tip()->nTime >= nPowTimeStampActive); }
 
 extern VersionBitsCache versionbitscache;
+
+void PruneStaleBlockIndexes();
 
 /**
  * Determine what nVersion a new block should use.


### PR DESCRIPTION
Stale block indexes will only occur if the chaintip gets thrashed around aggressively, or during extended periods of minting; never during InitialBlockDownload and even then this only needs to be checked periodically.

Performance increase during block synchronization is very noticeable once applied.