### PR TITLE
[RPC] Fix key image byte stride in RingCT transaction JSON output

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -353,7 +353,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vecto
 
                 UniValue arrKeyImages(UniValue::VARR);
                 for (unsigned int k = 0; k < nSigInputs; k++) {
-                    const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*nSigInputs]);
+                    const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
                     UniValue objKeyImage(UniValue::VOBJ);
                     objKeyImage.pushKV(std::to_string(k), HexStr(ki));
                     arrKeyImages.push_back(objKeyImage);


### PR DESCRIPTION
### Problem
`getrawtransaction`, `decoderawtransaction` and `getblock` report wrong data in `key_images` for any RingCT transaction spending more than one input: `key_images[1..n-1]` come out as empty strings or garbage.

Real example: mainnet tx `c979e3d94c4edda66c63b50073e05feafe4a22b23d5b5c9d5d77b0125e58f41e` (`num_inputs=2`, `ring_size=11`), current master:

```json
"key_images": [ {"0": "0366d5a557fd204070656610fd4d225759d305cb9b5c506c25f61037f6e69f9807"},
                {"1": ""} ]
```

with this fix:

```json
"key_images": [ {"0": "0366d5a557fd204070656610fd4d225759d305cb9b5c506c25f61037f6e69f9807"},
                {"1": "022be2c06166626010582588ce7aa97674e28469eaeda58155a03cf764a2555a4d"} ]
```

which matches bytes 33..66 of the key image blob in the raw transaction.

### Root Cause
`TxToUniv` indexes the serialized key-image blob with `k*nSigInputs` instead of `k*33` (a `CCmpPubKey` is 33 bytes). The misaligned first byte usually fails `CCmpPubKey`'s length detection, so the value serializes as an empty string. Every other reader of this blob in the codebase strides by 33: `consensus/tx_verify.cpp`, `txmempool.cpp`, `validation.cpp` (×3), `veil/ringct/anon.cpp`, `veil/ringct/anonwallet.cpp` (×6).

### Solution
One line: stride by 33.

### Testing Results
- Verified against mainnet: for a multi-input RingCT transaction, every `key_images[j]` equals bytes `[j*33, (j+1)*33)` of `scriptData.stack[0]`, located directly in the raw transaction bytes (compact-size stack framing checked as well).
- Full unit suite compared against clean master on the same machine: identical results, no regressions.

### Relationship to #688
#688 rewrote this whole serialization block (with the correct 33-byte stride) as part of a larger breaking RPC overhaul, and stalled in 2020 over the compatibility question. This PR extracts just the bugfix, with no format change, so it can land independently of that discussion.


Companion PR building on this: #1069.