### PR TITLE
Reject stealth and RingCT coinbase outputs after rollback height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -331,6 +331,7 @@ public:
                 { 706000, uint256S("0xf98ece86f185e15af9a9d6b554c54f36f0b8b19d11e5e98ffe3b7578a0c8e2f9")},
                 { 840000, uint256S("0x9b46be33e4a84456e7c4e4785bad8646cb7cf1b6192adfd4c2916e768254f621")},
                 { 1744442, uint256S("0xe464d7547e1a21fe2471ddc4a6da535e2e9011ed570ab687897c7b7c7d9ed83f")},
+                { 3890102, uint256S("0x5651c2cf36c6178512afe27340db440064020a2d7dae58d8513ee12aa45a7c90")},
             }
         };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -366,6 +366,7 @@ public:
         nHeightPoSStart = 1500;
         nKernelModulus = 100;
         nCoinbaseMaturity = 100;
+        nHeightRejectStealthOrRingCTCoinbase = 3890103;
         nProofOfFullNodeRounds = 4;
         nLastPOWBlock = 9816000; // Continue POW until supply creation ends
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
@@ -546,6 +547,7 @@ public:
         nHeightPoSStart = 100;
         nKernelModulus = 10;
         nCoinbaseMaturity = 10;
+        nHeightRejectStealthOrRingCTCoinbase = 0;
         nProofOfFullNodeRounds = 4;
         nLastPOWBlock = 9816000; // Continue POW until supply creation ends
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
@@ -718,6 +720,7 @@ public:
         nHeightPoSStart = 100;
         nKernelModulus = 10;
         nCoinbaseMaturity = 10;
+        nHeightRejectStealthOrRingCTCoinbase = 0;
         nProofOfFullNodeRounds = 4;
         nLastPOWBlock = 9816000; // Continue POW until supply creation ends
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time
@@ -871,6 +874,7 @@ public:
         nHeightPoSStart = 100;
         nKernelModulus = 10;
         nCoinbaseMaturity = 10;
+        nHeightRejectStealthOrRingCTCoinbase = 0;
         nProofOfFullNodeRounds = 4;
         nLastPOWBlock = 9816000; // Continue POW until supply creation ends
         nHeightSupplyCreationStop = 9816000; //Should create very close to 300m coins at this time

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -137,6 +137,7 @@ public:
     int HeightPoSStart() const { return nHeightPoSStart; }
     int KernelModulus() const { return nKernelModulus; }
     int CoinbaseMaturity() const { return nCoinbaseMaturity; }
+    int HeightRejectStealthOrRingCTCoinbase() const { return nHeightRejectStealthOrRingCTCoinbase; }
     int HeightSupplyCreationStop() const { return nHeightSupplyCreationStop; }
     int ProofOfFullNodeRounds() const {return nProofOfFullNodeRounds; }
     int EnforceWeightReductionTime() const { return nTimeEnforceWeightReduction; }
@@ -226,6 +227,7 @@ protected:
     int nKernelModulus;
     int nLastPOWBlock;
     int nCoinbaseMaturity;
+    int nHeightRejectStealthOrRingCTCoinbase;
     int nProofOfFullNodeRounds;
     int nHeightSupplyCreationStop;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2475,6 +2475,11 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (tx.IsCoinBase() && !tx.HasBlindedValues()) {
             nTxValueOut += tx.GetValueOut();
         } else if (tx.IsCoinBase()) {
+            if (pindex->nHeight >= Params().HeightRejectStealthOrRingCTCoinbase()) {
+                return state.DoS(100, error("ConnectBlock(): coinbase contains stealth or RingCT outputs\n"),
+                                 REJECT_INVALID, "bad-cb-stealth-ringct");
+            }
+
             // Check tx with blinded values
             for (auto& pout : tx.vpout) {
                 // Check non-blind txouts


### PR DESCRIPTION
Veil's code had a critical vulnerability that allowed malformed coinbase blocks to be accepted starting at height 3890103. These blocks contained stealth outputs in the coinbase transaction, which should never have been accepted by consensus.

The network stall happened between block 3890306 and 3890307 from 2026-06-28 07:42:30 UTC to 2026-06-28 17:35:08 UTC (according to my personal node), due to an attempt to spend those outputs to basecoin. The mempool accepted the transactions, but block validation saw a supply increase and rejected the block template. Nodes with poisoned mempools could not produce valid blocks.

Last clean block:

`3890102`
`5651c2cf36c6178512afe27340db440064020a2d7dae58d8513ee12aa45a7c90`

Existing synced nodes will still need to invalidate the first bad block or reindex/reorg onto the corrected chain:

```
invalidateblock 913780c878021677e2c5fc471016c8db5e1acf5e705ed48c413525bff85009fc
clearmempool
```