### PR TITLE
CI: build Windows, macOS and Linux installers

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 name: Github Actions CI for Veil
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 env:
   SOURCE_ARTIFACT: source
 jobs:
@@ -58,7 +58,7 @@ jobs:
     - name: Install Required Packages
       run: |
         sudo apt update
-        sudo apt install -y python3-zmq
+        sudo apt install -y python3-zmq dpkg-dev imagemagick
     - name: Build Dependencies
       run: make -C depends -j$(nproc)
       working-directory: ${{ env.SOURCE_ARTIFACT }}
@@ -72,6 +72,54 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
+    # Builds a .deb so Debian/Ubuntu/Mint users get a double click install and a
+    # Veil entry in the application menu instead of a folder of loose binaries.
+    - name: Build Debian Package
+      run: |
+        VERSION=$(ls $SOURCE_ARTIFACT/veil-*.tar.gz | sed 's|.*/veil-||; s|\.tar\.gz$||')
+        PKG=veil-deb
+        mkdir -p $PKG/DEBIAN $PKG/usr/bin $PKG/usr/share/applications \
+                 $PKG/usr/share/pixmaps $PKG/usr/share/doc/veil
+        cp $ARTIFACT_DIR/{veil-cli,veil-tx,veild,veil-qt} $PKG/usr/bin
+        cp $SOURCE_ARTIFACT/COPYING $PKG/usr/share/doc/veil/copyright
+        ICON=$SOURCE_ARTIFACT/src/qt/res/icons/bitcoin.png
+        for SIZE in 32 64 128 256; do
+          mkdir -p $PKG/usr/share/icons/hicolor/${SIZE}x${SIZE}/apps
+          convert $ICON -resize ${SIZE}x${SIZE} $PKG/usr/share/icons/hicolor/${SIZE}x${SIZE}/apps/veil.png
+        done
+        cp $PKG/usr/share/icons/hicolor/256x256/apps/veil.png $PKG/usr/share/pixmaps/veil.png
+        cat > $PKG/usr/share/applications/veil-qt.desktop <<'DESKTOP'
+        [Desktop Entry]
+        Type=Application
+        Name=Veil
+        GenericName=Veil Wallet
+        Comment=Send and receive Veil
+        Exec=veil-qt %u
+        Icon=veil
+        Terminal=false
+        Categories=Office;Finance;
+        MimeType=x-scheme-handler/veil;
+        DESKTOP
+        # Read the real shared library deps off the binary instead of guessing
+        mkdir -p debian
+        printf 'Source: veil\n\nPackage: veil\nArchitecture: amd64\n' > debian/control
+        DEPENDS=$(dpkg-shlibdeps --ignore-missing-info -O $PKG/usr/bin/veil-qt 2>/dev/null | sed 's/^shlibs:Depends=//') || true
+        [ -n "$DEPENDS" ] || DEPENDS='libc6, libstdc++6, libgcc-s1'
+        cat > $PKG/DEBIAN/control <<CONTROL
+        Package: veil
+        Version: $VERSION
+        Architecture: amd64
+        Section: utils
+        Priority: optional
+        Maintainer: Veil Project <https://github.com/Veil-Project/veil>
+        Homepage: https://veil-project.com/
+        Depends: $DEPENDS
+        Description: Veil privacy focused cryptocurrency wallet
+         Veil is a privacy focused cryptocurrency built on RingCT and zerocoin.
+         This package installs the Veil-Qt wallet along with the veild daemon
+         and the veil-cli and veil-tx command line tools.
+        CONTROL
+        dpkg-deb --build --root-owner-group $PKG $ARTIFACT_DIR/veil-$VERSION-amd64.deb
     - name: Upload Artifact
       uses: actions/upload-artifact@v6.0.0
       with:
@@ -97,7 +145,7 @@ jobs:
     - name: Install Required Packages
       run: |
         sudo apt update
-        sudo apt install -y g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
+        sudo apt install -y g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 nsis
     - name: Switch MinGW GCC and G++ to POSIX Threading
       run: |
         sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
@@ -110,11 +158,18 @@ jobs:
         ./configure --disable-jni --prefix=$(realpath depends/x86_64-w64-mingw32)
         make -j$(nproc)
       working-directory: ${{ env.SOURCE_ARTIFACT }}
+    # Produces veil-<version>-win64-setup.exe from share/setup.nsi: start menu
+    # entries, the veil: URI handler and an uninstaller, same as any other
+    # Windows program. Has to run before the binaries are moved out of src/.
+    - name: Build Windows Installer
+      run: make deploy
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
     - name: Prepare Files for Artifact
       run: |
         mkdir -p $ARTIFACT_DIR
         strip $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe}
         mv $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe} $ARTIFACT_DIR
+        mv $SOURCE_ARTIFACT/veil-*-win64-setup.exe $ARTIFACT_DIR
     - name: Upload Artifact
       uses: actions/upload-artifact@v6.0.0
       with:
@@ -142,8 +197,12 @@ jobs:
     - name: Install Required Packages
       run: |
         sudo apt update
-        sudo apt install -y python3-setuptools libcap-dev zlib1g-dev cmake
+        sudo apt install -y python3-setuptools libcap-dev zlib1g-dev cmake \
+          genisoimage librsvg2-bin imagemagick libtiff-tools
         sudo -H pip install setuptools
+        # macdeployqtplus and custom_dsstore.py need these to lay out the .dmg,
+        # installed against the same python3 that configure will pick up
+        sudo -H python3 -m pip install ds_store mac_alias biplist
 
     - name: Work around missing libtinfo.so.5 for macOS cross-toolchain
       run: |
@@ -175,12 +234,20 @@ jobs:
         make -j$(nproc)
       working-directory: ${{ env.SOURCE_ARTIFACT }}
 
+    # Wraps Veil-Qt.app in the usual drag-to-Applications disk image. The .dmg
+    # is unsigned, so first launch is right click -> Open.
+    - name: Build Disk Image
+      run: make deploy
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+
     - name: Prepare Files for Artifact
       run: |
         mkdir -p $ARTIFACT_DIR
         # strip fails with "Unable to recognise the format of the input file"
         #strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
+        VERSION=$(ls $SOURCE_ARTIFACT/veil-*.tar.gz | sed 's|.*/veil-||; s|\.tar\.gz$||')
+        mv $SOURCE_ARTIFACT/*.dmg $ARTIFACT_DIR/veil-$VERSION-osx64.dmg
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v6.0.0
@@ -346,3 +413,30 @@ jobs:
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
+  attach-installers-to-release:
+    name: Attach Installers to Release
+    needs: [build-x86_64-linux, build-win64, build-osx64]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+    - name: Getting Installers
+      uses: actions/download-artifact@v7.0.0
+      with:
+        path: artifacts
+    - name: Attach to Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        mkdir -p installers
+        cp artifacts/win64-binaries/*-win64-setup.exe installers
+        cp artifacts/macosx-binaries/*.dmg installers
+        cp artifacts/x86_64-linux-binaries/*.deb installers
+        (cd installers && sha256sum * > SHA256SUMS.txt)
+        # A tag can be pushed before its release page exists, so open a draft
+        # when there is nothing to attach to yet
+        gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+          gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME" --notes "Installers built by CI."
+        gh release upload "$GITHUB_REF_NAME" installers/* --clobber

--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -105,10 +105,14 @@ jobs:
         printf 'Source: veil\n\nPackage: veil\nArchitecture: amd64\n' > debian/control
         DEPENDS=$(dpkg-shlibdeps --ignore-missing-info -O $PKG/usr/bin/veil-qt 2>/dev/null | sed 's/^shlibs:Depends=//') || true
         [ -n "$DEPENDS" ] || DEPENDS='libc6, libstdc++6, libgcc-s1'
+        # dpkg-deb does not work this out on its own, and without it apt reports
+        # "0 B of additional disk space will be used" and cannot warn on a full disk
+        INSTALLED_SIZE=$(du -ks $PKG/usr | cut -f1)
         cat > $PKG/DEBIAN/control <<CONTROL
         Package: veil
         Version: $VERSION
         Architecture: amd64
+        Installed-Size: $INSTALLED_SIZE
         Section: utils
         Priority: optional
         Maintainer: Veil Project <https://github.com/Veil-Project/veil>

--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -72,9 +72,24 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
         mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
+    # Upload the binaries before packaging runs. Packaging is the newest and
+    # most fragile part of this job, and it should never be able to cost us the
+    # binaries that already built cleanly.
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v6.0.0
+      with:
+        name: ${{ env.ARTIFACT_DIR }}
+        path: ${{ env.ARTIFACT_DIR }}
     # Builds a .deb so Debian/Ubuntu/Mint users get a double click install and a
     # Veil entry in the application menu instead of a folder of loose binaries.
+    # Skipped for pull requests and branch pushes, where it only costs time.
+    # Master still runs it on every push, so a break shows up while it is cheap
+    # to fix rather than when a release tag is waiting on it.
     - name: Build Debian Package
+      if: >-
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/master'
       run: |
         VERSION=$(ls $SOURCE_ARTIFACT/veil-*.tar.gz | sed 's|.*/veil-||; s|\.tar\.gz$||')
         PKG=veil-deb
@@ -115,7 +130,7 @@ jobs:
         Installed-Size: $INSTALLED_SIZE
         Section: utils
         Priority: optional
-        Maintainer: Veil Project <https://github.com/Veil-Project/veil>
+        Maintainer: Veil Project <support@veil-project.com>
         Homepage: https://veil-project.com/
         Depends: $DEPENDS
         Description: Veil privacy focused cryptocurrency wallet
@@ -123,12 +138,17 @@ jobs:
          This package installs the Veil-Qt wallet along with the veild daemon
          and the veil-cli and veil-tx command line tools.
         CONTROL
-        dpkg-deb --build --root-owner-group $PKG $ARTIFACT_DIR/veil-$VERSION-amd64.deb
-    - name: Upload Artifact
+        mkdir -p installers
+        dpkg-deb --build --root-owner-group $PKG installers/veil-$VERSION-amd64.deb
+    - name: Upload Installer
+      if: >-
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/master'
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ env.ARTIFACT_DIR }}
-        path: ${{ env.ARTIFACT_DIR }}
+        name: installers-x86_64-linux
+        path: installers
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
@@ -162,23 +182,41 @@ jobs:
         ./configure --disable-jni --prefix=$(realpath depends/x86_64-w64-mingw32)
         make -j$(nproc)
       working-directory: ${{ env.SOURCE_ARTIFACT }}
-    # Produces veil-<version>-win64-setup.exe from share/setup.nsi: start menu
-    # entries, the veil: URI handler and an uninstaller, same as any other
-    # Windows program. Has to run before the binaries are moved out of src/.
-    - name: Build Windows Installer
-      run: make deploy
-      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    # Copy rather than move: the installer is built from the binaries in src/,
+    # so they have to stay there, and getting them uploaded first means a
+    # packaging break cannot take the binaries down with it.
     - name: Prepare Files for Artifact
       run: |
         mkdir -p $ARTIFACT_DIR
         strip $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe}
-        mv $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe} $ARTIFACT_DIR
-        mv $SOURCE_ARTIFACT/veil-*-win64-setup.exe $ARTIFACT_DIR
+        cp $SOURCE_ARTIFACT/src/{veil-cli.exe,veil-tx.exe,veild.exe,qt/veil-qt.exe} $ARTIFACT_DIR
     - name: Upload Artifact
       uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
+    # Produces veil-<version>-win64-setup.exe from share/setup.nsi: start menu
+    # entries, the veil: URI handler and an uninstaller, same as any other
+    # Windows program. Skipped for pull requests and branch pushes; master still
+    # builds it on every push so breakage surfaces before a tag needs it.
+    - name: Build Windows Installer
+      if: >-
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/master'
+      run: |
+        (cd $SOURCE_ARTIFACT && make deploy)
+        mkdir -p installers
+        mv $SOURCE_ARTIFACT/veil-*-win64-setup.exe installers
+    - name: Upload Installer
+      if: >-
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v6.0.0
+      with:
+        name: installers-win64
+        path: installers
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
@@ -238,26 +276,49 @@ jobs:
         make -j$(nproc)
       working-directory: ${{ env.SOURCE_ARTIFACT }}
 
-    # Wraps Veil-Qt.app in the usual drag-to-Applications disk image. The .dmg
-    # is unsigned, so first launch is right click -> Open.
-    - name: Build Disk Image
-      run: make deploy
-      working-directory: ${{ env.SOURCE_ARTIFACT }}
-
+    # Copy rather than move: the disk image is built from the tree in src/, so
+    # the binaries have to stay put, and uploading them first means a packaging
+    # break cannot take them down with it.
     - name: Prepare Files for Artifact
       run: |
         mkdir -p $ARTIFACT_DIR
         # strip fails with "Unable to recognise the format of the input file"
         #strip $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt}
-        mv $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
-        VERSION=$(ls $SOURCE_ARTIFACT/veil-*.tar.gz | sed 's|.*/veil-||; s|\.tar\.gz$||')
-        mv $SOURCE_ARTIFACT/*.dmg $ARTIFACT_DIR/veil-$VERSION-osx64.dmg
+        cp $SOURCE_ARTIFACT/src/{veil-cli,veil-tx,veild,qt/veil-qt} $ARTIFACT_DIR
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.ARTIFACT_DIR }}
         path: ${{ env.ARTIFACT_DIR }}
+
+    # Wraps Veil-Qt.app in the usual drag-to-Applications disk image. The .dmg
+    # is unsigned, so first launch is right click -> Open. Skipped for pull
+    # requests and branch pushes; master still builds it on every push so
+    # breakage surfaces before a tag needs it.
+    - name: Build Disk Image
+      if: >-
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/master'
+      run: |
+        (cd $SOURCE_ARTIFACT && make deploy)
+        mkdir -p installers
+        VERSION=$(ls $SOURCE_ARTIFACT/veil-*.tar.gz | sed 's|.*/veil-||; s|\.tar\.gz$||')
+        # One dmg is expected; name it explicitly rather than globbing into a
+        # single destination, which would fail confusingly if that ever changed.
+        DMG=$(ls $SOURCE_ARTIFACT/*.dmg | head -n1)
+        mv "$DMG" installers/veil-$VERSION-osx64.dmg
+
+    - name: Upload Installer
+      if: >-
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v6.0.0
+      with:
+        name: installers-osx64
+        path: installers
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
@@ -434,10 +495,12 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
       run: |
+        # The installers arrive in their own artifacts, separate from the loose
+        # binaries, so packaging can fail without costing us a binaries upload.
         mkdir -p installers
-        cp artifacts/win64-binaries/*-win64-setup.exe installers
-        cp artifacts/macosx-binaries/*.dmg installers
-        cp artifacts/x86_64-linux-binaries/*.deb installers
+        cp artifacts/installers-win64/*-win64-setup.exe installers
+        cp artifacts/installers-osx64/*.dmg installers
+        cp artifacts/installers-x86_64-linux/*.deb installers
         (cd installers && sha256sum * > SHA256SUMS.txt)
         # A tag can be pushed before its release page exists, so open a draft
         # when there is nothing to attach to yet


### PR DESCRIPTION
Veil has shipped installers before, most recently in v1.4.1.0, but they have
never been part of CI. They only ever appeared when someone built them by hand,
so they come and go: v1.3.0.0 and v1.4.0.0 had none, v1.4.1.0 had four, and the
last two releases including 1.4.3.0 went out as loose binaries only. Someone
asked for a normal GUI install on the 1.4.3.0 release, which is what prompted
this.

This makes installers a build artifact like everything else, so they stop
depending on anyone remembering.

Most of what is needed was already in the tree. `share/setup.nsi.in` is a
complete NSIS installer, and `Makefile.am` already has the macOS disk image
rules. Both hang off `make deploy`, which the workflow never called.

**Windows.** Installs `nsis` and calls `make deploy`, producing
`veil-1.4.3-win64-setup.exe`. Standard wizard, start menu shortcuts for mainnet
and testnet, `veild` and `veil-cli` under a daemon folder, the `veil:` URI
handler, and an uninstaller in Add or Remove Programs.

**macOS.** Installs the image tools and the python modules `macdeployqtplus`
and `custom_dsstore.py` need, then calls `make deploy` for the usual drag to
Applications disk image.

**Linux.** Nothing existed here, so the workflow builds a `.deb` with
`dpkg-deb`: binaries in `/usr/bin`, a desktop entry, hicolor icons at four
sizes, and `Installed-Size`. Dependencies are read off the built binary with
`dpkg-shlibdeps` instead of being hardcoded, which currently resolves to
`libc6 (>= 2.34), libfontconfig1, libfreetype6, libgcc-s1, libstdc++6 (>= 12),
libx11-6, libx11-xcb1, libxcb1`.

**Releases.** A new `attach-installers-to-release` job runs on tags only. It
takes the three installers out of the build artifacts, writes a
`SHA256SUMS.txt`, and uploads them to that tag's release page using the built
in `GITHUB_TOKEN`. No third party actions. On a branch push it skips.

Installers build on every push and pull request, not just tags, so the
packaging cannot rot unnoticed again. Also adds `workflow_dispatch` so a build
can be started by hand.

### Testing

All three were built from the `v1.4.3.0` tag, installed, and run:

| platform | result |
| --- | --- |
| Windows | installed and ran, reported by a tester |
| macOS 26, Apple Silicon | dmg mounted, dragged to Applications, wallet opened under Rosetta |
| Ubuntu 22.04 | `sudo apt install ./veil-1.4.3.0-amd64.deb`, menu entry appeared, wallet opened and synced |

The release job was exercised on a real tag, where it attached all four files,
and it skipped correctly on branch pushes. Test builds:
https://github.com/ohcee/veil/releases/tag/installer-test-1.4.3.0

### Known limitations, not addressed here

Nothing is code signed, so Windows shows the SmartScreen warning and macOS
needs the Open Anyway route under System Settings, Privacy and Security. The
older releases shipped unsigned too, which is why they are named
`-unsigned.dmg`. Signing needs paid certificates and an organization identity.

The macOS build is x86_64 and runs under Rosetta on Apple Silicon, same as the
binaries shipped today.

The x86_64 Linux job does not use `--enable-glibc-back-compat`, so the deb
requires Ubuntu 22.04 or newer. That is the same floor the loose binaries have
always had, the difference is apt states it up front instead of failing at
runtime. The arm32 job in this workflow already shows the fix. Worth doing
separately with its own testing.

Builds are not reproducible, so two runs of identical source produce different
hashes.
