### PR TITLE
Auto-convert basecoin and CT to RingCT

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -105,6 +105,7 @@ BITCOIN_TESTS =\
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \
+  wallet/test/autoconvert_tests.cpp \
   wallet/test/psbt_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \
   wallet/test/wallet_crypto_tests.cpp \

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -1278,6 +1278,28 @@ void AnonWallet::MarkInputsAsPendingSpend(const std::vector<COutPoint>& vin)
     }
 }
 
+void AnonWallet::UnwindPendingTransaction(const uint256& txid)
+{
+    LOCK(pwalletParent->cs_wallet);
+    auto mi = mapRecords.find(txid);
+    if (mi == mapRecords.end())
+        return;
+    for (const COutPoint& prevout : mi->second.vin) {
+        auto mit = mapRecords.find(prevout.hash);
+        if (mit == mapRecords.end())
+            continue;
+        COutputRecord* pout = mit->second.GetOutput(prevout.n);
+        if (!pout)
+            continue;
+        pout->MarkPendingSpend(false);
+        SaveRecord(prevout.hash, mit->second);
+    }
+    AnonWalletDB wdb(*walletDatabase);
+    wdb.EraseTxRecord(txid);
+    mapRecords.erase(mi);
+    LogPrintf("%s: removed unbroadcast transaction record %s\n", __func__, txid.ToString());
+}
+
 void AnonWallet::AddOutputRecordMetaData(CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend)
 {
     for (const auto &r : vecSend) {

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -215,6 +215,9 @@ public:
     void AddOutputRecordMetaData(CTransactionRecord &rtx, std::vector<CTempRecipient> &vecSend);
     bool ExpandTempRecipients(std::vector<CTempRecipient> &vecSend, std::string &sError);
     void MarkInputsAsPendingSpend(const std::vector<COutPoint>& rtxvin);
+    /** Remove the record of a transaction that was built but never accepted for
+     * broadcast, unmarking the pending spend state of its inputs. */
+    void UnwindPendingTransaction(const uint256& txid);
 
     bool AddCTData(CTxOutBase *txout, CTempRecipient &r, std::string &sError);
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -23,6 +23,8 @@
 void WalletInit::AddWalletOptions() const
 {
     gArgs.AddArg("-addresstype", strprintf("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")", FormatOutputType(DEFAULT_ADDRESS_TYPE)), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-autoconvert", strprintf("Automatically convert confirmed basecoin and CT balances in all loaded wallets to RingCT (default: %u). Each conversion is a normal transaction that pays the standard fee. Requires the wallet to be fully unlocked", DEFAULT_AUTOCONVERT), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-autoconvertthreshold=<amt>", strprintf("Minimum amount of eligible outputs required before an automatic conversion transaction is created (default: %s)", FormatMoney(DEFAULT_AUTOCONVERT_THRESHOLD)), false, OptionsCategory::WALLET);
     gArgs.AddArg("-avoidpartialspends", strprintf(_("Group outputs by address, selecting all or none, instead of selecting on a per-output basis. Privacy is improved as an address is only used once (unless someone sends to it after spending from it), but may result in slightly higher fees as suboptimal coin selection may result due to the added limitation (default: %u)"), DEFAULT_AVOIDPARTIALSPENDS), false, OptionsCategory::WALLET);
     gArgs.AddArg("-backupzerocoin", "Enable automatic backups of zerocoin", false, OptionsCategory::WALLET);
     gArgs.AddArg("-changetype", "What type of change to use (\"legacy\", \"p2sh-segwit\", or \"bech32\"). Default is same as -addresstype, except when -addresstype=p2sh-segwit a native segwit output is used when sending to a native segwit address)", false, OptionsCategory::WALLET);
@@ -247,6 +249,14 @@ void WalletInit::Start(CScheduler& scheduler) const
 
     // Run a thread to flush wallet periodically
     scheduler.scheduleEvery(MaybeCompactWalletDB, 500);
+
+    if (gArgs.GetBoolArg("-autoconvert", DEFAULT_AUTOCONVERT)) {
+        scheduler.scheduleEvery([]() {
+            for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
+                pwallet->AutoConvertToRingCT();
+            }
+        }, AUTOCONVERT_TIMER_INTERVAL_MS);
+    }
 }
 
 void WalletInit::Flush() const

--- a/src/wallet/test/autoconvert_tests.cpp
+++ b/src/wallet/test/autoconvert_tests.cpp
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Tests for the -autoconvert failure handling (wallet.cpp AutoConvertToRingCT):
+// a conversion transaction that is rejected by the mempool must leave no
+// trace in the wallet — no transaction record, no inputs stuck in the
+// pending-spend state, no balance change — and the backoff must delay the
+// next attempt. This is the one part of the feature that mainnet happy-path
+// testing cannot exercise.
+
+#include <test/test_veil.h>
+
+#include <consensus/validation.h>
+#include <policy/policy.h>
+#include <script/interpreter.h>
+#include <txdb.h>
+#include <txmempool.h>
+#include <util/time.h>
+#include <validation.h>
+#include <veil/ringct/anonwallet.h>
+#include <veil/ringct/blind.h>
+#include <veil/ringct/stealth.h>
+#include <veil/zerocoin/zwallet.h>
+#include <wallet/wallet.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+//! Depth the autoconvert selector requires (AUTOCONVERT_MIN_DEPTH in
+//! wallet.cpp) plus margin, on top of the CoinbaseMaturity() blocks the
+//! TestChain100Setup fixture already mined.
+constexpr int EXTRA_BLOCKS = 15;
+
+struct AutoConvertTestingSetup : public TestChain100Setup {
+    std::shared_ptr<CWallet> wallet;
+    AnonWallet* panonwallet{nullptr};
+    CScript coinbaseScript;
+
+    AutoConvertTestingSetup()
+    {
+        // The anon wallet needs the stealth and blinding secp256k1 contexts
+        // that AppInitMain normally starts; BasicTestingSetup only starts the
+        // base ECC context.
+        ECC_Start_Stealth();
+        ECC_Start_Blinding();
+
+        // ConnectBlock writes zerocoin accumulator checksums every ten blocks
+        // (first at height 20), so a chain extended past the fixture's default
+        // needs the zerocoin db that AppInitMain normally creates. In-memory,
+        // like the fixture's pblocktree/pcoinsdbview.
+        pzerocoinDB.reset(new CZerocoinDB(1 << 23, true /* fMemory */));
+
+        // Extend the chain so the early coinbases clear both coinbase
+        // maturity and the 12-confirmation floor the converter requires.
+        // These are X16RT proof-of-work blocks; after the PowUpdateTimestamp
+        // GetNextWorkRequired always returns the pow limit for them, so any
+        // number of blocks can be mined at constant difficulty.
+        coinbaseScript = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+        for (int i = 0; i < EXTRA_BLOCKS; i++) {
+            CBlock b = CreateAndProcessBlock({}, coinbaseScript);
+            m_coinbase_txns.push_back(b.vtx[0]);
+        }
+
+        // Wallet wired the same way CWallet::CreateWalletFromFile does it:
+        // HD seed first (the zerocoin and anon wallet master keys derive from
+        // it), then the zerocoin wallet, then the anon wallet on its own mock
+        // database.
+        wallet = std::make_shared<CWallet>("autoconvert-mock", WalletDatabase::CreateMock());
+        bool fFirstRun;
+        wallet->LoadWallet(fFirstRun);
+        wallet->SetHDSeed(wallet->GenerateNewSeed());
+
+        CzWallet* zwallet = new CzWallet(wallet.get());
+        wallet->setZWallet(zwallet);
+
+        std::shared_ptr<WalletDatabase> anonDatabase = WalletDatabase::CreateMock();
+        {
+            // Batches only create the backing (in-memory) db file when opened
+            // with 'c' in the mode; AnonWallet's own batches open "r+".
+            WalletBatch batch(*anonDatabase, "cr+");
+        }
+        panonwallet = new AnonWallet(wallet, "anonwallet", anonDatabase);
+        CExtKey extMasterAnon;
+        BOOST_REQUIRE(wallet->GetAnonWalletSeed(extMasterAnon));
+        BOOST_REQUIRE(panonwallet->Initialise(&extMasterAnon));
+        wallet->SetAnonWallet(panonwallet);
+        wallet->SetBroadcastTransactions(true);
+
+        // Hand the fixture's coinbase key to the wallet and pick up all the
+        // mined coinbases.
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        }
+        WalletRescanReserver reserver(wallet.get());
+        BOOST_REQUIRE(reserver.reserve());
+        wallet->ScanForWalletTransactions(chainActive.Genesis(), nullptr, reserver, true /* fUpdate */);
+    }
+
+    ~AutoConvertTestingSetup()
+    {
+        SetMockTime(0);
+        mempool.clear();
+        wallet->SetAnonWallet(nullptr);
+        delete panonwallet;
+        pzerocoinDB.reset();
+        ECC_Stop_Stealth();
+        ECC_Stop_Blinding();
+    }
+
+    //! Find the coinbase output paying the fixture's script (the miner
+    //! payment; Veil coinbases can carry additional budget outputs).
+    bool FindMinerOutput(const CTransactionRef& coinbase, int& nOut, CAmount& nValue) const
+    {
+        for (size_t i = 0; i < coinbase->vpout.size(); i++) {
+            const CTxOutBase* pout = coinbase->vpout[i].get();
+            if (!pout->IsStandardOutput())
+                continue;
+            if (*pout->GetPScriptPubKey() == coinbaseScript && pout->GetValue() > 0) {
+                nOut = (int)i;
+                nValue = pout->GetValue();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //! Build and sign a transaction spending a fixture coinbase directly with
+    //! the coinbase key, without going through the wallet. Submitted to the
+    //! mempool, it conflicts with any wallet transaction that later selects
+    //! the same coinbase — the wallet does not see foreign mempool spends, so
+    //! its next conversion attempt is guaranteed to fail mempool acceptance.
+    CMutableTransaction BuildForeignSpend(const CTransactionRef& coinbase) const
+    {
+        int nOut = -1;
+        CAmount nValue = 0;
+        BOOST_REQUIRE(FindMinerOutput(coinbase, nOut, nValue));
+
+        CMutableTransaction tx;
+        tx.nVersion = 1;
+        tx.vin.resize(1);
+        tx.vin[0].prevout = COutPoint(coinbase->GetHash(), nOut);
+
+        OUTPUT_PTR<CTxOutStandard> out = MAKE_OUTPUT<CTxOutStandard>();
+        out->nValue = nValue - CENT; // 0.01 VEIL fee
+        out->scriptPubKey = coinbaseScript;
+        tx.vpout.push_back(out);
+
+        std::vector<unsigned char> vchSig;
+        std::vector<uint8_t> vchAmount(8);
+        memcpy(vchAmount.data(), &nValue, 8);
+        uint256 hash = SignatureHash(coinbaseScript, tx, 0, SIGHASH_ALL, vchAmount, SigVersion::BASE);
+        BOOST_REQUIRE(coinbaseKey.Sign(hash, vchSig));
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        tx.vin[0].scriptSig << vchSig;
+        return tx;
+    }
+
+    size_t CountAvailableCoins() const
+    {
+        LOCK2(cs_main, wallet->cs_wallet);
+        std::vector<COutput> vCoins;
+        wallet->AvailableCoins(vCoins);
+        return vCoins.size();
+    }
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(autoconvert_tests, AutoConvertTestingSetup)
+
+// End-to-end: a mempool-rejected conversion unwinds completely, the failure
+// backoff delays the next attempt, and a later attempt converts for real.
+BOOST_AUTO_TEST_CASE(autoconvert_mempool_reject_unwinds)
+{
+    const size_t nRecordsBefore = panonwallet->mapRecords.size();
+    const size_t nWalletTxsBefore = wallet->mapWallet.size();
+    const size_t nCoinsBefore = CountAvailableCoins();
+    const CAmount nBalanceBefore = wallet->GetAvailableBalance();
+    BOOST_REQUIRE(nCoinsBefore > 0);
+    BOOST_REQUIRE(nBalanceBefore > 0);
+
+    // Occupy one of the wallet's mature coinbases in the mempool from the
+    // outside. The converter selects every eligible output (equal values,
+    // well under the 32-input cap), so its transaction must conflict.
+    CMutableTransaction foreignSpend = BuildForeignSpend(m_coinbase_txns[0]);
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        BOOST_REQUIRE_MESSAGE(
+            AcceptToMemoryPool(mempool, state, MakeTransactionRef(foreignSpend), nullptr, nullptr, false, 0),
+            "foreign conflict spend rejected: " + FormatStateMessage(state));
+    }
+    BOOST_REQUIRE_EQUAL(mempool.size(), 1U);
+
+    // First call after startup only arms the jittered timer (60..600s);
+    // advance mock time past the maximum jitter to reach the attempt.
+    const int64_t nStart = GetTime();
+    SetMockTime(nStart);
+    wallet->AutoConvertToRingCT();
+    SetMockTime(nStart + 700);
+    wallet->AutoConvertToRingCT();
+
+    // The build succeeded (record saved, inputs marked pending-spend), the
+    // mempool test-accept failed on the conflict, and the unwind must have
+    // erased every trace: no record, no wallet transaction, nothing in the
+    // mempool beyond the foreign spend, and the full balance spendable.
+    BOOST_CHECK_EQUAL(mempool.size(), 1U);
+    BOOST_CHECK_EQUAL(panonwallet->mapRecords.size(), nRecordsBefore);
+    BOOST_CHECK_EQUAL(wallet->mapWallet.size(), nWalletTxsBefore);
+    BOOST_CHECK_EQUAL(CountAvailableCoins(), nCoinsBefore);
+    BOOST_CHECK_EQUAL(wallet->GetAvailableBalance(), nBalanceBefore);
+
+    // Backoff — and proof the failure path really executed. A failed attempt
+    // schedules the next one exactly 10 minutes out (5min << 1), while a
+    // NOTHING_TO_CONVERT pass reschedules within at most 9 minutes. Probing
+    // in between (at +570s) with the conflict cleared discriminates the two:
+    // a genuine failure is still backed off (nothing converts), whereas an
+    // attempt that never really happened would convert right here and fail
+    // the mempool-empty check below.
+    mempool.clear();
+    SetMockTime(nStart + 700 + 570);
+    wallet->AutoConvertToRingCT();
+    BOOST_CHECK_EQUAL(mempool.size(), 0U);
+    BOOST_CHECK_EQUAL(panonwallet->mapRecords.size(), nRecordsBefore);
+
+    // Past the backoff window the conversion must go through: one
+    // transaction in the mempool, committed to the wallet, with the anon
+    // record keyed by the same txid, and basecoin balance reduced.
+    SetMockTime(nStart + 700 + 15 * 60);
+    wallet->AutoConvertToRingCT();
+
+    BOOST_REQUIRE_EQUAL(mempool.size(), 1U);
+    std::vector<uint256> vtxid;
+    mempool.queryHashes(vtxid);
+    const uint256& txidConversion = vtxid[0];
+
+    BOOST_CHECK_EQUAL(panonwallet->mapRecords.size(), nRecordsBefore + 1);
+    BOOST_CHECK(panonwallet->mapRecords.count(txidConversion));
+    BOOST_REQUIRE(wallet->mapWallet.count(txidConversion));
+    BOOST_CHECK(wallet->GetAvailableBalance() < nBalanceBefore);
+
+    // The conversion is a genuine batch (every mature coinbase selected, well
+    // over a handful of inputs) and its outputs are CT, not basecoin.
+    const CTransactionRef& txConversion = wallet->mapWallet.at(txidConversion).tx;
+    BOOST_CHECK(txConversion->vin.size() >= 10);
+    bool fHasCTOutput = false;
+    for (const auto& pout : txConversion->vpout) {
+        if (pout->GetType() == OUTPUT_CT)
+            fHasCTOutput = true;
+    }
+    BOOST_CHECK(fHasCTOutput);
+}
+
+// The do/undo symmetry of the wallet-state side effect itself:
+// MarkInputsAsPendingSpend + SaveRecord (what AddStandardInputs and
+// AddBlindedInputs do at build time) followed by UnwindPendingTransaction
+// must restore the source outputs exactly.
+BOOST_AUTO_TEST_CASE(unwind_restores_pending_spend)
+{
+    LOCK(wallet->cs_wallet);
+
+    const uint256 txidSource = InsecureRand256();
+    const uint256 txidSpend = InsecureRand256();
+
+    CTransactionRecord rtxSource;
+    COutputRecord rec;
+    rec.n = 0;
+    rec.nType = OUTPUT_CT;
+    rec.nFlags = ORF_OWNED;
+    rec.SetValue(5 * COIN);
+    rtxSource.InsertOutput(rec);
+    panonwallet->mapRecords[txidSource] = rtxSource;
+    BOOST_REQUIRE(panonwallet->SaveRecord(txidSource, rtxSource));
+
+    CTransactionRecord rtxSpend;
+    rtxSpend.vin.push_back(COutPoint(txidSource, 0));
+    panonwallet->mapRecords[txidSpend] = rtxSpend;
+    BOOST_REQUIRE(panonwallet->SaveRecord(txidSpend, rtxSpend));
+    panonwallet->MarkInputsAsPendingSpend(rtxSpend.vin);
+
+    // Build-time state: the source output is unusable.
+    {
+        const COutputRecord* pout = panonwallet->mapRecords.at(txidSource).GetOutput(0);
+        BOOST_REQUIRE(pout);
+        BOOST_CHECK(pout->nFlags & ORF_PENDING_SPEND);
+        BOOST_CHECK(pout->IsSpent(true /* fIncludePendingSpend */));
+    }
+
+    panonwallet->UnwindPendingTransaction(txidSpend);
+
+    // The failed spend's record is gone and the source output is spendable
+    // again, with no residual flags.
+    BOOST_CHECK_EQUAL(panonwallet->mapRecords.count(txidSpend), 0U);
+    {
+        const COutputRecord* pout = panonwallet->mapRecords.at(txidSource).GetOutput(0);
+        BOOST_REQUIRE(pout);
+        BOOST_CHECK(!(pout->nFlags & ORF_PENDING_SPEND));
+        BOOST_CHECK(!pout->IsSpent(true /* fIncludePendingSpend */));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <wallet/wallet.h>
+#include <veil/ringct/anon.h>
 #include <veil/ringct/anonwallet.h>
 #include <veil/budget.h>
 
@@ -4084,6 +4085,180 @@ bool CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
     return true;
 }
 
+// Tuning for -autoconvert.
+// Outputs need this many confirmations before they are converted, which keeps
+// conversions clear of short reorgs and decorrelates them from the block that
+// paid the wallet.
+static const int AUTOCONVERT_MIN_DEPTH = 12;
+// Cap the inputs per conversion so a sweep of a large wallet can never
+// approach the standard transaction size limits.
+static const size_t AUTOCONVERT_MAX_INPUTS = MAX_ANON_INPUTS;
+// Delay between conversion attempts: a minimum plus a random jitter so the
+// broadcasts do not fingerprint the wallet by trailing blocks or each other.
+static const int AUTOCONVERT_MIN_DELAY = 60;
+static const int AUTOCONVERT_JITTER = 9 * 60;
+// Exponential backoff applied after a failed conversion attempt.
+static const int64_t AUTOCONVERT_BACKOFF_BASE = 5 * 60;
+static const int64_t AUTOCONVERT_BACKOFF_MAX = 6 * 60 * 60;
+
+void CWallet::AutoConvertToRingCT()
+{
+    if (!pAnonWalletMain || !fBroadcastTransactions)
+        return;
+    if (IsInitialBlockDownload() || !HeadersAndBlocksSynced())
+        return;
+    // Requires a full unlock; AnonWallet::IsLocked also covers unlock-for-staking-only
+    if (pAnonWalletMain->IsLocked())
+        return;
+
+    int64_t nNow = GetTime();
+    if (m_autoconvert_not_before == 0) {
+        // First pass after startup: schedule with jitter instead of converting immediately
+        m_autoconvert_not_before = nNow + AUTOCONVERT_MIN_DELAY + GetRandInt(AUTOCONVERT_JITTER);
+        return;
+    }
+    if (nNow < m_autoconvert_not_before)
+        return;
+
+    // Lift matured CT outputs to RingCT first, then start new basecoin batches
+    AutoConvertResult result = AutoConvertBatch(/*fFromBasecoin*/false);
+    if (result == AutoConvertResult::NOTHING_TO_CONVERT)
+        result = AutoConvertBatch(/*fFromBasecoin*/true);
+
+    switch (result) {
+        case AutoConvertResult::NOTHING_TO_CONVERT:
+            // Randomize the next check so an output maturing past the depth
+            // floor is not converted at a predictable offset from its receipt
+            m_autoconvert_not_before = nNow + GetRandInt(AUTOCONVERT_JITTER);
+            break;
+        case AutoConvertResult::CONVERTED:
+            m_autoconvert_failures = 0;
+            m_autoconvert_not_before = nNow + AUTOCONVERT_MIN_DELAY + GetRandInt(AUTOCONVERT_JITTER);
+            break;
+        case AutoConvertResult::FAILED:
+            m_autoconvert_failures = std::min(m_autoconvert_failures + 1, 6);
+            m_autoconvert_not_before = nNow + std::min(AUTOCONVERT_BACKOFF_BASE << m_autoconvert_failures, AUTOCONVERT_BACKOFF_MAX);
+            LogPrintf("%s: %d consecutive failure(s), next attempt in %d seconds\n", __func__,
+                      m_autoconvert_failures, (int)(m_autoconvert_not_before - nNow));
+            break;
+    }
+}
+
+CWallet::AutoConvertResult CWallet::AutoConvertBatch(bool fFromBasecoin)
+{
+    CCoinControl coinControl;
+    coinControl.fAllowOtherInputs = false;
+
+    // Select up to AUTOCONVERT_MAX_INPUTS confirmed outputs, largest first, so
+    // the amount checked below is exactly the amount the transaction spends.
+    CAmount nTotal = 0;
+    {
+        LOCK2(cs_main, cs_wallet);
+        if (fFromBasecoin) {
+            std::vector<COutput> vCoins;
+            AvailableCoins(vCoins, true, nullptr, 1, MAX_MONEY, MAX_MONEY, 0, AUTOCONVERT_MIN_DEPTH);
+            std::sort(vCoins.begin(), vCoins.end(), [](const COutput& a, const COutput& b) {
+                return a.tx->tx->vpout[a.i]->GetValue() > b.tx->tx->vpout[b.i]->GetValue();
+            });
+            for (const COutput& out : vCoins) {
+                if (coinControl.setSelected.size() >= AUTOCONVERT_MAX_INPUTS)
+                    break;
+                if (!out.fSpendable)
+                    continue;
+                CAmount nValue = out.tx->tx->vpout[out.i]->GetValue();
+                coinControl.Select(COutPoint(out.tx->GetHash(), out.i), nValue);
+                nTotal += nValue;
+            }
+        } else {
+            std::vector<COutputR> vCoins;
+            pAnonWalletMain->AvailableBlindedCoins(vCoins, true, &coinControl, 1, MAX_MONEY, MAX_MONEY, 0, AUTOCONVERT_MIN_DEPTH);
+            auto recordValue = [](const COutputR& out) -> CAmount {
+                const COutputRecord* pout = out.rtx->second.GetOutput(out.i);
+                return pout ? pout->GetAmount() : 0;
+            };
+            std::sort(vCoins.begin(), vCoins.end(), [&recordValue](const COutputR& a, const COutputR& b) {
+                return recordValue(a) > recordValue(b);
+            });
+            for (const COutputR& out : vCoins) {
+                if (coinControl.setSelected.size() >= AUTOCONVERT_MAX_INPUTS)
+                    break;
+                if (!out.fSpendable)
+                    continue;
+                CAmount nValue = recordValue(out);
+                if (nValue <= 0)
+                    continue;
+                coinControl.Select(COutPoint(out.txhash, out.i), nValue);
+                nTotal += nValue;
+            }
+        }
+    }
+
+    if (coinControl.setSelected.empty() || nTotal < m_autoconvert_threshold)
+        return AutoConvertResult::NOTHING_TO_CONVERT;
+
+    std::vector<CTempRecipient> vecSend;
+    CTempRecipient r;
+    // Consensus only allows RingCT outputs when the inputs are CT or RingCT
+    // (bad-txns-ringct-output-no-anonin), so basecoin converts to CT here and
+    // a later cycle lifts the matured CT outputs to RingCT.
+    r.nType = fFromBasecoin ? OUTPUT_CT : OUTPUT_RINGCT;
+    r.SetAmount(nTotal);
+    r.fSubtractFeeFromAmount = true;
+    r.address = pAnonWalletMain->GetStealthChangeAddress();
+    vecSend.push_back(r);
+
+    CWalletTx wtx(this, nullptr);
+    CTransactionRecord rtx;
+    CAmount nFeeRet = 0;
+    std::string sError;
+    int nResult;
+    if (fFromBasecoin) {
+        nResult = pAnonWalletMain->AddStandardInputs(wtx, rtx, vecSend, true, nFeeRet, &coinControl, sError, false, 0);
+    } else {
+        nResult = pAnonWalletMain->AddBlindedInputs(wtx, rtx, vecSend, true, 0, nFeeRet, &coinControl, sError);
+    }
+    if (nResult != 0) {
+        // A failure after the transaction was fully built has already saved a
+        // record and marked its inputs as pending spend; undo that so the
+        // selected outputs remain spendable.
+        if (wtx.tx)
+            pAnonWalletMain->UnwindPendingTransaction(wtx.tx->GetHash());
+        LogPrintf("%s: %s conversion failed: %s\n", __func__, fFromBasecoin ? "basecoin->CT" : "CT->RingCT", sError);
+        return AutoConvertResult::FAILED;
+    }
+
+    const uint256 txid = wtx.tx->GetHash();
+
+    // Confirm the mempool would accept the transaction before committing it to
+    // the wallet, so a rejection cannot strand the inputs as spent.
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        if (!AcceptToMemoryPool(mempool, state, wtx.tx, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */,
+                                false /* bypass_limits */, maxTxFee, true /* test accept */)) {
+            pAnonWalletMain->UnwindPendingTransaction(txid);
+            LogPrintf("%s: %s conversion rejected by mempool: %s\n", __func__, fFromBasecoin ? "basecoin->CT" : "CT->RingCT",
+                      FormatStateMessage(state));
+            return AutoConvertResult::FAILED;
+        }
+    }
+
+    CValidationState state;
+    if (!CommitTransaction(wtx.tx, wtx.mapValue, wtx.vOrderForm, nullptr, g_connman.get(), state)) {
+        // CommitTransaction added the transaction to the wallet before the
+        // mempool rejected it; abandon it so its inputs become spendable again.
+        AbandonTransaction(txid);
+        pAnonWalletMain->UnwindPendingTransaction(txid);
+        LogPrintf("%s: %s conversion commit failed: %s\n", __func__, fFromBasecoin ? "basecoin->CT" : "CT->RingCT",
+                  FormatStateMessage(state));
+        return AutoConvertResult::FAILED;
+    }
+
+    LogPrintf("%s: %s: converted %d output(s) in tx %s, fee %s\n", __func__,
+              fFromBasecoin ? "basecoin->CT" : "CT->RingCT", (int)coinControl.setSelected.size(), txid.ToString(), FormatMoney(nFeeRet));
+    return AutoConvertResult::CONVERTED;
+}
+
 DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
 {
     LOCK2(cs_main, cs_wallet);
@@ -5361,6 +5536,15 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
                         _("This is the minimum transaction fee you pay on every transaction."));
         }
         walletInstance->m_min_fee = CFeeRate(n);
+    }
+
+    if (gArgs.IsArgSet("-autoconvertthreshold")) {
+        CAmount n = 0;
+        if (!ParseMoney(gArgs.GetArg("-autoconvertthreshold", ""), n) || 0 == n) {
+            InitError(AmountErrMsg("autoconvertthreshold", gArgs.GetArg("-autoconvertthreshold", "")));
+            return nullptr;
+        }
+        walletInstance->m_autoconvert_threshold = n;
     }
 
     walletInstance->m_allow_fallback_fee = Params().IsFallbackFeeEnabled();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -68,6 +68,12 @@ static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = false;
 //! Default for -avoidpartialspends
 static const bool DEFAULT_AVOIDPARTIALSPENDS = false;
+//! Default for -autoconvert
+static const bool DEFAULT_AUTOCONVERT = false;
+//! -autoconvertthreshold default
+static const CAmount DEFAULT_AUTOCONVERT_THRESHOLD = 10 * COIN;
+//! How often the -autoconvert scheduler task runs (milliseconds)
+static const int64_t AUTOCONVERT_TIMER_INTERVAL_MS = 60 * 1000;
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
@@ -697,6 +703,12 @@ protected:
     bool fUnlockForStakingOnly = false;
     bool fStakingEnabled = true;
 
+    //! -autoconvert state, only touched from the scheduler thread
+    enum class AutoConvertResult { NOTHING_TO_CONVERT, CONVERTED, FAILED };
+    AutoConvertResult AutoConvertBatch(bool fFromBasecoin);
+    int64_t m_autoconvert_not_before = 0;
+    int m_autoconvert_failures = 0;
+
     WalletBatch *encrypted_batch = nullptr;
 
     //! the current wallet version: clients below this version are not able to load the wallet
@@ -1073,6 +1085,9 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
+    /** Convert a batch of confirmed basecoin or CT outputs to RingCT. Runs from
+     * a scheduler task when -autoconvert is enabled. */
+    void AutoConvertToRingCT();
     CAmount GetBasecoinBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
     CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
     bool GetBalances(BalanceList& bal);
@@ -1135,6 +1150,7 @@ public:
     bool m_signal_rbf{DEFAULT_WALLET_RBF};
     bool m_allow_fallback_fee{true}; //<! will be defined via chainparams
     CFeeRate m_min_fee{DEFAULT_TRANSACTION_MINFEE}; //!< Override with -mintxfee
+    CAmount m_autoconvert_threshold{DEFAULT_AUTOCONVERT_THRESHOLD}; //!< Override with -autoconvertthreshold
     /**
      * If fee estimation does not have enough data to provide estimates, use this fee instead.
      * Has no effect if not using fee estimation


### PR DESCRIPTION

## Summary

Implements opt-in automatic conversion of basecoin and CT balances to RingCT, addressing #1033 and #1054.

**This is a substantially reworked version of the original PR** based on a deeper review of the wallet's transaction building internals. The conversion no longer runs inside `BlockConnected`. It now runs as a periodic wallet scheduler task with confirmation depth, batching, and failure handling safeguards, and the two conversion hops are staged instead of chained as unconfirmed transactions. `BlockConnected` is untouched by this PR.

## How it works

When `-autoconvert=1` is set, a wallet scheduler task runs every 60 seconds. For each loaded wallet it:

1. Selects up to 32 confirmed outputs (12+ confirmations), largest first. Matured CT outputs are lifted to RingCT first, otherwise a new basecoin batch is started
2. If the selected amount reaches the threshold (default 10 VEIL, configurable via `-autoconvertthreshold`), builds a single batched transaction for that hop
3. Tests acceptance against the mempool **before** committing to the wallet, so a rejection cannot strand inputs in a spent state
4. Commits and broadcasts only after the mempool test passes

### Why two hops

Consensus only permits RingCT outputs when the inputs are CT or RingCT (`bad-txns-ringct-output-no-anonin`, consensus/tx_verify.cpp), so basecoin cannot convert to RingCT in one transaction. Basecoin batches therefore convert to CT, and once those CT outputs reach 12 confirmations a later cycle lifts them to RingCT. Unlike the original design, the two hops are never chained while unconfirmed. Each stage only ever spends outputs with 12 or more confirmations.

## Failure handling

* `AddStandardInputs`/`AddBlindedInputs` persist a transaction record and mark inputs pending spend at build time. If anything fails after that point (build, mempool test, or commit), the new `AnonWallet::UnwindPendingTransaction` removes the record and clears the pending spend flags so the outputs remain spendable. Previously a failed broadcast could leave CT outputs invisible to the balance until a manual `rescanringctwallet`.
* A commit stage failure additionally abandons the wallet transaction so its basecoin inputs become spendable again.
* Consecutive failures back off exponentially (10 minutes doubling up to 6 hours) instead of retrying on every block.

## Privacy considerations

* Conversions are time based with random jitter (1 to 10 minutes between attempts), not block synchronous, so broadcasts do not deterministically trail the block that paid the wallet.
* The 12 confirmation floor keeps conversions clear of short reorgs and further decorrelates conversion time from receipt time.
* Known trade off: consolidation inherently links the converted inputs to each other on chain. The threshold and batch cap bound how often this happens, but users who need strict input isolation should not enable this option. Feedback on the default threshold is welcome.

## Configuration

Disabled by default (opt-in). In `veil.conf`:

```
autoconvert=1
autoconvertthreshold=10   # optional, amount in VEIL
```

Both options appear in `veild -help`.

## Safety gates

* Skips during initial block download and until headers and blocks are fully synced
* Skips when the wallet is locked or unlocked for staking only
* Skips when wallet broadcast is disabled (`-walletbroadcast=0`)
* Input count capped at 32 per transaction so sweeps of large wallets can never approach standard transaction size limits. Large balances convert over multiple cycles

## Testing status

⚠️ **Testing and review before merge.**

Done so far (macOS arm64, daemon build):

* Full end to end pipeline on regtest: 5500 VEIL across 110 coinbase outputs converted with `-autoconvertthreshold=5`. Four basecoin→CT batches (32/32/32/13 inputs, respecting the input cap) followed by the CT→RingCT lift after maturity. The entire balance arrived in RingCT with about 0.0073 in total fees and nothing stranded in any pool
* Failure path exercised live: a consensus rejected transaction was caught by the mempool test before touching the wallet, the record and pending spend unwind ran, and exponential backoff engaged
* Jittered scheduling observed between cycles (conversions at irregular multi minute intervals, not block locked)

Still to do:

* Longer testnet soak (real network fees, mempool pressure, reorgs)
* Encrypted wallet matrix: locked, staking only unlock, fully unlocked
* Restart between cycles with a conversion pending
* A repeatable regtest functional test for the conversion and unwind paths

## Closes

Veil-Project/veil#1033
Veil-Project/veil#1054
