### PR TITLE
[Fix / Upgrade] PoS Staking tx inclusion, watchonly upgrades, new stealthkey rpc

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -167,6 +167,14 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
+    // Add dummy coinstake tx as second transaction for PoS blocks
+    // This reserves position 1 so addPackageTxs doesn't put mempool txs there
+    if (fProofOfStake) {
+        pblock->vtx.emplace_back();
+        pblocktemplate->vTxFees.push_back(-1);
+        pblocktemplate->vTxSigOpsCost.push_back(-1);
+    }
+
     CMutableTransaction txCoinStake;
     CBlockIndex* pindexPrev;
     //Do not pass in the chain tip, because it can change. Instead pass the blockindex directly from mapblockindex, which is const.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -227,6 +227,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importlightwalletaddress", 2, "created_height"},
     { "importlightwalletaddress", 4, "num_prefix_bits"},
     { "importlightwalletaddress", 6, "bech32"},
+    { "importstealthkeys", 2, "rescan"},
     { "getanonoutputs", 0, "inputsize"},
     { "getanonoutputs", 1, "ringsize"},
     { "getkeyimages", 0, "txdata"},
@@ -237,9 +238,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnewaddress", 4, "makeV2"},
     { "getwatchonlytxes", 1, "starting_index"},
     { "getwatchonlytxes", 2, "batch_size"},
-
-
-
 };
 
 class CRPCConvertTable

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -2356,7 +2356,7 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
         return result;
     }
 
-    if (scannedToHeight >= scanFromHeight) {
+    if (scannedToHeight >= heightWhenImported) {
         result.pushKV("status", "synced");
         result.pushKV("stealth_address", sxAddr.ToString(fBech32));
 
@@ -2370,6 +2370,17 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
 
     result.pushKV("status", "scanning");
     result.pushKV("stealth_address", sxAddr.ToString(fBech32));
+    result.pushKV("scanned_to_height", scannedToHeight);
+    result.pushKV("scan_from_height", scanFromHeight);
+    result.pushKV("imported_at_height", heightWhenImported);
+
+    // Calculate progress
+    if (heightWhenImported > scanFromHeight) {
+        int64_t totalBlocks = heightWhenImported - scanFromHeight;
+        int64_t scannedBlocks = scannedToHeight - scanFromHeight;
+        double percentComplete = (scannedBlocks * 100.0) / totalBlocks;
+        result.pushKV("percent_complete", percentComplete);
+    }
     return result;
 };
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -2485,6 +2485,13 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
 
         int current_count = 0;
         if (GetWatchOnlyKeyCount(sxAddr.scan_secret, current_count)) {
+            // Handle legacy bug: first tx may be at index 0 with count stored as 0
+            if (current_count == 0) {
+                CWatchOnlyTx checkTx;
+                if (ReadWatchOnlyTransaction(sxAddr.scan_secret, 0, checkTx)) {
+                    current_count = 1;
+                }
+            }
             result.pushKV("transactions_found", current_count);
         }
 

--- a/src/veil/ringct/watchonlydb.h
+++ b/src/veil/ringct/watchonlydb.h
@@ -75,6 +75,10 @@ public:
     /** V2 Methods - Hash-based keys (CKeyID) */
     bool WriteWatchOnlyAddressV2(const CKeyID& keyID, const CWatchOnlyAddress& data);
     bool ReadWatchOnlyAddressV2(const CKeyID& keyID, CWatchOnlyAddress& data);
+    bool EraseWatchOnlyAddressV2(const CKeyID& keyID);
+
+    /** Erase all data for a watch-only address (address, transactions, count, checkpoint) */
+    bool EraseWatchOnlyAddressData(const CKeyID& keyID, const CKey& scan_secret);
 
     /** Database version management */
     int GetDatabaseVersion();


### PR DESCRIPTION
This PR contains several fixes and improvements for watch-only address handling, stealth key management, and a critical PoS block creation bug.                                                 
                                                                                                                                                                                                  
  Bug Fixes                                                                                                                                                                                       
                                                                                                                                                                                                  
  Fix PoS blocks dropping first mempool transaction (7e90fcf)                                                                                                                                     
  - PoS blocks were silently dropping the first transaction from the mempool                                                                                                                      
  - The coinstake transaction was overwriting position 1 in the block's transaction list, where addPackageTxs() had already placed a mempool transaction                                          
  - Added a dummy coinstake placeholder to reserve position 1 before mempool transactions are added                                                                                               
  - This ensures all pending transactions are properly included in PoS blocks                                                                                                                     
                                                                                                                                                                                                  
  Fix watchonly status showing 0 transactions (1c4c6344)                                                                                                                                          
  - getwatchonlystatus was reporting 0 transactions even when transactions existed                                                                                                                
  - Legacy bug caused first transaction to be stored at index 0 with count also stored as 0                                                                                                       
  - Added check to detect transactions at index 0 when count is 0                                                                                                                                 
                                                                                                                                                                                                  
  Fix watchonly status and indexing (af9de02)                                                                                                                                                     
  - Fixed sync status check to compare against heightWhenImported instead of scanFromHeight                                                                                                       
  - Added progress information (scanned height, scan from height, imported height, percent complete)                                                                                              
  - Fixed getwatchonlytxes indexing to use proper 0-based user-facing API with 1-based database indexing                                                                                          
  - Added input validation for starting_index parameter                                                                                                                                           
                                                                                                                                                                                                  
  New Features                                                                                                                                                                                    
                                                                                                                                                                                                  
  Import stealth keys RPC and dump improvements (49affbf)                                                                                                                                         
  - Added importstealthkeys RPC to import stealth addresses with full private keys (scan + spend secrets)                                                                                         
  - Added stealth key support to dumpwallet RPC - now exports stealth address private keys                                                                                                        
  - Fixed metadata saving - ephemeral pubkeys are now always saved (needed to regenerate keys later)                                                                                              
  - Fixed several instances of RegenerateKey to use GetKey for proper key retrieval                                                                                                               
                                                                                                                                                                                                  
  Remove watchonly address improvements (c43a625)                                                                                                                                                 
  - Enhanced removewatchonlyaddress to accept stealth address string directly (in addition to scan_secret + spend_public)                                                                         
  - Now properly removes all associated transaction data from the database                                                                                                                        
  - Returns count of transactions removed                                                                                                                                                         
  - Added database method EraseWatchOnlyAddress for complete cleanup