### PR TITLE
CI: update GitHub Actions to v5/v6/v7 for native Node.js 24 support

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -46,7 +46,7 @@ jobs:
       TEST_LOG_ARTIFACT_DIR: test-logs
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -85,7 +85,7 @@ jobs:
       ARTIFACT_DIR: win64-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -128,7 +128,7 @@ jobs:
       ARTIFACT_DIR: macosx-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -195,7 +195,7 @@ jobs:
       ARTIFACT_DIR: aarch64-linux-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -235,7 +235,7 @@ jobs:
       ARTIFACT_DIR: arm32-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -275,7 +275,7 @@ jobs:
       ARTIFACT_DIR: i686-linux32-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -314,7 +314,7 @@ jobs:
       ARTIFACT_DIR: riscv64-linux-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v6.0.0
+      uses: actions/download-artifact@v7.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}

--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -13,7 +13,7 @@ jobs:
       ARTIFACT_DIR: source
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v5.0.0
     # Needs qt and protobuf to configure qt and include veil-qt.1 in distribution
     - name: Install Required Packages
       run: |
@@ -33,7 +33,7 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv depends.tar.gz veil-*.tar.gz $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -46,7 +46,7 @@ jobs:
       TEST_LOG_ARTIFACT_DIR: test-logs
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}

--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -73,7 +73,7 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -85,7 +85,7 @@ jobs:
       ARTIFACT_DIR: win64-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -116,7 +116,7 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe}
         mv $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -128,7 +128,7 @@ jobs:
       ARTIFACT_DIR: macosx-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -183,7 +183,7 @@ jobs:
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -195,7 +195,7 @@ jobs:
       ARTIFACT_DIR: aarch64-linux-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -223,7 +223,7 @@ jobs:
         # strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -235,7 +235,7 @@ jobs:
       ARTIFACT_DIR: arm32-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -263,7 +263,7 @@ jobs:
         # strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -275,7 +275,7 @@ jobs:
       ARTIFACT_DIR: i686-linux32-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -302,7 +302,7 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -314,7 +314,7 @@ jobs:
       ARTIFACT_DIR: riscv64-linux-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v6.0.0
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -342,7 +342,7 @@ jobs:
         # strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}

--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -13,7 +13,7 @@ jobs:
       ARTIFACT_DIR: source
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     # Needs qt and protobuf to configure qt and include veil-qt.1 in distribution
     - name: Install Required Packages
       run: |
@@ -33,7 +33,7 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv depends.tar.gz veil-*.tar.gz $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -46,7 +46,7 @@ jobs:
       TEST_LOG_ARTIFACT_DIR: test-logs
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -73,7 +73,7 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -85,7 +85,7 @@ jobs:
       ARTIFACT_DIR: win64-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -116,7 +116,7 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe}
         mv $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -128,7 +128,7 @@ jobs:
       ARTIFACT_DIR: macosx-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -183,7 +183,7 @@ jobs:
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -195,7 +195,7 @@ jobs:
       ARTIFACT_DIR: aarch64-linux-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -223,7 +223,7 @@ jobs:
         # strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -235,7 +235,7 @@ jobs:
       ARTIFACT_DIR: arm32-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -263,7 +263,7 @@ jobs:
         # strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -275,7 +275,7 @@ jobs:
       ARTIFACT_DIR: i686-linux32-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -302,7 +302,7 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -314,7 +314,7 @@ jobs:
       ARTIFACT_DIR: riscv64-linux-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.SOURCE_ARTIFACT }}
@@ -342,7 +342,7 @@ jobs:
         # strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}


### PR DESCRIPTION
## Summary

Resolves #1060 — Node.js 20 deprecation warnings in CI.

Earlier point-release bumps (`@v4.2.2`, `@v4.4.3`, `@v4.1.8`) only patched metadata but still defaulted to running on Node.js 20 internally. This PR bumps to the major versions that natively run on Node.js 24:

- `actions/checkout` → `v5.0.0`
- `actions/upload-artifact` → `v6.0.0`
- `actions/download-artifact` → `v7.0.0` (v6 had only preliminary Node 24 support and still defaulted to Node 20 — v7 is required for the warning to fully clear)

## Testing

All 8 CI jobs (source distribution + 7 platform builds) pass cleanly with zero Node.js 20 deprecation warnings.

## Closes

Veil-Project/veil#1060