### PR TITLE
PoS tx inclusion, watch-only upgrades and stealth import, #1053 rebased onto master with fixes and tests

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -62,6 +62,8 @@ BITCOIN_TESTS =\
   test/multisig_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/pos_placeholder_tests.cpp \
+  test/watchonly_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -167,6 +167,14 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
+    // Add dummy coinstake tx as second transaction for PoS blocks
+    // This reserves position 1 so addPackageTxs doesn't put mempool txs there
+    if (fProofOfStake) {
+        pblock->vtx.emplace_back();
+        pblocktemplate->vTxFees.push_back(-1);
+        pblocktemplate->vTxSigOpsCost.push_back(-1);
+    }
+
     CMutableTransaction txCoinStake;
     CBlockIndex* pindexPrev;
     //Do not pass in the chain tip, because it can change. Instead pass the blockindex directly from mapblockindex, which is const.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -167,14 +167,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
-    // Add dummy coinstake tx as second transaction for PoS blocks
-    // This reserves position 1 so addPackageTxs doesn't put mempool txs there
-    if (fProofOfStake) {
-        pblock->vtx.emplace_back();
-        pblocktemplate->vTxFees.push_back(-1);
-        pblocktemplate->vTxSigOpsCost.push_back(-1);
-    }
-
     CMutableTransaction txCoinStake;
     CBlockIndex* pindexPrev;
     //Do not pass in the chain tip, because it can change. Instead pass the blockindex directly from mapblockindex, which is const.
@@ -200,6 +192,17 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             return nullptr;
         }
 #endif
+    }
+
+    // Add dummy coinstake tx as second transaction for PoS blocks
+    // This reserves position 1 so addPackageTxs doesn't put mempool txs there.
+    // Note: must be added after the coinstake creation above — while vtx[1] holds
+    // a null placeholder, CBlock::IsProofOfStake()/PowType() dereference vtx[1]
+    // when vtx.size() > 1 (pblock->PowType() is called for GetNextWorkRequired).
+    if (fProofOfStake) {
+        pblock->vtx.emplace_back();
+        pblocktemplate->vTxFees.push_back(-1);
+        pblocktemplate->vTxSigOpsCost.push_back(-1);
     }
 
     LOCK(cs_main);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -336,7 +336,10 @@ public:
     // two types of block: proof-of-work or proof-of-stake
     bool IsProofOfStake() const
     {
-        return (vtx.size() > 1 && vtx[1]->IsCoinStake());
+        // vtx[1] may be a null placeholder while a PoS block template is being
+        // assembled (see BlockAssembler::CreateNewBlock), so it must be checked
+        // before dereferencing.
+        return (vtx.size() > 1 && vtx[1] && vtx[1]->IsCoinStake());
     }
 
     bool IsProofOfWork() const

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -227,6 +227,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importlightwalletaddress", 2, "created_height"},
     { "importlightwalletaddress", 4, "num_prefix_bits"},
     { "importlightwalletaddress", 6, "bech32"},
+    { "importstealthkeys", 2, "rescan"},
     { "getanonoutputs", 0, "inputsize"},
     { "getanonoutputs", 1, "ringsize"},
     { "getkeyimages", 0, "txdata"},
@@ -237,9 +238,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnewaddress", 4, "makeV2"},
     { "getwatchonlytxes", 1, "starting_index"},
     { "getwatchonlytxes", 2, "batch_size"},
-
-
-
 };
 
 class CRPCConvertTable

--- a/src/test/pos_placeholder_tests.cpp
+++ b/src/test/pos_placeholder_tests.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Regression tests for the PoS block-template placeholder crash: while a
+// proof-of-stake template is being assembled, vtx[1] holds a null
+// CTransactionRef (see BlockAssembler::CreateNewBlock), and
+// CBlock::IsProofOfStake() is reached transitively through PowType() /
+// IsProofOfWork() before the real coinstake is assigned. Without the null
+// check these dereference a null shared_ptr and crash the staking thread.
+
+#include <test/test_veil.h>
+
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(pos_placeholder_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(null_coinstake_placeholder_is_not_pos)
+{
+    CBlock block;
+
+    // Empty block and single-entry block: the size check alone protects.
+    BOOST_CHECK(!block.IsProofOfStake());
+    block.vtx.emplace_back(); // null coinbase slot
+    BOOST_CHECK(!block.IsProofOfStake());
+
+    // The template-assembly state: two entries, vtx[1] a null placeholder.
+    // Before the fix this dereferenced null instead of returning false.
+    block.vtx.emplace_back();
+    BOOST_REQUIRE_EQUAL(block.vtx.size(), 2U);
+    BOOST_REQUIRE(!block.vtx[1]);
+    BOOST_CHECK(!block.IsProofOfStake());
+    BOOST_CHECK(block.IsProofOfWork());
+
+    // The call chain that actually crashed in CreateNewBlock: PowType()
+    // reaches IsProofOfStake() through the Is*() classifiers.
+    (void)block.PowType();
+    BOOST_CHECK(!block.IsProgPow());
+    BOOST_CHECK(!block.IsRandomX());
+    BOOST_CHECK(!block.IsSha256D());
+
+    // A real (non-coinstake) transaction in slot 1 is still not a coinstake.
+    CMutableTransaction mtx;
+    mtx.nVersion = 1;
+    mtx.vin.resize(1);
+    block.vtx[1] = MakeTransactionRef(std::move(mtx));
+    BOOST_CHECK(!block.IsProofOfStake());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/watchonly_tests.cpp
+++ b/src/test/watchonly_tests.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Tests for the watch-only transaction index layout and erasure.
+//
+// Historically the non-cached write path stored a fresh key's first
+// transaction at index 0 with the stored count not including it (the count
+// only covers indices 1..count), permanently under-counting, while the
+// cached/bulk path was 1-based. The fixes make fresh writes 1-based and make
+// erasure probe index 0 so legacy layouts are swept completely and the
+// removed-count is truthful.
+
+#include <test/test_veil.h>
+
+#include <key.h>
+#include <veil/ringct/watchonly.h>
+#include <veil/ringct/watchonlydb.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+struct WatchOnlyTestingSetup : public BasicTestingSetup {
+    WatchOnlyTestingSetup()
+    {
+        pwatchonlyDB.reset(new CWatchOnlyDB(1 << 20, true /* fMemory */));
+    }
+    ~WatchOnlyTestingSetup()
+    {
+        pwatchonlyDB.reset();
+    }
+
+    static CKey NewScanKey()
+    {
+        CKey key;
+        key.MakeNewKey(true);
+        return key;
+    }
+
+    static CWatchOnlyTx MakeTx(const CKey& scan_secret)
+    {
+        CWatchOnlyTx tx(scan_secret, InsecureRand256());
+        tx.type = CWatchOnlyTx::STEALTH; // serializes the (default) ctout
+        tx.tx_index = 0;
+        return tx;
+    }
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(watchonly_tests, WatchOnlyTestingSetup)
+
+// A fresh key's first transaction must land at index 1 with count 1 — the
+// same 1-based layout the cached/bulk path uses — and nothing at index 0.
+BOOST_AUTO_TEST_CASE(fresh_key_writes_one_based)
+{
+    const CKey key = NewScanKey();
+
+    int nCount = 0;
+    BOOST_REQUIRE(!GetWatchOnlyKeyCount(key, nCount));
+
+    const CWatchOnlyTx tx1 = MakeTx(key);
+    BOOST_REQUIRE(AddWatchOnlyTransaction(key, tx1));
+
+    BOOST_REQUIRE(GetWatchOnlyKeyCount(key, nCount));
+    BOOST_CHECK_EQUAL(nCount, 1);
+
+    CWatchOnlyTx txRead;
+    BOOST_CHECK(ReadWatchOnlyTransaction(key, 1, txRead));
+    BOOST_CHECK(txRead.tx_hash == tx1.tx_hash);
+
+    // The pre-fix path wrote the first transaction at index 0; nothing may
+    // live there now.
+    BOOST_CHECK(!ReadWatchOnlyTransaction(key, 0, txRead));
+
+    // Appending stays contiguous and the count stays truthful.
+    const CWatchOnlyTx tx2 = MakeTx(key);
+    BOOST_REQUIRE(AddWatchOnlyTransaction(key, tx2));
+    BOOST_REQUIRE(GetWatchOnlyKeyCount(key, nCount));
+    BOOST_CHECK_EQUAL(nCount, 2);
+    BOOST_CHECK(ReadWatchOnlyTransaction(key, 2, txRead));
+    BOOST_CHECK(txRead.tx_hash == tx2.tx_hash);
+}
+
+// Erasure must sweep a legacy layout completely: first transaction at index
+// 0, count not including it. The probe loop covers 0..count and the removed
+// count reports what was actually erased.
+BOOST_AUTO_TEST_CASE(erase_sweeps_legacy_index0_layout)
+{
+    const CKey key = NewScanKey();
+    const CKeyID keyID = key.GetPubKey().GetID();
+
+    // Reproduce the legacy layout at the db layer exactly as the old write
+    // path created it: WriteWatchOnlyTx(key, -1, ...) stored the first tx at
+    // index 0 with count 0, the next at index 1 with count 1.
+    const CWatchOnlyTx txLegacy0 = MakeTx(key);
+    const CWatchOnlyTx txLegacy1 = MakeTx(key);
+    BOOST_REQUIRE(pwatchonlyDB->WriteWatchOnlyTx(key, -1, txLegacy0));
+    BOOST_REQUIRE(pwatchonlyDB->WriteWatchOnlyTx(key, 0, txLegacy1));
+
+    int nCount = 0;
+    BOOST_REQUIRE(GetWatchOnlyKeyCount(key, nCount));
+    BOOST_CHECK_EQUAL(nCount, 1); // legacy under-count: 2 txs on disk
+
+    CWatchOnlyTx txRead;
+    BOOST_REQUIRE(ReadWatchOnlyTransaction(key, 0, txRead));
+    BOOST_REQUIRE(ReadWatchOnlyTransaction(key, 1, txRead));
+
+    int nTxesRemoved = 0;
+    BOOST_REQUIRE(pwatchonlyDB->EraseWatchOnlyAddressData(keyID, key, nTxesRemoved));
+
+    // Both records gone — including the index-0 one the pre-fix loop
+    // (1..count) leaked forever — and the count reflects reality.
+    BOOST_CHECK_EQUAL(nTxesRemoved, 2);
+    BOOST_CHECK(!ReadWatchOnlyTransaction(key, 0, txRead));
+    BOOST_CHECK(!ReadWatchOnlyTransaction(key, 1, txRead));
+    BOOST_CHECK(!GetWatchOnlyKeyCount(key, nCount));
+}
+
+// Erasing a fixed-era (1-based) layout is exact as well.
+BOOST_AUTO_TEST_CASE(erase_one_based_layout)
+{
+    const CKey key = NewScanKey();
+    const CKeyID keyID = key.GetPubKey().GetID();
+
+    BOOST_REQUIRE(AddWatchOnlyTransaction(key, MakeTx(key)));
+    BOOST_REQUIRE(AddWatchOnlyTransaction(key, MakeTx(key)));
+    BOOST_REQUIRE(AddWatchOnlyTransaction(key, MakeTx(key)));
+
+    int nTxesRemoved = 0;
+    BOOST_REQUIRE(pwatchonlyDB->EraseWatchOnlyAddressData(keyID, key, nTxesRemoved));
+    BOOST_CHECK_EQUAL(nTxesRemoved, 3);
+
+    int nCount = 0;
+    BOOST_CHECK(!GetWatchOnlyKeyCount(key, nCount));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -2356,7 +2356,7 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
         return result;
     }
 
-    if (scannedToHeight >= scanFromHeight) {
+    if (scannedToHeight >= heightWhenImported) {
         result.pushKV("status", "synced");
         result.pushKV("stealth_address", sxAddr.ToString(fBech32));
 
@@ -2370,6 +2370,17 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
 
     result.pushKV("status", "scanning");
     result.pushKV("stealth_address", sxAddr.ToString(fBech32));
+    result.pushKV("scanned_to_height", scannedToHeight);
+    result.pushKV("scan_from_height", scanFromHeight);
+    result.pushKV("imported_at_height", heightWhenImported);
+
+    // Calculate progress
+    if (heightWhenImported > scanFromHeight) {
+        int64_t totalBlocks = heightWhenImported - scanFromHeight;
+        int64_t scannedBlocks = scannedToHeight - scanFromHeight;
+        double percentComplete = (scannedBlocks * 100.0) / totalBlocks;
+        result.pushKV("percent_complete", percentComplete);
+    }
     return result;
 };
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -2485,6 +2485,13 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
 
         int current_count = 0;
         if (GetWatchOnlyKeyCount(sxAddr.scan_secret, current_count)) {
+            // Handle legacy bug: first tx may be at index 0 with count stored as 0
+            if (current_count == 0) {
+                CWatchOnlyTx checkTx;
+                if (ReadWatchOnlyTransaction(sxAddr.scan_secret, 0, checkTx)) {
+                    current_count = 1;
+                }
+            }
             result.pushKV("transactions_found", current_count);
         }
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -2170,7 +2170,7 @@ static UniValue importstealthkeys(const JSONRPCRequest &request)
                 "\nArguments:\n"
                 "1. \"scan_secret\"      (string, required) Scan secret key in WIF or hex format\n"
                 "2. \"spend_secret\"     (string, required) Spend secret key in WIF or hex format\n"
-                "3. rescan               (boolean, optional, default=true) Rescan the wallet for transactions\n"
+                "3. rescan               (boolean, optional, default=true) Rescan the blockchain for transactions (may take several minutes)\n"
                 "4. \"label\"            (string, optional, default=\"\") Label for address in addressbook\n"
                 "\nResult:\n"
                 "{\n"
@@ -2273,11 +2273,18 @@ static UniValue importstealthkeys(const JSONRPCRequest &request)
     result.pushKV("result", "success");
     result.pushKV("stealth_address", sxAddr.ToString(true));
 
-    // Rescan if requested
+    // Rescan the chain if requested. AnonWallet::RescanWallet() only repairs
+    // records the wallet already knows about — a full chain rescan is required
+    // to discover historical transactions received by the imported keys
+    // (CWallet::AddToWalletIfInvolvingMe feeds the AnonWallet stealth
+    // processing during the rescan).
     if (fRescan) {
-        result.pushKV("rescan", "started");
-        LOCK2(cs_main, pwallet->cs_wallet);
-        anonwallet->RescanWallet();
+        WalletRescanReserver reserver(pwallet);
+        if (!reserver.reserve()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait, then rescan manually.");
+        }
+        pwallet->RescanFromTime(0 /* scan whole chain */, reserver, true /* update */);
+        result.pushKV("rescan", "completed");
     }
 
     return result;
@@ -2375,13 +2382,15 @@ static UniValue removewatchonlyaddress(const JSONRPCRequest &request)
     }
 
     // Remove address and all associated data
-    if (!RemoveWatchOnlyAddress(address, scan_secret, spend_public)) {
+    int nTxesRemoved = 0;
+    if (!RemoveWatchOnlyAddress(address, scan_secret, spend_public, nTxesRemoved)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Failed to remove watch-only address");
     }
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("result", "success");
     result.pushKV("address", address);
+    result.pushKV("transactions_removed", nTxesRemoved);
     return result;
 }
 
@@ -2485,12 +2494,13 @@ static UniValue getwatchonlystatus(const JSONRPCRequest &request)
 
         int current_count = 0;
         if (GetWatchOnlyKeyCount(sxAddr.scan_secret, current_count)) {
-            // Handle legacy bug: first tx may be at index 0 with count stored as 0
-            if (current_count == 0) {
-                CWatchOnlyTx checkTx;
-                if (ReadWatchOnlyTransaction(sxAddr.scan_secret, 0, checkTx)) {
-                    current_count = 1;
-                }
+            // Databases written through the non-cached path stored the first
+            // transaction at index 0 with the count not including it (the count
+            // only covers indices 1..count). Probe index 0 and include it so the
+            // reported total is correct for any count, not just count == 0.
+            CWatchOnlyTx checkTx;
+            if (ReadWatchOnlyTransaction(sxAddr.scan_secret, 0, checkTx)) {
+                current_count += 1;
             }
             result.pushKV("transactions_found", current_count);
         }

--- a/src/veil/ringct/watchonly.cpp
+++ b/src/veil/ringct/watchonly.cpp
@@ -723,8 +723,10 @@ bool AddWatchOnlyAddress(const std::string& address, const CKey& scan_secret, co
     return true;
 }
 
-bool RemoveWatchOnlyAddress(const std::string& address, const CKey& scan_secret, const CPubKey& spend_pubkey)
+bool RemoveWatchOnlyAddress(const std::string& address, const CKey& scan_secret, const CPubKey& spend_pubkey, int& nTxesRemoved)
 {
+    nTxesRemoved = 0;
+
     // Use CKeyID as the map key (V2)
     CKeyID keyID = scan_secret.GetPubKey().GetID();
 
@@ -755,7 +757,7 @@ bool RemoveWatchOnlyAddress(const std::string& address, const CKey& scan_secret,
     watchonlyTxCache.Flush(scan_secret);
 
     // Remove all data from database (address, transactions, count, checkpoint)
-    if (!pwatchonlyDB->EraseWatchOnlyAddressData(keyID, scan_secret)) {
+    if (!pwatchonlyDB->EraseWatchOnlyAddressData(keyID, scan_secret, nTxesRemoved)) {
         return error("%s: Failed to erase watch-only address data from database", __func__);
     }
 
@@ -825,9 +827,12 @@ bool AddWatchOnlyTransaction(const CKey& key, const CWatchOnlyTx& watchonlytx)
             // Key count exists
             return pwatchonlyDB->WriteWatchOnlyTx(key, current_count, watchonlytx);
         } else {
-            // Key count didn't exist.. do the same thing?
+            // Key count didn't exist: write the first transaction at index 1 so the
+            // non-cached path matches the 1-based indexing used by the cached path
+            // (WriteBulkWatchOnlyTx). Writing with -1 here stored the first tx at
+            // index 0 with the count also stored as 0, permanently under-counting.
             LogPrintf("%s: adding watchonly transaction to fresh count %d\n", __func__, current_count);
-            return pwatchonlyDB->WriteWatchOnlyTx(key, -1, watchonlytx);
+            return pwatchonlyDB->WriteWatchOnlyTx(key, 0, watchonlytx);
         }
     }
 }

--- a/src/veil/ringct/watchonly.h
+++ b/src/veil/ringct/watchonly.h
@@ -203,7 +203,7 @@ public:
 
 /** Watchonly address methods */
 bool AddWatchOnlyAddress(const std::string& address, const CKey& scan_secret, const CPubKey& spend_pubkey, const int64_t& nStart, const int64_t& nImported);
-bool RemoveWatchOnlyAddress(const std::string& address, const CKey& scan_secret, const CPubKey& spend_pubkey);
+bool RemoveWatchOnlyAddress(const std::string& address, const CKey& scan_secret, const CPubKey& spend_pubkey, int& nTxesRemoved);
 bool LoadWatchOnlyAddresses();
 bool FlushWatchOnlyAddresses();
 

--- a/src/veil/ringct/watchonlydb.cpp
+++ b/src/veil/ringct/watchonlydb.cpp
@@ -282,19 +282,28 @@ bool CWatchOnlyDB::EraseWatchOnlyAddressV2(const CKeyID& keyID)
     return WriteBatch(batch);
 }
 
-bool CWatchOnlyDB::EraseWatchOnlyAddressData(const CKeyID& keyID, const CKey& scan_secret)
+bool CWatchOnlyDB::EraseWatchOnlyAddressData(const CKeyID& keyID, const CKey& scan_secret, int& nTxesRemoved)
 {
     CDBBatch batch(*this);
+
+    nTxesRemoved = 0;
 
     // Get the transaction count for this key
     int txCount = 0;
     ReadKeyCount(scan_secret, txCount);
 
-    // Erase all transactions for this address
-    for (int i = 1; i <= txCount; i++) {
+    // Erase all transactions for this address. Index 0 must be included: the
+    // first transaction written through the non-cached path was historically
+    // stored at index 0 (with the count not including it), while the cached
+    // path is 1-based — probe 0..txCount and erase whatever exists.
+    for (int i = 0; i <= txCount; i++) {
+        CWatchOnlyTx probeTx;
+        if (Read(std::make_pair(DB_WATCHONLY_TXS, std::make_pair(scan_secret, i)), probeTx)) {
+            nTxesRemoved++;
+        }
         batch.Erase(std::make_pair(DB_WATCHONLY_TXS, std::make_pair(scan_secret, i)));
     }
-    LogPrint(BCLog::WATCHONLYDB, "Erasing %d transactions for watchonly address %s from db.\n", txCount, keyID.ToString());
+    LogPrint(BCLog::WATCHONLYDB, "Erasing %d transactions for watchonly address %s from db.\n", nTxesRemoved, keyID.ToString());
 
     // Erase the key count
     batch.Erase(std::make_pair(DB_WATCHONLY_KEY_COUNT, scan_secret));

--- a/src/veil/ringct/watchonlydb.h
+++ b/src/veil/ringct/watchonlydb.h
@@ -75,6 +75,10 @@ public:
     /** V2 Methods - Hash-based keys (CKeyID) */
     bool WriteWatchOnlyAddressV2(const CKeyID& keyID, const CWatchOnlyAddress& data);
     bool ReadWatchOnlyAddressV2(const CKeyID& keyID, CWatchOnlyAddress& data);
+    bool EraseWatchOnlyAddressV2(const CKeyID& keyID);
+
+    /** Erase all data for a watch-only address (address, transactions, count, checkpoint) */
+    bool EraseWatchOnlyAddressData(const CKeyID& keyID, const CKey& scan_secret);
 
     /** Database version management */
     int GetDatabaseVersion();

--- a/src/veil/ringct/watchonlydb.h
+++ b/src/veil/ringct/watchonlydb.h
@@ -77,8 +77,9 @@ public:
     bool ReadWatchOnlyAddressV2(const CKeyID& keyID, CWatchOnlyAddress& data);
     bool EraseWatchOnlyAddressV2(const CKeyID& keyID);
 
-    /** Erase all data for a watch-only address (address, transactions, count, checkpoint) */
-    bool EraseWatchOnlyAddressData(const CKeyID& keyID, const CKey& scan_secret);
+    /** Erase all data for a watch-only address (address, transactions, count, checkpoint).
+     *  nTxesRemoved is set to the number of transaction records actually erased. */
+    bool EraseWatchOnlyAddressData(const CKeyID& keyID, const CKey& scan_secret, int& nTxesRemoved);
 
     /** Database version management */
     int GetDatabaseVersion();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1268,14 +1268,16 @@ static UniValue getwatchonlytxes(const JSONRPCRequest& request)
         int dbStartIndex = nStartingIndex;  // Start at actual user index
         int dbEndIndex = dbStartIndex + nBatchSize - 1;
 
-        // Clamp to available range (total_count is the max 1-based index, but we also check 0)
-        if (dbEndIndex > total_count) {
-            dbEndIndex = total_count;
-        }
+        // The requested range [dbStartIndex, dbEndIndex] deliberately extends past
+        // total_count so that unflushed cached transactions (which occupy indices
+        // total_count+1 and up) can be returned in the same batch. Only the
+        // database loop below is clamped to total_count; clamping dbEndIndex
+        // itself would make the cached-transaction range check always fail.
+        int dbLoopEnd = std::min(dbEndIndex, total_count);
 
         // Fetch transactions from database
         // Try index 0 first (handles buggy writes), then 1-based indices
-        for (int i = dbStartIndex; i <= dbEndIndex; i++) {
+        for (int i = dbStartIndex; i <= dbLoopEnd; i++) {
             CWatchOnlyTx watchonlytx;
             if (ReadWatchOnlyTransaction(scan_secret, i, watchonlytx)) {
                 // Get transaction block information for confirmations and timestamp


### PR DESCRIPTION
This carries #1053 forward so it can merge. It is @blondfrogs' branch, rebased onto current master (post-1.4.3.0, includes #1062), plus the two fixes from blondfrogs#2 and a regression test suite. All of blondfrogs' commits are preserved with his authorship.

**From #1053 (blondfrogs):**
- Fix for PoS blocks silently dropping the first mempool transaction (present since Oct 2018 — every PoS block on mainnet has been affected)
- Watch-only status/indexing fixes and `importstealthkeys` support

**Added here:**
- Fix a null dereference when assembling PoS block templates: the dummy coinstake placeholder reserved `vtx[1]` before the coinstake ran, and `CBlock::PowType()` → `IsProofOfStake()` dereferences `vtx[1]` whenever `vtx.size() > 1`. Every PoS template assembly segfaulted once the wallet had a stakeable zerocoin. The placeholder now goes in after coinstake creation, and `IsProofOfStake()` null-checks `vtx[1]`.
- Fix watch-only indexing, erasure and removal count; `importstealthkeys` now rescans the chain so pre-import funds are found.
- `src/test/pos_placeholder_tests.cpp` and `src/test/watchonly_tests.cpp` lock both fixes against regression (these ran green on blondfrogs#2, CI 8/8).

**Testing:** deterministic regtest repro of the staking crash, 3-node regtest matrices for staking A/B, watch-only and stealth-import flows, live testnet validation on 2026-07-27 confirming staked blocks now include mempool transactions, and community testnet nodes currently running these fixes. @seanPhill additionally verified no crashes across Windows/Linux with these fixes (blondfrogs#2 thread).
