### PR TITLE
[RPC] Report ring member pubkeys and value commitments in RingCT inputs; fix getblock ring listing

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -6,6 +6,7 @@
 #define BITCOIN_CORE_IO_H
 
 #include <amount.h>
+#include <uint256.h>
 
 #include <string>
 #include <vector>
@@ -22,6 +23,18 @@ class CTxOutBase;
 class CTxOutRingCT;
 class CTxOutCT;
 class CAnonOutput;
+
+/** A ring member referenced by a RingCT input, resolved from the global
+ *  RingCT output index. Real spends and decoys are indistinguishable. */
+struct RingCtInputMember
+{
+    uint32_t nInput = 0;                  //!< which real input's ring this member belongs to (0-based)
+    int64_t nRingCtIndex = 0;             //!< global RingCT output index
+    uint256 txhash;                       //!< transaction the member output was created in
+    uint32_t n = 0;                       //!< output position within that transaction
+    std::vector<uint8_t> vchPubkey;       //!< 33-byte one-time output pubkey
+    std::vector<uint8_t> vchCommitment;   //!< 33-byte Pedersen value commitment
+};
 
 // core_read.cpp
 CScript ParseScript(const std::string& s);
@@ -40,7 +53,7 @@ std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vector<std::vector<COutPoint>>& vTxRingCtInputs, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vector<std::vector<RingCtInputMember>>& vTxRingCtInputs, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
 
 void OutputToJSON(const uint256 &txid, const int& i,const CTxOutBase *baseOut, UniValue &entry, bool isCoinBase = false);
 void RingCTOutputToJSON(const uint256& txid, const int& i, const int64_t& ringctIndex, const CTxOutRingCT& ringctOut, UniValue &entry);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -353,7 +353,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vecto
 
                 UniValue arrKeyImages(UniValue::VARR);
                 for (unsigned int k = 0; k < nSigInputs; k++) {
-                    const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*nSigInputs]);
+                    const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
                     UniValue objKeyImage(UniValue::VOBJ);
                     objKeyImage.pushKV(std::to_string(k), HexStr(ki));
                     arrKeyImages.push_back(objKeyImage);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -313,7 +313,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
     out.pushKV("addresses", a);
 }
 
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vector<std::vector<COutPoint>>& vTxRingCtInputs, UniValue& entry, bool include_hex, int serialize_flags)
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vector<std::vector<RingCtInputMember>>& vTxRingCtInputs, UniValue& entry, bool include_hex, int serialize_flags)
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("hash", tx.GetWitnessHash().GetHex());
@@ -338,27 +338,32 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, const std::vecto
 
             //Add ring ct inputs
             if (vTxRingCtInputs.size() > i) {
-                std::vector<COutPoint> vRingCtInputs = vTxRingCtInputs[i];
+                const std::vector<RingCtInputMember>& vRingCtInputs = vTxRingCtInputs[i];
                 UniValue arrRing(UniValue::VARR);
-                for (const COutPoint& outpoint : vRingCtInputs) {
+                for (const RingCtInputMember& member : vRingCtInputs) {
                     UniValue obj(UniValue::VOBJ);
-                    obj.pushKV("txid", outpoint.hash.GetHex());
-                    obj.pushKV("vout.n", (uint64_t) outpoint.n);
+                    obj.pushKV("txid", member.txhash.GetHex());
+                    obj.pushKV("vout.n", (uint64_t) member.n);
+                    obj.pushKV("input", (int) member.nInput);
+                    obj.pushKV("ringctindex", member.nRingCtIndex);
+                    obj.pushKV("pubkey", HexStr(member.vchPubkey));
+                    obj.pushKV("commitment", HexStr(member.vchCommitment));
                     arrRing.push_back(obj);
                 }
                 in.pushKV("ringct_inputs", arrRing);
-                const std::vector<uint8_t> vKeyImages = txin.scriptData.stack[0];
-                uint32_t nInputs, nRingSize;
-                txin.GetAnonInfo(nInputs, nRingSize);
-
-                UniValue arrKeyImages(UniValue::VARR);
-                for (unsigned int k = 0; k < nSigInputs; k++) {
-                    const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
-                    UniValue objKeyImage(UniValue::VOBJ);
-                    objKeyImage.pushKV(std::to_string(k), HexStr(ki));
-                    arrKeyImages.push_back(objKeyImage);
+                if (txin.scriptData.stack.size() == 1) {
+                    const std::vector<uint8_t>& vKeyImages = txin.scriptData.stack[0];
+                    if (vKeyImages.size() == nSigInputs * 33) {
+                        UniValue arrKeyImages(UniValue::VARR);
+                        for (unsigned int k = 0; k < nSigInputs; k++) {
+                            const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
+                            UniValue objKeyImage(UniValue::VOBJ);
+                            objKeyImage.pushKV(std::to_string(k), HexStr(ki));
+                            arrKeyImages.push_back(objKeyImage);
+                        }
+                        in.pushKV("key_images", arrKeyImages);
+                    }
                 }
-                in.pushKV("key_images", arrKeyImages);
             }
         } else {
             in.pushKV("txid", txin.prevout.hash.GetHex());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -185,8 +185,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         if(txDetails)
         {
             UniValue objTx(UniValue::VOBJ);
-            std::vector<std::vector<COutPoint> > vInputs;
-            GetRingCtInputs(tx->vin[0], vInputs);
+            std::vector<std::vector<RingCtInputMember>> vInputs = GetTxRingCtInputMembers(tx);
             TxToUniv(*tx, uint256(), vInputs, objTx, true, RPCSerializationFlags());
             txs.push_back(objTx);
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -41,7 +41,7 @@
 #include <univalue.h>
 
 
-static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry, const std::vector<std::vector<COutPoint>>& vTxRingCtInputs)
+static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry, const std::vector<std::vector<RingCtInputMember>>& vTxRingCtInputs)
 {
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.
     //
@@ -199,7 +199,7 @@ static UniValue getrawtransaction(const JSONRPCRequest& request)
     }
 
     //Get ringct inputs
-    std::vector<std::vector<COutPoint> > vTxRingCtInputs = GetTxRingCtInputs(tx);
+    std::vector<std::vector<RingCtInputMember>> vTxRingCtInputs = GetTxRingCtInputMembers(tx);
     UniValue result(UniValue::VOBJ);
     if (blockindex) result.pushKV("in_active_chain", in_active_chain);
     TxToJSON(*tx, hash_block, result, vTxRingCtInputs);

--- a/src/veil/ringct/anon.cpp
+++ b/src/veil/ringct/anon.cpp
@@ -396,6 +396,63 @@ bool GetRingCtInputs(const CTxIn& txin, std::vector<std::vector<COutPoint> >& vI
     return true;
 }
 
+std::vector<std::vector<RingCtInputMember>> GetTxRingCtInputMembers(const CTransactionRef ptx)
+{
+    std::vector<std::vector<RingCtInputMember>> vTxRingCtInputs;
+    for (const CTxIn& txin : ptx->vin) {
+        if (txin.IsAnonInput()) {
+            std::vector<RingCtInputMember> vMembers = GetRingCtInputMembers(txin);
+            vTxRingCtInputs.emplace_back(vMembers);
+        }
+    }
+    return vTxRingCtInputs;
+}
+
+std::vector<RingCtInputMember> GetRingCtInputMembers(const CTxIn& txin)
+{
+    std::vector<RingCtInputMember> vMembers;
+    uint32_t nInputs, nRingSize;
+    txin.GetAnonInfo(nInputs, nRingSize);
+
+    if (txin.scriptData.stack.size() != 1)
+        return vMembers;
+
+    if (txin.scriptWitness.stack.size() != 2)
+        return vMembers;
+
+    const std::vector<uint8_t>& vKeyImages = txin.scriptData.stack[0];
+    const std::vector<uint8_t>& vMI = txin.scriptWitness.stack[0];
+
+    if (vKeyImages.size() != nInputs * 33)
+        return vMembers;
+
+    size_t ofs = 0, nB = 0;
+    for (size_t k = 0; k < nInputs; ++k) {
+        for (size_t i = 0; i < nRingSize; ++i) {
+            int64_t nIndex = 0;
+
+            if (0 != GetVarInt(vMI, ofs, (uint64_t&) nIndex, nB))
+                return vMembers;
+            ofs += nB;
+
+            CAnonOutput ao;
+            if (!pblocktree->ReadRCTOutput(nIndex, ao)) {
+                continue;
+            }
+
+            RingCtInputMember member;
+            member.nInput = k;
+            member.nRingCtIndex = nIndex;
+            member.txhash = ao.outpoint.hash;
+            member.n = ao.outpoint.n;
+            member.vchPubkey.assign(ao.pubkey.begin(), ao.pubkey.end());
+            member.vchCommitment.assign(&ao.commitment.data[0], &ao.commitment.data[0] + 33);
+            vMembers.emplace_back(member);
+        }
+    }
+    return vMembers;
+}
+
 //bool RewindToCheckpoint(int nCheckPointHeight, int &nBlocks, std::string &sError)
 //{
 //    LogPrintf("%s: At height %d\n", __func__, nCheckPointHeight);

--- a/src/veil/ringct/anon.h
+++ b/src/veil/ringct/anon.h
@@ -4,6 +4,7 @@
 #ifndef VEIL_ANON_H
 #define VEIL_ANON_H
 
+#include <core_io.h>
 #include <inttypes.h>
 #include <primitives/transaction.h>
 
@@ -32,6 +33,8 @@ bool RewindToCheckpoint(int nCheckPointHeight, int &nBlocks, std::string &sError
 std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin);
 bool GetRingCtInputs(const CTxIn& txin, std::vector<std::vector<COutPoint> >& vInputs);
 std::vector<std::vector<COutPoint>> GetTxRingCtInputs(const CTransactionRef ptx);
+std::vector<RingCtInputMember> GetRingCtInputMembers(const CTxIn& txin);
+std::vector<std::vector<RingCtInputMember>> GetTxRingCtInputMembers(const CTransactionRef ptx);
 
 
 #endif //VEIL_ANON_H


### PR DESCRIPTION
### Problem
External software, explorers, auditors, light protocols (the goal #688 pursued with "Veil Link”): cannot reconstruct the MLSAG ring matrix from RPC: `ringct_inputs` lists only `txid`/`vout.n` of ring members, even though the node already reads the full member records from the RCT index to produce that list.

Separately, `getblock` verbosity 2 shows only the **first** real input's ring members on multi-input RingCT spends.

### Relationship to #688, and why this approach instead
#688 (2019, @mimirmim) set out to expose RingCT internals over RPC for external tooling. It was approved four times, but stalled in 2020 over one issue: it **changed the existing RPC output format**, which pushed it behind a v2.0.0 milestone that never shipped. Meanwhile, master independently gained basic key-image and ring-outpoint reporting in 2021, superseding much of its diff; the branch is now ~650 commits behind with conflicts in every core file it touches.

Rather than rebase a six-year-old branch over code that reimplemented half of it, this PR (stacked on #1068) ports the still-missing substance of #688 **additively**, no existing field changes name, shape, or meaning, so it does not require the compatibility break that stalled the original.

**Kept from #688:**
- per-ring-member data sufficient to rebuild the MLSAG ring matrix externally: `pubkey`, `commitment`, the global `ringctindex`, and `input` (which real input's ring the member belongs to);
- the correct 33-byte key-image stride (split out as the standalone bugfix #1068).

**Deliberately not ported:**
- `commitment_sig`: #688 labeled 32-byte slices of the MLSAG scalar vector (`scriptWitness.stack[1]`) as a "commitment signature". Those bytes are the ring signature's scalars, not a commitment signature; publishing them under that name would mislead integrators. The full signature remains available in the raw hex.
- The breaking changes: restructured/grouped `ringct_inputs`, the `data_hex` → `ephemeral_pubkey` rename, and removal of the `gettransaction` debug section. Those deserve their own compatibility discussion and can build on top of this PR if wanted.

Together with #1068, this lands the remaining useful content of #688, which can then be closed.

### What changed
- New `RingCtInputMember` struct (`core_io.h`) and `GetTxRingCtInputMembers`/`GetRingCtInputMembers` helpers (`veil/ringct/anon.cpp`). The three existing `GetRingCtInputs` variants are untouched — they have consensus-path callers in `validation.cpp`.
- Each `ringct_inputs` entry gains `input`, `ringctindex`, `pubkey`, `commitment`; naming follows the existing `AnonOutputToJSON`. Existing fields are unchanged.
- `blockToJSON` previously fed `TxToUniv` per-real-input groups from `vin[0]` (via the grouped `GetRingCtInputs` overload) where per-vin lists are expected, dropping every ring beyond input 0 in `getblock` verbosity 2. It now uses the same per-vin helper as `getrawtransaction`.
- The `key_images` block in `TxToUniv` gets the same stack/size guards used in `veil/ringct/anon.cpp`, so malformed hex fed to `decoderawtransaction` cannot index past the key image blob.

Example output (mainnet, abbreviated):

```json
"ringct_inputs": [
  { "txid": "…", "vout.n": 3, "input": 0, "ringctindex": 1873204,
    "pubkey": "03…", "commitment": "02…" },
  …
]
```

### Testing Results
- Real mainnet data (offline node with txindex): for a 1-input and a 2-input RingCT transaction, all 33 ring members verified: member count = `num_inputs × ring_size`, k-major grouping, `pubkey`/`commitment` byte-identical to the referenced output's actual `pubkey`/`valueCommitment` fetched independently through txindex, and `ringctindex` distinct within the transaction (consensus rule).
- `getblock` verbosity 2 invariants checked across a 300-block mainnet scan: zero failures.
- 481-variant corruption fuzz of `veil-tx -json` decoding: zero crashes or hangs (parity with master).
- Full unit suite compared against clean master on the same machine: identical results, no regressions.

Draft until #1068 merges (this branch contains its commit); will rebase and mark ready then.
