### PR TITLE
Issue#976 dumpwallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -692,7 +692,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "dumpwallet \"filename\"\n"
-            "\nNote: Dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n
+            "\nNote: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n"
             "Dumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\n"
             "Imported scripts are included in the dumpfile, but corresponding BIP173 addresses, etc. may not be added automatically by importwallet.\n"
             "Note that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by\n"

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -645,10 +645,10 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-            "dumpprivkey \"address\"\n"
-            "\nNote: dumprivkey does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n" 
+            "dumpprivkey \"address\"\n" 
             "\nReveals the private key corresponding to 'address'.\n"
             "Then the importprivkey can be used with this output\n"
+            "\nNote: dumpprivkey does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n" 
             "\nArguments:\n"
             "1. \"address\"   (string, required) The veil address for the private key\n"
             "\nResult:\n"
@@ -701,7 +701,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"filename\" : {        (string) The filename with full absolute path\n"
-            "} Note: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n"
+            "}\n"
             "\nExamples:\n"
             + HelpExampleCli("dumpwallet", "\"test\"")
             + HelpExampleRpc("dumpwallet", "\"test\"")
@@ -750,6 +750,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     file << strprintf("# * Created on %s\n", FormatISO8601DateTime(GetTime()));
     file << strprintf("# * Best block at time of backup was %i (%s),\n", chainActive.Height(), chainActive.Tip()->GetBlockHash().ToString());
     file << strprintf("#   mined on %s\n", FormatISO8601DateTime(chainActive.Tip()->GetBlockTime()));
+    file << "# Note: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n";
     file << "\n";
 
     // add the base58check encoded extended master if the wallet uses HD

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -646,7 +646,9 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "dumpprivkey \"address\"\n"
-            "\nReveals the private key corresponding to 'address'.\n"
+            "\nNote: dumprivkey does not include private keys for stealth addresses.\n" 
+             "Use wallet.dat file or seed words for complete backup.\n" 
+             "Reveals the private key corresponding to 'address'.\n"
             "Then the importprivkey can be used with this output\n"
             "\nArguments:\n"
             "1. \"address\"   (string, required) The veil address for the private key\n"
@@ -690,7 +692,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "dumpwallet \"filename\"\n"
-            "\nDumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\n"
+            "\nNote: Dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n
+            "Dumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\n"
             "Imported scripts are included in the dumpfile, but corresponding BIP173 addresses, etc. may not be added automatically by importwallet.\n"
             "Note that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by\n"
             "only backing up the seed itself, and must be backed up too (e.g. ensure you back up the whole dumpfile).\n"

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -646,9 +646,8 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "dumpprivkey \"address\"\n"
-            "\nNote: dumprivkey does not include private keys for stealth addresses.\n" 
-             "Use wallet.dat file or seed words for complete backup.\n" 
-             "Reveals the private key corresponding to 'address'.\n"
+            "\nNote: dumprivkey does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n" 
+            "\nReveals the private key corresponding to 'address'.\n"
             "Then the importprivkey can be used with this output\n"
             "\nArguments:\n"
             "1. \"address\"   (string, required) The veil address for the private key\n"
@@ -691,18 +690,18 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-            "dumpwallet \"filename\"\n"
-            "\nNote: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n"
-            "Dumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\n"
+            "dumpwallet \"filename\"\n" 
+            "\nDumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\n"
             "Imported scripts are included in the dumpfile, but corresponding BIP173 addresses, etc. may not be added automatically by importwallet.\n"
             "Note that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by\n"
             "only backing up the seed itself, and must be backed up too (e.g. ensure you back up the whole dumpfile).\n"
+            "\nNote: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n"
             "\nArguments:\n"
             "1. \"filename\"    (string, required) The filename with path (either absolute or relative to veild)\n"
             "\nResult:\n"
             "{                           (json object)\n"
             "  \"filename\" : {        (string) The filename with full absolute path\n"
-            "}\n"
+            "} Note: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.\n"
             "\nExamples:\n"
             + HelpExampleCli("dumpwallet", "\"test\"")
             + HelpExampleRpc("dumpwallet", "\"test\"")


### PR DESCRIPTION
This PR leaves the note ```Note: dumpwallet does not include private keys for stealth addresses. Use wallet.dat file or seed words for complete backup.``` in the `help dumpprivkey` and `help dumpwallet` as well as the dumped `.dat` file. 

![dumpwallet](https://user-images.githubusercontent.com/46406370/235829110-51990f95-f730-4051-8da2-10ea04a2bfb1.png)
![dumpprivkey](https://user-images.githubusercontent.com/46406370/235829119-c81affd6-7000-48a5-9ca7-20c79b557b1a.png)
![wallet dat](https://user-images.githubusercontent.com/46406370/235829126-32b66cc3-22dc-4f25-a317-2c569c932d16.png)

If this fulfills what the bounty requires:
sv1qqpy56fkfmkffp44q8tjx6scldglaf5qqkwsv3lzd440z9vh6d8y9hcpqts3u7xpwt92gxsyr0n42c228n6j5cczzvrget8hhzyfrq7qydv05qqqr7s9z5