### PR TITLE
[RingCT][LightWallet] Fix decoy validation, ring reuse, ring size and watchonly key parsing

### DIFF
--- a/src/veil/ringct/lightwallet.cpp
+++ b/src/veil/ringct/lightwallet.cpp
@@ -278,13 +278,6 @@ bool BuildLightWalletRingCTTransaction(const std::vector<std::string>& args, con
         return false;
     }
 
-    // Check inputspersig
-    if (nInputsPerSig < 1 || (size_t)nInputsPerSig > MAX_ANON_INPUTS) {
-        LogPrintf("Num inputs per signature out of range.");
-        errorMsg = "Num inputs per signature out of range.";
-        return false;
-    }
-
     // Build the recipient data
     if (!BuildRecipientData(vecSend, errorMsg)) {
         LogPrintf("Failed - %s\n", errorMsg);

--- a/src/veil/ringct/lightwallet.cpp
+++ b/src/veil/ringct/lightwallet.cpp
@@ -1160,7 +1160,7 @@ bool GetAmountAndBlindForUnspentTx(std::vector<CWatchOnlyTx>& vTxes, const std::
 
 bool CheckAmounts(const CAmount& nValueOut, const std::vector<CWatchOnlyTx>& vSpendableTx)
 {
-    CAmount nSum;
+    CAmount nSum = 0;
     for (const auto& tx : vSpendableTx) {
         LogPrintf("Getting amounts from inputs: %d\n", tx.nAmount);
         nSum += tx.nAmount;

--- a/src/veil/ringct/lightwallet.cpp
+++ b/src/veil/ringct/lightwallet.cpp
@@ -13,6 +13,8 @@
 #include <veil/ringct/blind.h>
 #include <wallet/coincontrol.h>
 #include <veil/ringct/anonwallet.h>
+#include <veil/ringct/anon.h>
+#include <chainparams.h>
 #include <policy/policy.h>
 #include <core_io.h>
 
@@ -211,9 +213,10 @@ bool BuildLightWalletRingCTTransaction(const std::vector<std::string>& args, con
         return false;
     }
 
-    // Default ringsize is 11
-    int nRingSize = 5;
-    int nInputsPerSig = nRingSize;
+    // Aim for the network default ring size. The caller supplies the decoys, so this
+    // gets capped further down to whatever the supplied set can actually cover.
+    int nRingSize = Params().DefaultRingSize();
+    int nInputsPerSig = MAX_ANON_INPUTS;
 
     // Get change address - this is the same address we are sending from
     CStealthAddress sxAddr;
@@ -269,14 +272,14 @@ bool BuildLightWalletRingCTTransaction(const std::vector<std::string>& args, con
     }
 
     // Check ringsize
-    if (nRingSize < 3 || nRingSize > 32) {
+    if ((size_t)nRingSize < MIN_RINGSIZE || (size_t)nRingSize > MAX_RINGSIZE) {
         LogPrintf("Ring size out of range.");
         errorMsg = "Ring size out of range.";
         return false;
     }
 
     // Check inputspersig
-    if (nInputsPerSig < 1 || nInputsPerSig > 32) {
+    if (nInputsPerSig < 1 || (size_t)nInputsPerSig > MAX_ANON_INPUTS) {
         LogPrintf("Num inputs per signature out of range.");
         errorMsg = "Num inputs per signature out of range.";
         return false;
@@ -341,6 +344,26 @@ bool BuildLightWalletRingCTTransaction(const std::vector<std::string>& args, con
         return false;
     }
 
+    // The caller supplies the decoy set. Each input needs (nRingSize - 1) decoys, and
+    // consensus rejects a transaction that reuses a ring member anywhere in it, see
+    // VerifyMLSAG "bad-anonin-dup-i". Cap the ring at what the supplied set can cover so
+    // that older callers keep working and newer ones get a bigger ring for free.
+    const size_t nSelectedInputs = vSelectedTxes.size();
+    if (nSelectedInputs == 0) {
+        errorMsg = "No spendable inputs were selected";
+        return false;
+    }
+    const size_t nRingFromDummies = (vDummyOutputs.size() / nSelectedInputs) + 1;
+    if ((size_t)nRingSize > nRingFromDummies)
+        nRingSize = (int)nRingFromDummies;
+    if ((size_t)nRingSize > MAX_RINGSIZE)
+        nRingSize = (int)MAX_RINGSIZE;
+    if ((size_t)nRingSize < MIN_RINGSIZE) {
+        errorMsg = strprintf("Not enough decoy outputs supplied: got %u for %u inputs, need at least %u",
+                             vDummyOutputs.size(), nSelectedInputs, nSelectedInputs * (MIN_RINGSIZE - 1));
+        return false;
+    }
+
     int nRemainder = vSelectedTxes.size() % nInputsPerSig;
     int nTxRingSigs = vSelectedTxes.size() / nInputsPerSig + (nRemainder == 0 ? 0 : 1);
 
@@ -385,7 +408,10 @@ bool BuildLightWalletRingCTTransaction(const std::vector<std::string>& args, con
     }
 
     // Add in dummy outputs
-    LightWalletFillInDummyOutputs(txNew,vDummyOutputs,vSecretColumns,vMI);
+    if (!LightWalletFillInDummyOutputs(txNew, vDummyOutputs, vSecretColumns, vMI, errorMsg)) {
+        LogPrintf("Failed LightWalletFillInDummyOutputs - %s\n", errorMsg);
+        return false;
+    }
 
     // Get the amout of bytes
     nBytes = GetVirtualTransactionSize(txNew);
@@ -547,10 +573,6 @@ bool BuildLightWalletStealthTransaction(const std::vector<std::string>& args, co
         return false;
     }
 
-    // Default ringsize is 11
-    int nRingSize = 5;
-    int nInputsPerSig = nRingSize;
-
     // Get change address - this is the same address we are sending from
     CStealthAddress sxAddr;
     sxAddr.label = "";
@@ -602,20 +624,6 @@ bool BuildLightWalletStealthTransaction(const std::vector<std::string>& args, co
             errorMsg = "Transaction amounts must not be negative";
             return false;
         }
-    }
-
-    // Check ringsize
-    if (nRingSize < 3 || nRingSize > 32) {
-        LogPrintf("Ring size out of range.");
-        errorMsg = "Ring size out of range.";
-        return false;
-    }
-
-    // Check inputspersig
-    if (nInputsPerSig < 1 || nInputsPerSig > 32) {
-        LogPrintf("Num inputs per signature out of range.");
-        errorMsg = "Num inputs per signature out of range.";
-        return false;
     }
 
     // Build the recipient data
@@ -1506,8 +1514,13 @@ bool LightWalletAddRealOutputs(CMutableTransaction& txNew, std::vector<CWatchOnl
 }
 
 
-void LightWalletFillInDummyOutputs(CMutableTransaction& txNew, const std::vector<CLightWalletAnonOutputData>& vDummyOutputs, std::vector<size_t>& vSecretColumns, std::vector<std::vector<std::vector<int64_t>>>& vMI)
+bool LightWalletFillInDummyOutputs(CMutableTransaction& txNew, const std::vector<CLightWalletAnonOutputData>& vDummyOutputs, std::vector<size_t>& vSecretColumns, std::vector<std::vector<std::vector<int64_t>>>& vMI, std::string& errorMsg)
 {
+    // Each decoy is consumed once for the whole transaction. Consensus rejects a
+    // transaction that lists the same ring member twice even across separate
+    // signatures, see VerifyMLSAG "bad-anonin-dup-i", so this must not restart per input.
+    size_t nCurrentLocation = 0;
+
     // Fill in dummy signatures for fee calculation.
     for (size_t l = 0; l < txNew.vin.size(); ++l) {
         auto &txin = txNew.vin[l];
@@ -1516,14 +1529,19 @@ void LightWalletFillInDummyOutputs(CMutableTransaction& txNew, const std::vector
 
         // Place Hiding Outputs
         {
-            int nCurrentLocation = 0;
             for (size_t k = 0; k < vMI[l].size(); ++k) {
                 for (size_t i = 0; i < nSigRingSize; ++i) {
                     if (i == vSecretColumns[l]) {
                         continue;
                     }
 
-                    LogPrintf("looking at vector index :%d, setting index for dummy: %d\n",nCurrentLocation, vDummyOutputs[nCurrentLocation].index);
+                    // The decoy set comes from the caller, so never index past it.
+                    if (nCurrentLocation >= vDummyOutputs.size()) {
+                        errorMsg = strprintf("Not enough decoy outputs supplied: only %u available",
+                                             vDummyOutputs.size());
+                        return false;
+                    }
+
                     vMI[l][k][i] = vDummyOutputs[nCurrentLocation].index;
                     nCurrentLocation++;
                 }
@@ -1548,6 +1566,8 @@ void LightWalletFillInDummyOutputs(CMutableTransaction& txNew, const std::vector
                                                          : 0)); // extra commitment for split value if multiple sigs
         txin.scriptWitness.stack.emplace_back(vDL);
     }
+
+    return true;
 }
 
 

--- a/src/veil/ringct/lightwallet.h
+++ b/src/veil/ringct/lightwallet.h
@@ -51,7 +51,7 @@ bool LightWalletAddCTData(CMutableTransaction& txNew, std::vector<CTempRecipient
 
 bool LightWalletAddRealOutputs(CMutableTransaction& txNew, std::vector<CWatchOnlyTx>& vSelectedTxes, std::vector<std::vector<uint8_t>>& vInputBlinds, std::vector<size_t>& vSecretColumns, std::vector<std::vector<std::vector<int64_t>>>& vMI, std::string& errorMsg);
 
-void LightWalletFillInDummyOutputs(CMutableTransaction& txNew, const std::vector<CLightWalletAnonOutputData>& vDummyOutputs, std::vector<size_t>& vSecretColumns, std::vector<std::vector<std::vector<int64_t>>>& vMI);
+bool LightWalletFillInDummyOutputs(CMutableTransaction& txNew, const std::vector<CLightWalletAnonOutputData>& vDummyOutputs, std::vector<size_t>& vSecretColumns, std::vector<std::vector<std::vector<int64_t>>>& vMI, std::string& errorMsg);
 
 bool LightWalletUpdateChangeOutputCommitment(CMutableTransaction& txNew, std::vector<CTempRecipient>& vecSend, int& nChangePositionOut, std::vector<const uint8_t *>& vpOutCommits, std::vector<const uint8_t *>& vpOutBlinds, std::string& errorMsg);
 

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -734,7 +734,7 @@ static std::string SendHelp(std::shared_ptr<CWallet> pwallet, OutputTypes typeIn
                                                                                                                                "                            The narration is stored in the blockchain and is sent encrypted when destination is a stealth address and uncrypted otherwise.\n";
     if (typeIn == OUTPUT_RINGCT)
         rv +=
-                "7. ringsize        (int, optional, default=4).\n"
+                "7. ringsize        (int, optional, default=11).\n"
                 "8. inputs_per_sig  (int, optional, default=32).\n"
                 "9. inputs_per_tx   (int, optional, default=0, max=32). Allows sending in multiple transactions if necessary.\n"
                 "                            If 0, will attempt to accomplish in one transaction.\n"
@@ -858,7 +858,7 @@ UniValue sendtypeto(const JSONRPCRequest &request)
                 "5. \"comment_to\"      (string, optional) A comment to store the name of the person or organization \n"
                 "                            to which you're sending the transaction. This is not part of the \n"
                 "                            transaction, just kept in your wallet.\n"
-                "6. ringsize         (int, optional, default=4) Only applies when typein is ringct.\n"
+                "6. ringsize         (int, optional, default=11) Only applies when typein is ringct.\n"
                 "7. inputs_per_sig   (int, optional, default=32) Only applies when typein is ringct.\n"
                 "8. test_fee         (bool, optional, default=false) Only return the fee it would cost to send, txn is discarded.\n"
                 "9. coin_control     (json, optional) Coincontrol object.\n"

--- a/src/veil/ringct/rpcanonwallet.cpp
+++ b/src/veil/ringct/rpcanonwallet.cpp
@@ -2356,16 +2356,38 @@ static UniValue removewatchonlyaddress(const JSONRPCRequest &request)
         std::string sScanSecret = request.params[0].get_str();
         std::string sSpendPublic = request.params[1].get_str();
 
-        std::vector<uint8_t> vData = ParseHex(sScanSecret);
-        if (vData.size() != 32) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid scan secret - must be 32 bytes hex");
+        // Accept the same forms importlightwalletaddress does, otherwise an address
+        // imported with the WIF that viewscankeys hands out cannot be removed with it.
+        std::vector<uint8_t> vData;
+        CBitcoinSecret wifScanSecret;
+        if (IsHex(sScanSecret)) {
+            vData = ParseHex(sScanSecret);
+        } else
+        if (wifScanSecret.SetString(sScanSecret)) {
+            scan_secret = wifScanSecret.GetKey();
+        } else {
+            if (!DecodeBase58(sScanSecret, vData, MAX_STEALTH_RAW_SIZE)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Could not decode scan secret as WIF, hex or base58.");
+            }
         }
-        scan_secret.Set(vData.begin(), vData.end(), true);
+        if (vData.size() > 0) {
+            if (vData.size() != 32) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Scan secret is not 32 bytes.");
+            }
+            scan_secret.Set(vData.begin(), vData.end(), true);
+        }
         if (!scan_secret.IsValid()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid scan secret");
         }
 
-        std::vector<uint8_t> vPubKey = ParseHex(sSpendPublic);
+        std::vector<uint8_t> vPubKey;
+        if (IsHex(sSpendPublic)) {
+            vPubKey = ParseHex(sSpendPublic);
+        } else {
+            if (!DecodeBase58(sSpendPublic, vPubKey, MAX_STEALTH_RAW_SIZE)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Could not decode spend public as hex or base58.");
+            }
+        }
         spend_public.Set(vPubKey.begin(), vPubKey.end());
         if (!spend_public.IsValid()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid spend public key");


### PR DESCRIPTION
## Summary

Five fixes in the C++ light wallet path, in `src/veil/ringct/lightwallet.cpp` and its RPC
surface, plus a documentation correction. Three were found while testing against a live node on
current master; one is corroborated by two independent downstream reimplementations having
fixed the same thing.

Neither #1047 (light wallet upgrades, Nov 2025) nor #1070 (watch-only upgrades, Aug 2026)
touched `LightWalletFillInDummyOutputs`. That function is byte identical between the 1.4.3.0
release and current master.

## 1. Caller supplied decoy data is not validated

The decoy array arrives from the caller of `buildlightwallettx`. The builder consumes
`nInputs * (nRingSize - 1)` entries, derived from the ring size the daemon picks, and nothing
reconciles that against the length the caller actually sent, so the array can be indexed past
its end.

The RPC layer also silently discards decoy entries that fail to deserialize
(`rpcanonwallet.cpp`, a `catch` with `// Fall through.`), so a caller does not need to send a
short array deliberately in order to end up with one.

Adds the length check and returns a clear error. The per decoy `LogPrintf` is dropped, since it
dereferenced before any check and was only ever debug output.

## 2. Decoys reused across ring signatures

`int nCurrentLocation = 0;` is declared inside the per input loop, so every ring signature
restarts at decoy zero and reuses the same ring members. Consensus rejects that in
`VerifyMLSAG` via `setHaveI` with `bad-anonin-dup-i`, and the local per signature check with
`secp256k1_verify_mlsag` does not catch it.

Effect: `inputs_per_sig` is set to `nRingSize` in this path, so any send needing more than five
inputs builds a transaction the network will not accept.

Corroborated twice downstream. The Dart reimplementation hoisted the counter and left the
original placement as a commented line beside its fix, plus added explicit duplicate detection.
The newer Rust reimplementation tracks consumed decoys in a set scoped across all rings, with a
comment explaining that no output may appear in two rings. Two independent ports hit this and
fixed it locally; neither change came back here.

Fixed by hoisting the counter so each decoy is consumed once per transaction.

## 3. Ring size hardcoded to 5

```cpp
// Default ringsize is 11
int nRingSize = 5;
```

The comment is right and the code is wrong. `nDefaultRingSize` has been 11 on every network
since 2018 and every other send path uses `Params().DefaultRingSize()`. Ring size is plaintext
in the input and reported as `ring_size`, so a smaller value does not only weaken the ring, it
separates these transactions from every other RingCT spend on the chain.

Uses `Params().DefaultRingSize()`, then caps to whatever the supplied decoy set can actually
cover, so callers supplying fewer decoys keep working rather than failing outright, and callers
supplying more get a larger ring with no further change needed here. `inputs_per_sig` is raised
to `MAX_ANON_INPUTS` to match every other send path, which also keeps typical sends to a single
signature.

Also removes the dead `nRingSize` and `nInputsPerSig` from
`BuildLightWalletStealthTransaction`. That path spends CT outputs and builds no ring at all, so
both variables and their range checks were unreachable, and their presence suggested stealth
sends were using ring size 5 as well.

## 4. `CheckAmounts` sums into an uninitialised variable

```cpp
CAmount nSum;                       // never initialised
for (const auto& tx : vSpendableTx) {
    nSum += tx.nAmount;
    if ((nValueOut + CENT) < nSum) return true;
}
```

`CAmount` is a plain `int64_t`, so this starts from whatever is on the stack. It is the "do you
have enough funds" gate for every light wallet send.

Observed on testnet: a send from an address whose only watched output was a genuine zero value
RingCT output passed this check and proceeded to `SelectSpendableTxForValue`, which is
downstream of it. With `nSum` zeroed the caller correctly gets "Amount is over the balance of
this address".

## 5. `removewatchonlyaddress` rejects the key format the wallet emits

The two parameter form parsed the scan secret with a bare `ParseHex` requiring 32 raw bytes,
while `importlightwalletaddress`, `getwatchonlystatus`, `getwatchonlytxes`, `getkeyimages` and
`buildlightwallettx` all accept WIF, hex or base58, and `viewscankeys` returns WIF.

So an address could be imported with the key the wallet hands you and never removed with it.
Hit this while testing the above; the WIF had to be hand decoded to raw hex for the call to
succeed.

Fixed by reusing the parsing block `importlightwalletaddress` already uses. The spend public key
gets the same treatment, since it had the same bare `ParseHex`.

This sits on top of #1070, which added a one parameter form taking the stealth address
directly. That form works around the problem, but the two parameter path still had it.

## 6. Documentation

The help for `sendringctto*` and `sendtypeto` advertises `ringsize` as `default=4`. The real
default is `Params().DefaultRingSize()`, which is 11 on every network. Corrected in its own
commit.

## Testing

Both changed translation units compile clean and the tree links. CI is green on all eight
platforms.

The fixes were then verified against a testnet node running a CI build of this branch, by
rerunning the same cases that exposed the problems on an unpatched node:

| Case | Unpatched | Patched |
|---|---|---|
| One decoy supplied where the ring needs more | indexed past the end of the array, then failed downstream with "No pubkey found for dummy output" | `Not enough decoy outputs supplied: got 1 for 1 inputs, need at least 2` |
| Full decoy set supplied | built at ring 5 | built at ring 11 |
| Amount larger than the supplied input holds | passed the funds check and failed later in coin selection | `Amount is over the balance of this address` |
| `removewatchonlyaddress` with the WIF from `viewscankeys` | `Invalid scan secret - must be 32 bytes hex` | accepted, 731 entries removed |

The ring 11 transaction from the second case was checked against consensus rather than only
decoded:

```
decoderawtransaction   [11]
testmempoolaccept      allowed: true
```

`testmempoolaccept` runs full validation including `VerifyMLSAG`, so the transaction is valid
rather than merely well formed. It was not broadcast.

Item 2 was not exercised directly, since it needs six or more spendable inputs selected in one
send to force a second ring signature. It rests on the source argument and on the two
independent downstream reimplementations that fixed the same thing.

Item 3's effect on chain was confirmed separately by fee analysis over mainnet blocks 3949061
to 3949261: every ring 5 transaction paid exactly `CENT` while every ring 11 transaction paid a
size based fee, which identifies the light wallet path as the source of the ring 5 spends.

## Out of scope

The flat `nFeeNeeded = CENT` in this path is left alone. It makes every light wallet
transaction identifiable on chain independently of ring size, and overpays by roughly an order
of magnitude, but its existing TODO says it needs server side feerate plumbing that does not
exist yet.
