### PR TITLE
Issue # 943 automintoff by default

### DIFF
--- a/src/qt/veil/forms/settingsminting.ui
+++ b/src/qt/veil/forms/settingsminting.ui
@@ -271,8 +271,8 @@ border:0;
 font-size:18px;</string>
               </property>
               <property name="text">
-               <string>Automint is now OFF. This only effects AUTOMINTING. 
-You can still mint to right side-> or with the debug console</string>
+               <string>AUTOMINTING is now OFF. 
+You can still mint with the debug console or to the right-></string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>

--- a/src/qt/veil/forms/settingsminting.ui
+++ b/src/qt/veil/forms/settingsminting.ui
@@ -271,8 +271,8 @@ border:0;
 font-size:18px;</string>
               </property>
               <property name="text">
-               <string>Select a Zerocoin denomination
-to have automatically minted by automint</string>
+               <string>Automint is now OFF. This only effects AUTOMINTING. 
+You can still mint to right side-> or with the debug console</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
@@ -292,8 +292,8 @@ to have automatically minted by automint</string>
 font-size:14px;</string>
               </property>
               <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Every 5 minutes the wallet will try to 
-&lt;br&gt;mint new zerocoins of the selected denom&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;To manually mint with debug console:
+&lt;br&gt;Settings Tab>Advanced Options>Console Tab> mintzerocoin (denom)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4944,7 +4944,7 @@ std::vector<std::string> CWallet::GetDestValues(const std::string& prefix) const
 // CWallet::AutoZeromint() gets called with each new incoming block
 void CWallet::AutoZeromint()
 {
-    if (gArgs.GetBoolArg("-automintoff", false)) {
+    if (gArgs.GetBoolArg("-automintoff", true)) {
         return;
     }
 


### PR DESCRIPTION
This fix should have `automint` turned off by default. I have tested on mac with no issues. All the other wallet functionally seem to work with automint disabled. I have also changed the automint page to reflect the change and to help the user understand that they can still mint to the right of the page like always. As well as from the debug console. 