### PR TITLE
Batch Zerocoin Database Write to Improve Sync Speed

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -823,6 +823,6 @@ bool CZerocoinDB::WriteBlockZerocoinData(
              (unsigned int)countMints,
              (unsigned int)countPubcoinSpends);
 
-    return WriteBatch(batch, true);
+    return WriteBatch(batch, false);
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -823,6 +823,6 @@ bool CZerocoinDB::WriteBlockZerocoinData(
              (unsigned int)countMints,
              (unsigned int)countPubcoinSpends);
 
-    return WriteBatch(batch, false);
+    return WriteBatch(batch, true);
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -155,6 +155,14 @@ public:
     bool EraseBlacklisterPubcoin(const uint256& hashPubcoin);
     bool LoadBlacklistOutPoints();
     bool LoadBlacklistPubcoins();
+
+    // Write all Zerocoin data for a block in a single batch
+    bool WriteBlockZerocoinData(
+        const std::map<libzerocoin::CoinSpend, uint256>& spendInfo,
+        const std::map<libzerocoin::PublicCoin, uint256>& mintInfo,
+        const std::map<uint256, uint256>& mapPubcoinSpends,
+        const uint256& hashBlock,
+        bool fWritePubcoinSpends);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2908,15 +2908,17 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     pindex->nAnonOutputs = view.nLastRCTOutput;
 
     // Record zerocoin serials
-    std::set<uint256> setAddedTx;
+    //std::set<uint256> setAddedTx;
 
-    // Flush spend/mint info to disk
-    if (!pzerocoinDB->WriteCoinSpendBatch(mapSpends)) return state.Error(("Failed to record coin serials to database"));
-    if (!pzerocoinDB->WriteCoinMintBatch(mapMints)) return state.Error(("Failed to record new mints to database"));
-    if (pindex->nHeight >= Params().HeightLightZerocoin()) {
-        if (!pzerocoinDB->WritePubcoinSpendBatch(mapSpentPubcoinsInBlock, pindex->GetBlockHash()) )
-            return state.Error(("Failed to record new pubcoinspends to database"));
-    }
+    bool fWritePubcoinSpends = (pindex->nHeight >= Params().HeightLightZerocoin());
+	if (!pzerocoinDB->WriteBlockZerocoinData(
+	        mapSpends,
+	        mapMints,
+	        mapSpentPubcoinsInBlock,
+	        pindex->GetBlockHash(),
+	        fWritePubcoinSpends)) {
+	    return state.Error("Failed to record zerocoin data to database");
+	}
 
     int64_t nTime6 = GetTimeMicros(); nTimeDatabaseZerocoin += nTime6 - nTime5;
     LogPrint(BCLog::BENCH, "    - Writing zerocoin to database : %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime6 - nTime5), nTimeDatabaseZerocoin * MICRO, nTimeDatabaseZerocoin * MILLI / nBlocksTotal);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2907,9 +2907,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     pindex->nAnonOutputs = view.nLastRCTOutput;
 
-    // Record zerocoin serials
-    //std::set<uint256> setAddedTx;
-
+	// Batch-write all Zerocoin data (spends, mints, pubcoin spends) in a single DB operation.
     bool fWritePubcoinSpends = (pindex->nHeight >= Params().HeightLightZerocoin());
 	if (!pzerocoinDB->WriteBlockZerocoinData(
 	        mapSpends,


### PR DESCRIPTION
This change improves sync performance by replacing multiple separate LevelDB writes for Zerocoin data with a single batched write. Previously, ConnectBlock() wrote spends, mints, and pubcoin spends individually, causing excessive disk I/O and slower block validation. The new function `WriteBlockZerocoinData()` combines these into one operation.

Key Points:
- Reduces LevelDB write overhead
- Enhances sync speed without configuration changes
- Improves performance on both older and modern hardware
- No consensus compatibility changes