### PR TITLE
Update build-factory.yml

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: source
     steps:
@@ -40,7 +40,7 @@ jobs:
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: x86_64-linux-binaries
       TEST_LOG_ARTIFACT_DIR: test-logs
@@ -79,7 +79,7 @@ jobs:
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: win64-binaries
     steps:
@@ -121,7 +121,7 @@ jobs:
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: macosx-binaries
     steps:
@@ -168,7 +168,7 @@ jobs:
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: aarch64-linux-binaries
     steps:
@@ -207,7 +207,7 @@ jobs:
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: arm32-binaries
     steps:
@@ -246,7 +246,7 @@ jobs:
   build-i686-linux32:
     name: Build for x86 Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: i686-linux32-binaries
     steps:


### PR DESCRIPTION
Was having problems finding any action runners to start the workflow and came across this https://github.com/actions/runner-images/issues/6002. So I updated to the the oldest usable image 20.04. When finished I noticed that x86 Linux 32 bit failed. I assume there is no support after 18.04. Everything else is working fine. 