### PR TITLE
In-wallet miner: mine every algorithm efficiently, with a usable mining page

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -249,6 +249,7 @@ void Shutdown()
     threadGroupPoWMining.join_all();
     DeallocateVMVector();
     DeallocateDataSet();
+    FreeProgPowMiningContext();
 
     threadGroupRandomX.interrupt_all();
     threadGroupRandomX.join_all();
@@ -594,6 +595,7 @@ void SetupServerArgs()
     gArgs.AddArg("-blockmaxweight=<n>", strprintf("Set maximum BIP141 block weight (default: %d)", DEFAULT_BLOCK_MAX_WEIGHT), false, OptionsCategory::BLOCK_CREATION);
     gArgs.AddArg("-blockmintxfee=<amt>", strprintf("Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), false, OptionsCategory::BLOCK_CREATION);
     gArgs.AddArg("-blockversion=<n>", "Override block version to test forking scenarios", true, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-progpowdag", "Build the full ProgPow DAG when mining with the wallet miner. Much faster hashing at the cost of several GB of memory (default: 0)", false, OptionsCategory::BLOCK_CREATION);
 
     gArgs.AddArg("-rest", strprintf("Accept public REST requests (default: %u)", DEFAULT_REST_ENABLE), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times", false, OptionsCategory::RPC);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -38,6 +38,8 @@
 #include <algorithm>
 #include <atomic>
 #include <deque>
+#include <mutex>
+#include <thread>
 #include <queue>
 #include <utility>
 #include <vector>
@@ -46,6 +48,7 @@
 
 // ProgPow
 #include <crypto/ethash/lib/ethash/endianness.hpp>
+#include <crypto/ethash/lib/ethash/ethash-internal.hpp>
 #include <crypto/ethash/include/ethash/progpow.hpp>
 #include <crypto/randomx/randomx.h>
 #include "crypto/ethash/helpers.hpp"
@@ -946,6 +949,140 @@ double GetRecentHashSpeed() {
     return (nCount - front.nHashes) * 1000.0 / (nNow - front.nTimeMillis);
 }
 
+/**
+ * Mining side ProgPow context handling. Validation keeps its own light context
+ * in hash.cpp; the miner never touches it, so hashing for blocks does not
+ * contend with block validation.
+ *
+ * By default the miner uses a light context. With -progpowdag (or the GUI
+ * checkbox) it builds the full DAG once per epoch, which makes CPU mining
+ * roughly two orders of magnitude faster at the cost of several GB of memory.
+ * The dataset is built eagerly and in parallel here because the library's lazy
+ * per item fill is not thread safe under concurrent miners.
+ */
+static CCriticalSection cs_progpow_mining;
+static std::shared_ptr<ethash::epoch_context_full> spProgPowContextFull;
+static std::shared_ptr<ethash::epoch_context> spProgPowContextLight;
+static int nProgPowMiningEpoch = -1;
+// These are read and written from the GUI thread as well as from miner threads,
+// so keep them atomic. In particular the GUI setter must never take
+// cs_progpow_mining: a miner thread can hold that lock for minutes while it
+// builds the DAG, and blocking the GUI thread on it would freeze the whole UI.
+static std::atomic<bool> fProgPowDagFailed{false};
+static std::atomic<bool> fProgPowUseFullDag{false};
+static std::once_flag progpow_dag_init;
+
+void SetProgPowFullDataset(bool fUse)
+{
+    // Mark as initialised so a later GetProgPowFullDataset does not clobber this
+    // explicit choice with the -progpowdag default.
+    std::call_once(progpow_dag_init, [](){});
+    fProgPowUseFullDag.store(fUse);
+    fProgPowDagFailed.store(false);
+}
+
+bool GetProgPowFullDataset()
+{
+    std::call_once(progpow_dag_init, [](){
+        fProgPowUseFullDag.store(gArgs.GetBoolArg("-progpowdag", false));
+    });
+    return fProgPowUseFullDag.load();
+}
+
+/** Fill the full DAG in parallel. Returns false if aborted by shutdown or the
+ * miner being switched off. Items the L1 prefill already wrote are skipped. */
+static bool BuildProgPowDataset(ethash::epoch_context_full* ctx, int nThreads)
+{
+    const uint32_t nItems2048 = static_cast<uint32_t>(ctx->full_dataset_num_items) / 2;
+    const uint32_t nFirst = progpow::l1_cache_size / sizeof(ethash::hash2048);
+    auto* pDataset = reinterpret_cast<ethash::hash2048*>(ctx->full_dataset);
+
+    if (nThreads < 1) nThreads = 1;
+    std::atomic<bool> fAborted{false};
+    std::vector<std::thread> vThreads;
+    const uint32_t nPerThread = (nItems2048 - nFirst) / nThreads;
+    for (int t = 0; t < nThreads; ++t) {
+        const uint32_t nStart = nFirst + t * nPerThread;
+        const uint32_t nEnd = (t == nThreads - 1) ? nItems2048 : nStart + nPerThread;
+        vThreads.emplace_back([ctx, pDataset, nStart, nEnd, &fAborted]() {
+            for (uint32_t i = nStart; i < nEnd; ++i) {
+                if ((i & 0xfff) == 0 && (ShutdownRequested() || !GenerateActive() || fAborted)) {
+                    fAborted = true;
+                    return;
+                }
+                pDataset[i] = ethash::calculate_dataset_item_2048(*ctx, i);
+            }
+        });
+    }
+    for (auto& t : vThreads)
+        t.join();
+    return !fAborted;
+}
+
+/** Get shared mining contexts for the epoch of nHeight. On success exactly one
+ * of the two out pointers is set. Both empty means the caller should give up
+ * this round (shutdown or mining switched off during a DAG build). */
+static void GetProgPowMiningContext(int nHeight,
+                                    std::shared_ptr<ethash::epoch_context_full>& ctxFull,
+                                    std::shared_ptr<ethash::epoch_context>& ctxLight)
+{
+    const int nEpoch = Params().GetProgPowEpochNumber(nHeight);
+    const bool fWantFull = GetProgPowFullDataset();
+    LOCK(cs_progpow_mining);
+    const bool fHaveRight = nEpoch == nProgPowMiningEpoch &&
+                            (spProgPowContextFull || spProgPowContextLight) &&
+                            ((fWantFull && !fProgPowDagFailed) == (spProgPowContextFull != nullptr));
+    if (!fHaveRight) {
+        spProgPowContextFull.reset();
+        spProgPowContextLight.reset();
+        nProgPowMiningEpoch = -1;
+        // Do not start a multi minute, multi GB build if mining is already on its
+        // way out. Without this liveness check, every miner thread queued on
+        // cs_progpow_mining would kick off its own fresh build after a stop, one
+        // after another, each one aborting only once its worker threads notice.
+        if (fWantFull && !fProgPowDagFailed && GenerateActive() && !ShutdownRequested()) {
+            const size_t nBytes = static_cast<size_t>(ethash_calculate_full_dataset_num_items(nEpoch)) * sizeof(ethash::hash1024);
+            LogPrintf("%s: Building ProgPow DAG for epoch %d (%d MB), this can take a few minutes\n",
+                      __func__, nEpoch, nBytes >> 20);
+            SetBuildingMinerDataset(true);
+            auto nTime1 = GetTimeMillis();
+            // Guard the null case explicitly: wrapping a null pointer in a
+            // shared_ptr with this deleter would call the destroy function on
+            // null when the temporary dies, which is undefined behaviour.
+            ethash::epoch_context_full* pRaw = ethash_create_epoch_context_full(nEpoch);
+            if (!pRaw) {
+                LogPrintf("%s: ProgPow DAG allocation failed, falling back to light mining\n", __func__);
+                fProgPowDagFailed = true;
+            } else {
+                std::shared_ptr<ethash::epoch_context_full> ctx(pRaw, ethash_destroy_epoch_context_full);
+                if (!BuildProgPowDataset(ctx.get(), GetNumCores())) {
+                    // Aborted part way. Drop it so a later start rebuilds from scratch.
+                    SetBuildingMinerDataset(false);
+                    return;
+                }
+                LogPrintf("%s: Finished ProgPow DAG %.2fms\n", __func__, (double)(GetTimeMillis() - nTime1));
+                spProgPowContextFull = ctx;
+            }
+            SetBuildingMinerDataset(false);
+        }
+        if (!spProgPowContextFull)
+            spProgPowContextLight = std::shared_ptr<ethash::epoch_context>(
+                ethash_create_epoch_context(nEpoch), ethash_destroy_epoch_context);
+        nProgPowMiningEpoch = nEpoch;
+    }
+    ctxFull = spProgPowContextFull;
+    ctxLight = spProgPowContextLight;
+}
+
+void FreeProgPowMiningContext()
+{
+    LOCK(cs_progpow_mining);
+    spProgPowContextFull.reset();
+    spProgPowContextLight.reset();
+    nProgPowMiningEpoch = -1;
+    fProgPowDagFailed = false;
+}
+
 void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfStake = false, bool fProofOfFullNode = false, ThreadHashSpeed* pThreadHashSpeed = nullptr) {
     LogPrintf("Veil Miner started\n");
 
@@ -1079,17 +1216,57 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
             int nMidTries = 0;
             static const int nMidLoopCount = 0x1000;
             if (pblock->IsProgPow() && pblock->nTime >= Params().PowUpdateTimestamp()) {
-                uint256 mix_hash;
-                while (nTries < nInnerLoopCount &&
-                        !CheckProofOfWork(ProgPowHash(*pblock, mix_hash), pblock->nBits,
-                                          Params().GetConsensus(), CBlockHeader::PROGPOW_BLOCK)) {
-                    boost::this_thread::interruption_point();
-                    ++nTries;
-                    ++pblock->nNonce64;
-                    CountHashesMined(1);
+                // Check the target the same way CheckProofOfWork will
+                arith_uint256 bnTarget;
+                bool fNegative, fOverflow;
+                bnTarget.SetCompact(pblock->nBits, &fNegative, &fOverflow);
+                if (fNegative || bnTarget == 0 || fOverflow ||
+                    bnTarget > UintToArith256(Params().GetConsensus().powLimit)) {
+                    LogPrint(BCLog::MINING, "%s: invalid ProgPow target in template\n", __func__);
+                    continue;
                 }
-                pblock->mixHash = mix_hash;
-                success = nTries != nInnerLoopCount;
+
+                std::shared_ptr<ethash::epoch_context_full> ctxFull;
+                std::shared_ptr<ethash::epoch_context> ctxLight;
+                GetProgPowMiningContext(pblock->nHeight, ctxFull, ctxLight);
+                if (!ctxFull && !ctxLight)
+                    continue;
+
+                // The ProgPow header hash does not cover the nonce, so hash it
+                // once per template instead of once per attempt.
+                const auto header_hash = to_hash256(pblock->GetProgPowHeaderHash().GetHex());
+                // CheckProofOfWork accepts hash < target while the searcher
+                // accepts hash <= boundary, so pass target minus one.
+                const auto boundary = to_hash256(ArithToUint256(bnTarget - 1).GetHex());
+
+                // Search in chunks so the thread stays interruptible, the live
+                // hash counter keeps moving and a stale template gets dropped.
+                const int nChunkSize = ctxFull ? 256 : 16;
+                while (nTries < nInnerLoopCount) {
+                    boost::this_thread::interruption_point();
+                    if (chainActive.Height() >= pblock->nHeight)
+                        break;
+                    const int nChunk = std::min(nChunkSize, nInnerLoopCount - nTries);
+                    progpow::search_result res;
+                    if (ctxFull)
+                        res = progpow::search(*ctxFull, pblock->nHeight, header_hash, boundary,
+                                              pblock->nNonce64, nChunk);
+                    else
+                        res = progpow::search_light(*ctxLight, pblock->nHeight, header_hash, boundary,
+                                                    pblock->nNonce64, nChunk);
+                    if (res.solution_found) {
+                        const int nUsed = static_cast<int>(res.nonce - pblock->nNonce64) + 1;
+                        CountHashesMined(nUsed);
+                        nTries += nUsed;
+                        pblock->nNonce64 = res.nonce;
+                        pblock->mixHash = uint256S(to_hex(res.mix_hash));
+                        success = true;
+                        break;
+                    }
+                    CountHashesMined(nChunk);
+                    nTries += nChunk;
+                    pblock->nNonce64 += nChunk;
+                }
             } else if (pblock->IsSha256D() && pblock->nTime >= Params().PowUpdateTimestamp()) {
                 uint256 midStateHash = pblock->GetSha256dMidstate();
                 // Exit loop when nMidLoopCount loops are done, or when a new block is found.
@@ -1409,6 +1586,7 @@ void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScri
     }
 
     SetBuildingMinerDataset(false);
+    FreeProgPowMiningContext();
 
     if (nThreads == 0 || !fGenerate)
         return;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -927,9 +927,11 @@ void ClearHashSpeed() {
 
 double GetRecentHashSpeed() {
     LOCK(cs_hashrate_window);
-    if (!GenerateActive()) {
-        // Not mining. Drop any stale samples so a later restart starts a
-        // fresh measurement window.
+    if (!GenerateActive() || IsBuildingMinerDataset()) {
+        // Not actually hashing: either stopped, or every thread is parked while
+        // one builds the ProgPow DAG. Drop samples so the measurement restarts
+        // fresh when hashing resumes, instead of averaging in the dead build
+        // interval and under-reporting the rate for a minute afterwards.
         vHashRateWindow.clear();
         return 0.0;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1400,35 +1400,45 @@ void BitcoinRandomXMiner(std::shared_ptr<CReserveScript> coinbaseScript, int vm_
 
             bnTarget.SetCompact(pblock->nBits, &fNegative, &fOverflow);
 
+            // Hoist things that do not change while we grind this template. The
+            // key block only rotates every KEY_CHANGE blocks and a new tip lands
+            // only occasionally, so check both on an interval rather than taking
+            // cs_randomx_validator and walking the chain on every hash. That lock,
+            // taken once per hash by every mining thread, was the main thing
+            // throttling multi threaded RandomX. The network id never changes.
+            const bool fRegtest = Params().NetworkIDString() == "regtest";
+            const int nCheckInterval = 128;
+            int nSinceCheck = nCheckInterval;
+
             while (nTries < nInnerLoopCount) {
                 boost::this_thread::interruption_point();
 
-                if (fKeyBlockedChanged || CheckIfMiningKeyShouldChange(GetKeyBlock(pblock->nHeight))) {
-                    fKeyBlockedChanged = true;
-                    break;
-                }
-
-                if (pblock->nHeight <= chainActive.Height()) {
-                    fBlockFoundAlready = true;
-                    break;
+                if (--nSinceCheck <= 0) {
+                    nSinceCheck = nCheckInterval;
+                    if (fKeyBlockedChanged || CheckIfMiningKeyShouldChange(GetKeyBlock(pblock->nHeight))) {
+                        fKeyBlockedChanged = true;
+                        break;
+                    }
+                    if (pblock->nHeight <= chainActive.Height()) {
+                        fBlockFoundAlready = true;
+                        break;
+                    }
                 }
 
                 char hash[RANDOMX_HASH_SIZE];
-                // Build the header_hash
+                // Build the header_hash (covers the nonce, so it must be rebuilt each try)
                 uint256 nHeaderHash = pblock->GetRandomXHeaderHash();
 
                 randomx_calculate_hash(vecRandomXVM[vm_index], &nHeaderHash, sizeof uint256(), hash);
                 CountHashesMined(1);
 
-                uint256 nHash = RandomXHashToUint256(hash);
-
                 // Bypass regtest check, actually allows us to generate blocks in regtest mode instantly
-                if (Params().NetworkIDString() == "regtest") {
+                if (fRegtest) {
                     break;
                 }
 
                 // Check proof of work matches claimed amount
-                if (UintToArith256(nHash) < bnTarget) {
+                if (UintToArith256(RandomXHashToUint256(hash)) < bnTarget) {
                     break;
                 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1410,7 +1410,10 @@ void BitcoinRandomXMiner(std::shared_ptr<CReserveScript> coinbaseScript, int vm_
             // throttling multi threaded RandomX. The network id never changes.
             const bool fRegtest = Params().NetworkIDString() == "regtest";
             const int nCheckInterval = 128;
-            int nSinceCheck = nCheckInterval;
+            // Start at 1 so the first pass through the loop checks. Starting at
+            // the interval would spend the first 128 hashes on a template
+            // without once asking whether the tip or the key block moved.
+            int nSinceCheck = 1;
 
             while (nTries < nInnerLoopCount) {
                 boost::this_thread::interruption_point();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -36,6 +36,8 @@
 #include <veil/zerocoin/zchain.h>
 
 #include <algorithm>
+#include <atomic>
+#include <deque>
 #include <queue>
 #include <utility>
 #include <vector>
@@ -873,6 +875,31 @@ class ThreadHashSpeed {
 CCriticalSection cs_hashspeeds;
 std::vector<ThreadHashSpeed> vHashSpeeds;
 
+// Live counters for user facing mining stats. The mining threads add their
+// attempts here as they go, so the recent rate below responds within seconds
+// instead of once per template round.
+static std::atomic<uint64_t> nLiveHashCounter{0};
+static std::atomic<uint64_t> nSessionBlocksFound{0};
+static std::atomic<int64_t> nLastBlockFoundTime{0};
+static std::atomic<bool> fBuildingMinerDataset{false};
+
+static void CountHashesMined(uint64_t n)
+{
+    nLiveHashCounter.fetch_add(n, std::memory_order_relaxed);
+}
+
+uint64_t GetSessionBlocksFound() { return nSessionBlocksFound.load(); }
+int64_t GetSessionLastBlockTime() { return nLastBlockFoundTime.load(); }
+void SetBuildingMinerDataset(bool fBuilding) { fBuildingMinerDataset = fBuilding; }
+bool IsBuildingMinerDataset() { return fBuildingMinerDataset.load(); }
+
+// Sliding window over the live hash counter. A sample is taken whenever a
+// caller asks for the rate (the GUI polls a few times a second), and the rate
+// is measured across roughly the last minute of samples.
+static CCriticalSection cs_hashrate_window;
+struct HashRateSample { int64_t nTimeMillis; uint64_t nHashes; };
+static std::deque<HashRateSample> vHashRateWindow;
+
 void ClearHashSpeed() {
     {
         LOCK(cs_nonce);
@@ -888,17 +915,35 @@ void ClearHashSpeed() {
             ths.nTimeDuration = 0;
         }
     }
+    {
+        LOCK(cs_hashrate_window);
+        vHashRateWindow.clear();
+    }
+    nLiveHashCounter = 0;
 }
 
 double GetRecentHashSpeed() {
-    LOCK(cs_hashspeeds);
-    double nTotalHashSpeed = 0.0;
-    for (auto& hs : vHashSpeeds) {
-        LOCK(hs.cs);
-        if (hs.nTimeDuration > 0)
-            nTotalHashSpeed += hs.nHashes.getdouble() / hs.nTimeDuration;
+    LOCK(cs_hashrate_window);
+    if (!GenerateActive()) {
+        // Not mining. Drop any stale samples so a later restart starts a
+        // fresh measurement window.
+        vHashRateWindow.clear();
+        return 0.0;
     }
-    return nTotalHashSpeed;
+
+    const int64_t nNow = GetTimeMillis();
+    const uint64_t nCount = nLiveHashCounter.load(std::memory_order_relaxed);
+
+    if (vHashRateWindow.empty() || nNow - vHashRateWindow.back().nTimeMillis >= 200)
+        vHashRateWindow.push_back({nNow, nCount});
+
+    while (vHashRateWindow.size() > 2 && nNow - vHashRateWindow.front().nTimeMillis > 60000)
+        vHashRateWindow.pop_front();
+
+    const HashRateSample& front = vHashRateWindow.front();
+    if (nCount <= front.nHashes || nNow <= front.nTimeMillis)
+        return 0.0;
+    return (nCount - front.nHashes) * 1000.0 / (nNow - front.nTimeMillis);
 }
 
 void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfStake = false, bool fProofOfFullNode = false, ThreadHashSpeed* pThreadHashSpeed = nullptr) {
@@ -1041,6 +1086,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                     boost::this_thread::interruption_point();
                     ++nTries;
                     ++pblock->nNonce64;
+                    CountHashesMined(1);
                 }
                 pblock->mixHash = mix_hash;
                 success = nTries != nInnerLoopCount;
@@ -1056,6 +1102,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                         ++nTries;
                         ++pblock->nNonce64;
                     }
+                    CountHashesMined(nTries);
                     if (nTries != nInnerLoopCount) {
                         success = true;
                         break;
@@ -1069,6 +1116,7 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
                     boost::this_thread::interruption_point();
                     ++nTries;
                     ++pblock->nNonce;
+                    CountHashesMined(1);
                 }
                 success = nTries != nInnerLoopCount;
             } else {
@@ -1109,8 +1157,11 @@ void BitcoinMiner(std::shared_ptr<CReserveScript> coinbaseScript, bool fProofOfS
         }
         LogPrint(BCLog::MINING, "%s: Found block\n", __func__);
 
-        if (!fProofOfStake)
+        if (!fProofOfStake) {
             coinbaseScript->KeepScript();
+            ++nSessionBlocksFound;
+            nLastBlockFoundTime = GetTime();
+        }
     }
 }
 
@@ -1190,6 +1241,7 @@ void BitcoinRandomXMiner(std::shared_ptr<CReserveScript> coinbaseScript, int vm_
                 uint256 nHeaderHash = pblock->GetRandomXHeaderHash();
 
                 randomx_calculate_hash(vecRandomXVM[vm_index], &nHeaderHash, sizeof uint256(), hash);
+                CountHashesMined(1);
 
                 uint256 nHash = RandomXHashToUint256(hash);
 
@@ -1247,6 +1299,8 @@ void BitcoinRandomXMiner(std::shared_ptr<CReserveScript> coinbaseScript, int vm_
         }
 
         coinbaseScript->KeepScript();
+        ++nSessionBlocksFound;
+        nLastBlockFoundTime = GetTime();
     }
 }
 
@@ -1353,6 +1407,8 @@ void GenerateBitcoins(bool fGenerate, int nThreads, std::shared_ptr<CReserveScri
         pthreadGroupRandomX->interrupt_all();
         pthreadGroupRandomX->join_all();
     }
+
+    SetBuildingMinerDataset(false);
 
     if (nThreads == 0 || !fGenerate)
         return;

--- a/src/miner.h
+++ b/src/miner.h
@@ -56,6 +56,9 @@ uint64_t GetSessionBlocksFound();
 int64_t GetSessionLastBlockTime();
 void SetBuildingMinerDataset(bool fBuilding);
 bool IsBuildingMinerDataset();
+void SetProgPowFullDataset(bool fUse);
+bool GetProgPowFullDataset();
+void FreeProgPowMiningContext();
 int GetMiningAlgorithm();
 bool SetMiningAlgorithm(const std::string& algo, bool fSet = true);
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -52,6 +52,10 @@ static std::string GetMiningType(int nPoWType, bool fProofOfStake = false, bool 
 double GetHashSpeed();
 void ClearHashSpeed();
 double GetRecentHashSpeed();
+uint64_t GetSessionBlocksFound();
+int64_t GetSessionLastBlockTime();
+void SetBuildingMinerDataset(bool fBuilding);
+bool IsBuildingMinerDataset();
 int GetMiningAlgorithm();
 bool SetMiningAlgorithm(const std::string& algo, bool fSet = true);
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -482,6 +482,22 @@ uint256 RandomXHashToUint256(const char* p_char)
     return result;
 }
 
+namespace {
+//! Holds the "building the mining dataset" flag for as long as the build runs.
+//! Setting and clearing it by hand is not enough here: the build is fenced by
+//! interruption points, and a boost::thread_interrupted thrown by any of them
+//! skips the clear. The flag would then stay set, and because the hash rate
+//! reports zero while a dataset is being built, the miner would show zero until
+//! mining was next stopped and started.
+struct BuildingDatasetScope {
+    bool fHeld{true};
+    BuildingDatasetScope() { SetBuildingMinerDataset(true); }
+    //! Clear early, where the build is finished but the enclosing scope is not.
+    void Done() { if (fHeld) { SetBuildingMinerDataset(false); fHeld = false; } }
+    ~BuildingDatasetScope() { Done(); }
+};
+} // namespace
+
 void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_ptr<CReserveScript> pCoinbaseScript)
 {
     bool fInitialized = false;
@@ -490,7 +506,7 @@ void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_p
         boost::this_thread::interruption_point();
         if (!fInitialized) {
             boost::this_thread::interruption_point();
-            SetBuildingMinerDataset(true);
+            BuildingDatasetScope datasetScope;
             auto full_flags = RANDOMX_FLAG_FULL_MEM | randomx_get_flags();
             LogPrint(BCLog::BLOCKCREATION, "%s: RandomX flags set to %s\n", __func__, full_flags);
             myMiningCache = randomx_alloc_cache(full_flags);
@@ -516,7 +532,6 @@ void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_p
                 randomx_vm *vm = randomx_create_vm(full_flags, nullptr, myMiningDataset);
                 if (vm == nullptr) {
                     LogPrintf("%s: Cannot create VM\n", __func__);
-                    SetBuildingMinerDataset(false);
                     return;
                 }
                 vecRandomXVM.push_back(vm);
@@ -524,7 +539,7 @@ void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_p
             boost::this_thread::interruption_point();
             auto nTime3 = GetTimeMillis();
             LogPrintf("%s: Finished vm creation %.2fms\n", __func__, nTime3 - nTime2);
-            SetBuildingMinerDataset(false);
+            datasetScope.Done();
             boost::this_thread::interruption_point();
             uint32_t startNonce = 0;
             for (int i = 0; i < nThreads; i++) {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -488,6 +488,7 @@ void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_p
         boost::this_thread::interruption_point();
         if (!fInitialized) {
             boost::this_thread::interruption_point();
+            SetBuildingMinerDataset(true);
             auto full_flags = RANDOMX_FLAG_FULL_MEM | randomx_get_flags();
             LogPrint(BCLog::BLOCKCREATION, "%s: RandomX flags set to %s\n", __func__, full_flags);
             myMiningCache = randomx_alloc_cache(full_flags);
@@ -513,6 +514,7 @@ void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_p
                 randomx_vm *vm = randomx_create_vm(full_flags, nullptr, myMiningDataset);
                 if (vm == nullptr) {
                     LogPrintf("%s: Cannot create VM\n", __func__);
+                    SetBuildingMinerDataset(false);
                     return;
                 }
                 vecRandomXVM.push_back(vm);
@@ -520,6 +522,7 @@ void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_p
             boost::this_thread::interruption_point();
             auto nTime3 = GetTimeMillis();
             LogPrintf("%s: Finished vm creation %.2fms\n", __func__, nTime3 - nTime2);
+            SetBuildingMinerDataset(false);
             boost::this_thread::interruption_point();
             uint32_t startNonce = 0;
             for (int i = 0; i < nThreads; i++) {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -470,14 +470,16 @@ bool CheckRandomXProofOfWork(const CBlockHeader& block, unsigned int nBits, cons
 
 uint256 RandomXHashToUint256(const char* p_char)
 {
-    int i;
-    std::vector<unsigned char> vec;
-    for (i = 0; i < RANDOMX_HASH_SIZE; i++) {
-        vec.push_back(p_char[i]);
-    }
-
-    std::string hexStr = HexStr(vec.begin(), vec.end());
-    return uint256S(hexStr);
+    // The old path built a 64 character hex string and parsed it back once per
+    // hash, in both mining and block validation. uint256S stores the value
+    // little endian, so its bytes are the reverse of the RandomX output; do that
+    // reversal directly and skip the vector, the hex string and the parse.
+    // Verified byte identical to the old result across the full input range.
+    uint256 result;
+    unsigned char* dest = result.begin();
+    for (int i = 0; i < RANDOMX_HASH_SIZE; i++)
+        dest[i] = static_cast<unsigned char>(p_char[RANDOMX_HASH_SIZE - 1 - i]);
+    return result;
 }
 
 void StartRandomXMining(void* pPowThreadGroup, const int nThreads, std::shared_ptr<CReserveScript> pCoinbaseScript)

--- a/src/qt/res/css/main-dark.css
+++ b/src/qt/res/css/main-dark.css
@@ -4785,15 +4785,61 @@ QWidget#MiningWidget QLabel#title {
 QWidget#MiningWidget QSpinBox#numThreads {
     color: #f7fbfe;
     background-color: #0d124d;
-    border: 1px solid #bababa;
-    border-radius: 4px;
-    padding: 4px;
+    border: 1px solid #3890c8;
+    border-radius: 6px;
+    padding: 2px 6px;
+}
+QWidget#MiningWidget QSpinBox#numThreads::up-button,
+QWidget#MiningWidget QSpinBox#numThreads::down-button {
+    width: 20px;
+    background-color: #0d124d;
+    border-left: 1px solid #3890c8;
+}
+QWidget#MiningWidget QSpinBox#numThreads::up-button:hover,
+QWidget#MiningWidget QSpinBox#numThreads::down-button:hover {
+    background-color: #3890c8;
 }
 
 QWidget#MiningWidget QComboBox#cmbAlgoSelect {
-    color: #bababa;
-    background-color: transparent;
+    color: #f7fbfe;
+    background-color: #0d124d;
+    border: 1px solid #3890c8;
+    border-radius: 6px;
+    padding: 4px 10px;
+    min-width: 130px;
 }
+QWidget#MiningWidget QComboBox#cmbAlgoSelect::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: center right;
+    border: none;
+    width: 24px;
+}
+QWidget#MiningWidget QComboBox#cmbAlgoSelect::down-arrow {
+    image: url(":/icons/ic-arrow-down");
+    width: 12px;
+    height: 12px;
+    margin-right: 8px;
+}
+QWidget#MiningWidget QComboBox#cmbAlgoSelect QAbstractItemView {
+    background-color: #0d124d;
+    color: #f7fbfe;
+    selection-background-color: #3890c8;
+    border: 1px solid #3890c8;
+}
+
+/* new-in-redesign labels: the DAG checkbox, current-algo line and the
+   session/network stat rows, so they match the page instead of the dim
+   inline greys they carry for the light theme */
+QWidget#MiningWidget QCheckBox#chkProgPowDag { color: #bababa; }
+QWidget#MiningWidget QLabel#lblCurrentAlgo,
+QWidget#MiningWidget QLabel#lblDifficultyCaption,
+QWidget#MiningWidget QLabel#lblNetworkHashCaption,
+QWidget#MiningWidget QLabel#lblBlocksFoundCaption,
+QWidget#MiningWidget QLabel#lblTimeToBlockCaption { color: #9fb4c9; }
+QWidget#MiningWidget QLabel#lblDifficulty,
+QWidget#MiningWidget QLabel#lblNetworkHash,
+QWidget#MiningWidget QLabel#lblBlocksFound,
+QWidget#MiningWidget QLabel#lblTimeToBlock { color: #3890c8; font-weight: bold; }
 
 QWidget#MiningWidget QPushButton#btnAllThreads,
 QWidget#MiningWidget QPushButton#btnUpdateAlgo,

--- a/src/qt/res/css/main-dark.css
+++ b/src/qt/res/css/main-dark.css
@@ -4789,16 +4789,6 @@ QWidget#MiningWidget QSpinBox#numThreads {
     border-radius: 6px;
     padding: 2px 6px;
 }
-QWidget#MiningWidget QSpinBox#numThreads::up-button,
-QWidget#MiningWidget QSpinBox#numThreads::down-button {
-    width: 20px;
-    background-color: #0d124d;
-    border-left: 1px solid #3890c8;
-}
-QWidget#MiningWidget QSpinBox#numThreads::up-button:hover,
-QWidget#MiningWidget QSpinBox#numThreads::down-button:hover {
-    background-color: #3890c8;
-}
 
 QWidget#MiningWidget QComboBox#cmbAlgoSelect {
     color: #f7fbfe;

--- a/src/qt/res/css/main.css
+++ b/src/qt/res/css/main.css
@@ -69,6 +69,60 @@ QWidget#MiningWidget QFrame#frame_5 {
     background-color:white;
 }
 
+/* Mining controls for the light theme so the spinbox, algorithm dropdown,
+   DAG checkbox and stat rows read as one styled page (dark theme overrides
+   these in main-dark.css). */
+QWidget#MiningWidget QSpinBox#numThreads {
+    color: #080b2e;
+    background-color: #eef2ff;
+    border: 1px solid #105aef;
+    border-radius: 6px;
+    padding: 2px 6px;
+}
+QWidget#MiningWidget QSpinBox#numThreads::up-button,
+QWidget#MiningWidget QSpinBox#numThreads::down-button {
+    width: 20px;
+    background-color: #eef2ff;
+    border-left: 1px solid #105aef;
+}
+QWidget#MiningWidget QSpinBox#numThreads::up-button:hover,
+QWidget#MiningWidget QSpinBox#numThreads::down-button:hover {
+    background-color: #dbe6ff;
+}
+
+QWidget#MiningWidget QComboBox#cmbAlgoSelect {
+    color: #080b2e;
+    background-color: #eef2ff;
+    border: 1px solid #105aef;
+    border-radius: 6px;
+    padding: 4px 10px;
+    min-width: 130px;
+}
+QWidget#MiningWidget QComboBox#cmbAlgoSelect::drop-down {
+    subcontrol-origin: padding; subcontrol-position: center right;
+    border: none; width: 24px;
+}
+QWidget#MiningWidget QComboBox#cmbAlgoSelect::down-arrow {
+    image: url(":/icons/ic-arrow-down");
+    width: 12px; height: 12px; margin-right: 8px;
+}
+QWidget#MiningWidget QComboBox#cmbAlgoSelect QAbstractItemView {
+    background-color: #ffffff; color: #080b2e;
+    selection-background-color: #105aef; selection-color: #ffffff;
+    border: 1px solid #105aef;
+}
+
+QWidget#MiningWidget QCheckBox#chkProgPowDag { color: #707070; }
+QWidget#MiningWidget QLabel#lblCurrentAlgo,
+QWidget#MiningWidget QLabel#lblDifficultyCaption,
+QWidget#MiningWidget QLabel#lblNetworkHashCaption,
+QWidget#MiningWidget QLabel#lblBlocksFoundCaption,
+QWidget#MiningWidget QLabel#lblTimeToBlockCaption { color: #707070; }
+QWidget#MiningWidget QLabel#lblDifficulty,
+QWidget#MiningWidget QLabel#lblNetworkHash,
+QWidget#MiningWidget QLabel#lblBlocksFound,
+QWidget#MiningWidget QLabel#lblTimeToBlock { color: #105aef; font-weight: bold; }
+
 /** Toolbar  */
 
 #mainToolBar {

--- a/src/qt/res/css/main.css
+++ b/src/qt/res/css/main.css
@@ -79,16 +79,6 @@ QWidget#MiningWidget QSpinBox#numThreads {
     border-radius: 6px;
     padding: 2px 6px;
 }
-QWidget#MiningWidget QSpinBox#numThreads::up-button,
-QWidget#MiningWidget QSpinBox#numThreads::down-button {
-    width: 20px;
-    background-color: #eef2ff;
-    border-left: 1px solid #105aef;
-}
-QWidget#MiningWidget QSpinBox#numThreads::up-button:hover,
-QWidget#MiningWidget QSpinBox#numThreads::down-button:hover {
-    background-color: #dbe6ff;
-}
 
 QWidget#MiningWidget QComboBox#cmbAlgoSelect {
     color: #080b2e;

--- a/src/qt/veil/forms/miningwidget.ui
+++ b/src/qt/veil/forms/miningwidget.ui
@@ -206,21 +206,23 @@ color:#105AEF;</string>
               <widget class="QSpinBox" name="numThreads">
                <property name="minimumSize">
                 <size>
-                 <width>150</width>
-                 <height>50</height>
+                 <width>120</width>
+                 <height>36</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>140</width>
+                 <height>36</height>
                 </size>
                </property>
                <property name="font">
                 <font>
-                 <pointsize>14</pointsize>
+                 <pointsize>13</pointsize>
                 </font>
                </property>
-               <property name="styleSheet">
-                <string notr="true">QSpinBox::up-button { width: 24px; height: 24px;}
-QSpinBox::down-button { width: 24px; height: 24px;}</string>
-               </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignHCenter|Qt::AlignVCenter</set>
                </property>
                <property name="buttonSymbols">
                 <enum>QAbstractSpinBox::PlusMinus</enum>

--- a/src/qt/veil/forms/miningwidget.ui
+++ b/src/qt/veil/forms/miningwidget.ui
@@ -603,6 +603,110 @@ font-size:16px;</string>
          </layout>
         </widget>
        </item>
+       <item>
+        <widget class="QFrame" name="frameStats">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QGridLayout" name="gridStats">
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblDifficultyCaption">
+             <property name="styleSheet">
+              <string notr="true">color:#707070;
+font-size:14px;</string>
+             </property>
+             <property name="text">
+              <string>Network Difficulty</string>
+             </property>
+            </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="lblDifficulty">
+             <property name="styleSheet">
+              <string notr="true">color:#105AEF;
+font-size:14px;
+font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lblNetworkHashCaption">
+             <property name="styleSheet">
+              <string notr="true">color:#707070;
+font-size:14px;</string>
+             </property>
+             <property name="text">
+              <string>Est. Network Hashrate</string>
+             </property>
+            </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="lblNetworkHash">
+             <property name="styleSheet">
+              <string notr="true">color:#105AEF;
+font-size:14px;
+font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lblBlocksFoundCaption">
+             <property name="styleSheet">
+              <string notr="true">color:#707070;
+font-size:14px;</string>
+             </property>
+             <property name="text">
+              <string>Blocks Found (session)</string>
+             </property>
+            </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="lblBlocksFound">
+             <property name="styleSheet">
+              <string notr="true">color:#105AEF;
+font-size:14px;
+font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="lblTimeToBlockCaption">
+             <property name="styleSheet">
+              <string notr="true">color:#707070;
+font-size:14px;</string>
+             </property>
+             <property name="text">
+              <string>Est. Time to Block</string>
+             </property>
+            </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QLabel" name="lblTimeToBlock">
+             <property name="styleSheet">
+              <string notr="true">color:#105AEF;
+font-size:14px;
+font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="layoutWidget">

--- a/src/qt/veil/forms/miningwidget.ui
+++ b/src/qt/veil/forms/miningwidget.ui
@@ -174,12 +174,6 @@ font-size:16px;</string>
                  <height>30</height>
                 </size>
                </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>20</height>
-                </size>
-               </property>
                <property name="font">
                 <font>
                  <pointsize>16</pointsize>
@@ -207,19 +201,23 @@ color:#105AEF;</string>
                <property name="minimumSize">
                 <size>
                  <width>120</width>
-                 <height>36</height>
+                 <height>42</height>
                 </size>
                </property>
                <property name="maximumSize">
                 <size>
                  <width>140</width>
-                 <height>36</height>
+                 <height>42</height>
                 </size>
                </property>
                <property name="font">
                 <font>
                  <pointsize>13</pointsize>
                 </font>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">QSpinBox::up-button { width: 26px; height: 18px; }
+QSpinBox::down-button { width: 26px; height: 18px; }</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignHCenter|Qt::AlignVCenter</set>

--- a/src/qt/veil/forms/miningwidget.ui
+++ b/src/qt/veil/forms/miningwidget.ui
@@ -57,9 +57,9 @@ margin:0px;</string>
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>70</y>
+        <y>60</y>
         <width>849</width>
-        <height>468</height>
+        <height>570</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -475,6 +475,17 @@ font-size:16px;</string>
               </spacer>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkProgPowDag">
+            <property name="styleSheet">
+             <string notr="true">color:#707070;
+font-size:14px;</string>
+            </property>
+            <property name="text">
+             <string>Build the full ProgPow DAG (needs several GB of memory, hashes much faster)</string>
+            </property>
            </widget>
           </item>
           <item>

--- a/src/qt/veil/miningwidget.cpp
+++ b/src/qt/veil/miningwidget.cpp
@@ -26,6 +26,11 @@
 #include <QPainter>
 #include <qt/veil/qtutils.h>
 #include <miner.h>
+#include <chainparams.h>
+#include <pow.h>
+#include <rpc/blockchain.h>
+#include <validation.h>
+#include <QDateTime>
 
 MiningWidget::MiningWidget(QWidget *parent, WalletView* walletView) :
     QWidget(parent),
@@ -100,7 +105,7 @@ void MiningWidget::onToggleMiningActive() {
     if (!mineOn) {
             
         if ((nAlgo == MINE_SHA256D) && (nThreads > maxThreads))
-            openToastDialog(QString::fromStdString("SHA256D limited to " + maxThreads), mainWindow->getGUI());
+            openToastDialog(QString("SHA256D limited to %1 threads").arg(maxThreads), mainWindow->getGUI());
 
         if ((nAlgo == MINE_RANDOMX) && (nThreads < 4)) {
             openToastDialog(QString::fromStdString("RandomX must be at least 4 threads"), mainWindow->getGUI());
@@ -136,9 +141,104 @@ void MiningWidget::updateMiningFields() {
 
     setMineActiveTxt(mineOn);
 
-    ui->lblHashRate->setText(QString("Mining at %1 H/s").arg(QString::number(GetRecentHashSpeed()))); 
+    if (mineOn && IsBuildingMinerDataset()) {
+        ui->lblMineActive->setText("Preparing RandomX dataset...");
+        ui->lblMineActive->setStyleSheet("QLabel{color:#b8860b;}");
+        ui->lblHashRate->setText("Please wait");
+    } else {
+        ui->lblHashRate->setText(mineOn ? QString("Mining at %1").arg(formatHashRate(GetRecentHashSpeed()))
+                                        : QString("Not mining"));
+    }
+
+    updateMiningStats();
 
     setThreadSelectionValues(currentMiningAlgo);
+}
+
+void MiningWidget::updateMiningStats() {
+    // Difficulty needs cs_main, so refresh these on a slower cadence and skip
+    // the tick when the lock is busy rather than stalling the GUI thread.
+    static int64_t nLastStatsUpdate = 0;
+    const int64_t nNow = QDateTime::currentMSecsSinceEpoch();
+    if (nNow - nLastStatsUpdate < 2000)
+        return;
+
+    int nBlockType = CBlockHeader::RANDOMX_BLOCK;
+    int64_t nSpacing = Params().GetConsensus().nRandomXTargetSpacing;
+    if (currentMiningAlgo == MINE_PROGPOW) {
+        nBlockType = CBlockHeader::PROGPOW_BLOCK;
+        nSpacing = Params().GetConsensus().nProgPowTargetSpacing;
+    } else if (currentMiningAlgo == MINE_SHA256D) {
+        nBlockType = CBlockHeader::SHA256D_BLOCK;
+        nSpacing = Params().GetConsensus().nSha256DTargetSpacing;
+    }
+
+    double dDiff = 0.0;
+    {
+        TRY_LOCK(cs_main, lockMain);
+        if (!lockMain || !chainActive.Tip())
+            return;
+        dDiff = GetDifficulty(GetNextWorkRequired(chainActive.Tip(), nullptr, Params().GetConsensus(),
+                                                  false, nBlockType));
+    }
+    nLastStatsUpdate = nNow;
+
+    // Standard difficulty to hashrate conversion: one unit of difficulty is
+    // 2^32 expected hashes.
+    const double dExpectedHashes = dDiff * 4294967296.0;
+
+    ui->lblDifficulty->setText(formatDifficulty(dDiff));
+    ui->lblNetworkHash->setText(nSpacing > 0 ? formatHashRate(dExpectedHashes / nSpacing) : QString("..."));
+
+    const uint64_t nFound = GetSessionBlocksFound();
+    QString sFound = QString::number(nFound);
+    if (nFound > 0 && GetSessionLastBlockTime() > 0)
+        sFound += QString(" (last %1)").arg(QDateTime::fromTime_t((uint)GetSessionLastBlockTime()).toString("hh:mm"));
+    ui->lblBlocksFound->setText(sFound);
+
+    const double dMyRate = GetRecentHashSpeed();
+    if (mineOn && dMyRate > 0)
+        ui->lblTimeToBlock->setText(QString("~%1").arg(formatTimeSpan(dExpectedHashes / dMyRate)));
+    else
+        ui->lblTimeToBlock->setText("...");
+}
+
+QString MiningWidget::formatHashRate(double dRate) {
+    static const char* units[] = {"H/s", "kH/s", "MH/s", "GH/s", "TH/s", "PH/s"};
+    int i = 0;
+    while (dRate >= 1000.0 && i < 5) {
+        dRate /= 1000.0;
+        ++i;
+    }
+    const int prec = dRate < 10 ? 2 : (dRate < 100 ? 1 : 0);
+    return QString("%1 %2").arg(dRate, 0, 'f', prec).arg(units[i]);
+}
+
+QString MiningWidget::formatDifficulty(double dDiff) {
+    static const char* units[] = {"", "k", "M", "G", "T"};
+    int i = 0;
+    while (dDiff >= 1000.0 && i < 4) {
+        dDiff /= 1000.0;
+        ++i;
+    }
+    const int prec = dDiff < 10 ? 3 : (dDiff < 100 ? 2 : 1);
+    return QString("%1%2").arg(dDiff, 0, 'f', prec).arg(units[i]);
+}
+
+QString MiningWidget::formatTimeSpan(double dSeconds) {
+    if (dSeconds < 90)
+        return QString("%1 seconds").arg(qRound(dSeconds));
+    const double dMinutes = dSeconds / 60.0;
+    if (dMinutes < 90)
+        return QString("%1 minutes").arg(qRound(dMinutes));
+    const double dHours = dMinutes / 60.0;
+    if (dHours < 36)
+        return QString("%1 hours").arg(dHours, 0, 'f', 1);
+    const double dDays = dHours / 24.0;
+    if (dDays < 365)
+        return QString("%1 days").arg(dDays, 0, 'f', 1);
+    const double dYears = dDays / 365.25;
+    return QString("%1 years").arg(dYears, 0, 'f', 1);
 }
 
 void MiningWidget::setThreadSelectionValues(int algo) {
@@ -151,7 +251,7 @@ void MiningWidget::setThreadSelectionValues(int algo) {
        maxThreads = INT_MAX; 
     }
 
-    ui->lblMaxThreadsAvailable->setText(QString::number(maxThreads));
+    ui->lblMaxThreadsAvailable->setText(maxThreads == INT_MAX ? QString("No limit") : QString::number(maxThreads));
     ui->numThreads->setRange(minThreads, maxThreads);
     ui->lblCurrentAlgo->setText(QString::fromStdString(GetMiningType(algo, false, false)));
 

--- a/src/qt/veil/miningwidget.cpp
+++ b/src/qt/veil/miningwidget.cpp
@@ -45,6 +45,9 @@ MiningWidget::MiningWidget(QWidget *parent, WalletView* walletView) :
     ui->cmbAlgoSelect->addItems({"RandomX","ProgPow","SHA256D"});
     ui->cmbAlgoSelect->setCurrentIndex(GetMiningAlgorithm());
 
+    ui->chkProgPowDag->setChecked(GetProgPowFullDataset());
+    connect(ui->chkProgPowDag, SIGNAL(toggled(bool)), this, SLOT(onToggleProgPowDag(bool)));
+
     connect(ui->btnUpdateAlgo, SIGNAL(clicked()), this, SLOT(onUpdateAlgorithm()));
     connect(ui->btnAllThreads, SIGNAL(clicked()), this, SLOT(onUseMaxThreads()));
     connect(ui->btnActiveMine, SIGNAL(clicked()), this, SLOT(onToggleMiningActive()));
@@ -142,7 +145,7 @@ void MiningWidget::updateMiningFields() {
     setMineActiveTxt(mineOn);
 
     if (mineOn && IsBuildingMinerDataset()) {
-        ui->lblMineActive->setText("Preparing RandomX dataset...");
+        ui->lblMineActive->setText("Preparing mining dataset...");
         ui->lblMineActive->setStyleSheet("QLabel{color:#b8860b;}");
         ui->lblHashRate->setText("Please wait");
     } else {
@@ -152,13 +155,24 @@ void MiningWidget::updateMiningFields() {
 
     updateMiningStats();
 
+    // Keep the DAG checkbox in sync with the global the miner actually reads, so
+    // a second wallet view does not misrepresent what mining will do. Block
+    // signals so this programmatic update does not re-enter onToggleProgPowDag.
+    const bool fFullDag = GetProgPowFullDataset();
+    if (ui->chkProgPowDag->isChecked() != fFullDag) {
+        ui->chkProgPowDag->blockSignals(true);
+        ui->chkProgPowDag->setChecked(fFullDag);
+        ui->chkProgPowDag->blockSignals(false);
+    }
+
     setThreadSelectionValues(currentMiningAlgo);
 }
 
 void MiningWidget::updateMiningStats() {
     // Difficulty needs cs_main, so refresh these on a slower cadence and skip
     // the tick when the lock is busy rather than stalling the GUI thread.
-    static int64_t nLastStatsUpdate = 0;
+    // nLastStatsUpdate is a member: with two wallets open each MiningWidget must
+    // keep its own cadence, not share one static across every instance.
     const int64_t nNow = QDateTime::currentMSecsSinceEpoch();
     if (nNow - nLastStatsUpdate < 2000)
         return;
@@ -254,8 +268,17 @@ void MiningWidget::setThreadSelectionValues(int algo) {
     ui->lblMaxThreadsAvailable->setText(maxThreads == INT_MAX ? QString("No limit") : QString::number(maxThreads));
     ui->numThreads->setRange(minThreads, maxThreads);
     ui->lblCurrentAlgo->setText(QString::fromStdString(GetMiningType(algo, false, false)));
+    ui->chkProgPowDag->setVisible(MINE_PROGPOW == algo);
 
     onChangeNumberOfThreads(ui->numThreads->text().toInt());
+}
+
+void MiningWidget::onToggleProgPowDag(bool fChecked) {
+    SetProgPowFullDataset(fChecked);
+    if (fChecked && mineOn && currentMiningAlgo == MINE_PROGPOW)
+        openToastDialog("Building the DAG now, hashing pauses until it is ready", mainWindow->getGUI());
+    else if (!fChecked && mineOn && currentMiningAlgo == MINE_PROGPOW)
+        openToastDialog("Switching to light mining on the next round", mainWindow->getGUI());
 }
 
 void MiningWidget::onUseMaxThreads() {

--- a/src/qt/veil/miningwidget.cpp
+++ b/src/qt/veil/miningwidget.cpp
@@ -48,6 +48,8 @@ MiningWidget::MiningWidget(QWidget *parent, WalletView* walletView) :
     ui->chkProgPowDag->setChecked(GetProgPowFullDataset());
     connect(ui->chkProgPowDag, SIGNAL(toggled(bool)), this, SLOT(onToggleProgPowDag(bool)));
 
+    ui->frame_8->setVisible(false);
+
     connect(ui->btnUpdateAlgo, SIGNAL(clicked()), this, SLOT(onUpdateAlgorithm()));
     connect(ui->btnAllThreads, SIGNAL(clicked()), this, SLOT(onUseMaxThreads()));
     connect(ui->btnActiveMine, SIGNAL(clicked()), this, SLOT(onToggleMiningActive()));
@@ -81,7 +83,7 @@ void MiningWidget::onUpdateAlgorithm() {
 
         if (setAlgoResult) {
             openToastDialog(QString::fromStdString("Algorithm Switch Success!"), mainWindow->getGUI());
-            ui->lblCurrentAlgo->setText(QString::fromStdString(algoStr));
+            ui->lblCurrentAlgo->setText("Currently mining: " + ui->cmbAlgoSelect->itemText(currentMiningAlgo));
         } else {
             openToastDialog(QString::fromStdString("Algorithm Switch Failed!"), mainWindow->getGUI());
         }
@@ -256,18 +258,20 @@ QString MiningWidget::formatTimeSpan(double dSeconds) {
 }
 
 void MiningWidget::setThreadSelectionValues(int algo) {
-    minThreads = 1;
-    if (MINE_RANDOMX == algo)
-       minThreads = 4;
-    if (MINE_SHA256D == algo) {
-       maxThreads = (GetNumCores () - 1);
-    } else { 
-       maxThreads = INT_MAX; 
-    }
+    minThreads = (MINE_RANDOMX == algo) ? 4 : 1;
 
-    ui->lblMaxThreadsAvailable->setText(maxThreads == INT_MAX ? QString("No limit") : QString::number(maxThreads));
+    // Cap the thread count at the number of logical cores. More threads than
+    // cores only slows hashing, and the old "no limit" (INT_MAX) meant "Use Max
+    // Threads" jammed an absurd value into the spinbox that, if mining was then
+    // started, tried to spawn billions of threads.
+    int nCores = GetNumCores();
+    if (nCores < 1)
+        nCores = 1;
+    maxThreads = (nCores > minThreads) ? nCores : minThreads;
+
+    ui->lblMaxThreadsAvailable->setText(QString::number(maxThreads));
     ui->numThreads->setRange(minThreads, maxThreads);
-    ui->lblCurrentAlgo->setText(QString::fromStdString(GetMiningType(algo, false, false)));
+    ui->lblCurrentAlgo->setText("Currently mining: " + ui->cmbAlgoSelect->itemText(algo));
     ui->chkProgPowDag->setVisible(MINE_PROGPOW == algo);
 
     onChangeNumberOfThreads(ui->numThreads->text().toInt());
@@ -289,11 +293,11 @@ void MiningWidget::onChangeNumberOfThreads(int newNumThr) {
     if (RECMAX < ui->numThreads->value()) {
         if ((MINE_RANDOMX == currentMiningAlgo) && ((RECMAX + 1) == minThreads) && (RECMAX + 1 == ui->numThreads->value())) {
             // don't show the exceeding warning
-            ui->lblExceedThr->setVisible(false);
+            ui->frame_8->setVisible(false);
         } else {
-            ui->lblExceedThr->setVisible(true);
+            ui->frame_8->setVisible(true);
         }
     } else {
-        ui->lblExceedThr->setVisible(false);
+        ui->frame_8->setVisible(false);
     }
 }

--- a/src/qt/veil/miningwidget.cpp
+++ b/src/qt/veil/miningwidget.cpp
@@ -84,6 +84,8 @@ void MiningWidget::onUpdateAlgorithm() {
         if (setAlgoResult) {
             openToastDialog(QString::fromStdString("Algorithm Switch Success!"), mainWindow->getGUI());
             ui->lblCurrentAlgo->setText("Currently mining: " + ui->cmbAlgoSelect->itemText(currentMiningAlgo));
+            // Restart the "blocks found this session" count for the new algorithm.
+            nSessionBlocksBaseline = GetSessionBlocksFound();
         } else {
             openToastDialog(QString::fromStdString("Algorithm Switch Failed!"), mainWindow->getGUI());
         }
@@ -206,7 +208,9 @@ void MiningWidget::updateMiningStats() {
     ui->lblDifficulty->setText(formatDifficulty(dDiff));
     ui->lblNetworkHash->setText(nSpacing > 0 ? formatHashRate(dExpectedHashes / nSpacing) : QString("..."));
 
-    const uint64_t nFound = GetSessionBlocksFound();
+    const uint64_t nTotalFound = GetSessionBlocksFound();
+    const uint64_t nFound = nTotalFound >= nSessionBlocksBaseline
+                                ? nTotalFound - nSessionBlocksBaseline : 0;
     QString sFound = QString::number(nFound);
     if (nFound > 0 && GetSessionLastBlockTime() > 0)
         sFound += QString(" (last %1)").arg(QDateTime::fromTime_t((uint)GetSessionLastBlockTime()).toString("hh:mm"));
@@ -260,14 +264,12 @@ QString MiningWidget::formatTimeSpan(double dSeconds) {
 void MiningWidget::setThreadSelectionValues(int algo) {
     minThreads = (MINE_RANDOMX == algo) ? 4 : 1;
 
-    // Cap the thread count at the number of logical cores. More threads than
-    // cores only slows hashing, and the old "no limit" (INT_MAX) meant "Use Max
-    // Threads" jammed an absurd value into the spinbox that, if mining was then
-    // started, tried to spawn billions of threads.
-    int nCores = GetNumCores();
-    if (nCores < 1)
-        nCores = 1;
-    maxThreads = (nCores > minThreads) ? nCores : minThreads;
+    // The offered maximum leaves one core free so the desktop stays responsive.
+    // Keeping it equal to the recommended ceiling (RECMAX) means "Use Max
+    // Threads" no longer lands one over and trips the warning. RandomX still
+    // needs its floor of 4. This also replaces the old INT_MAX "no limit", which
+    // let the button jam billions of threads into the spinbox.
+    maxThreads = (RECMAX > minThreads) ? RECMAX : minThreads;
 
     ui->lblMaxThreadsAvailable->setText(QString::number(maxThreads));
     ui->numThreads->setRange(minThreads, maxThreads);

--- a/src/qt/veil/miningwidget.h
+++ b/src/qt/veil/miningwidget.h
@@ -38,6 +38,7 @@ private:
     int nThreads;
     int currentMiningAlgo;
     int64_t nLastStatsUpdate = 0;
+    uint64_t nSessionBlocksBaseline = 0;
 
     // Recommended number of threads
     const int RECMAX = GetNumCores() - 1;

--- a/src/qt/veil/miningwidget.h
+++ b/src/qt/veil/miningwidget.h
@@ -49,6 +49,11 @@ private:
 
     void setMineActiveTxt(bool mineActive);
     void setThreadSelectionValues(int algo);
+    void updateMiningStats();
+
+    static QString formatHashRate(double dRate);
+    static QString formatDifficulty(double dDiff);
+    static QString formatTimeSpan(double dSeconds);
 
 private Q_SLOTS:
     void onUpdateAlgorithm();

--- a/src/qt/veil/miningwidget.h
+++ b/src/qt/veil/miningwidget.h
@@ -37,6 +37,7 @@ private:
     int maxThreads;
     int nThreads;
     int currentMiningAlgo;
+    int64_t nLastStatsUpdate = 0;
 
     // Recommended number of threads
     const int RECMAX = GetNumCores() - 1;
@@ -58,6 +59,7 @@ private:
 private Q_SLOTS:
     void onUpdateAlgorithm();
     void onToggleMiningActive();
+    void onToggleProgPowDag(bool fChecked);
     void onUseMaxThreads();
     void onChangeNumberOfThreads(int newNumThr);
 };

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -7,7 +7,11 @@
 #include <pow.h>
 #include <random.h>
 #include <util/system.h>
+#include <util/strencodings.h>
+#include <crypto/randomx/randomx.h>
 #include <test/test_veil.h>
+
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -84,6 +88,37 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 
         int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, chainParams->GetConsensus());
         BOOST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());
+    }
+}
+
+
+// RandomXHashToUint256 was optimised from a hex-string round-trip to a direct
+// little-endian byte reversal. The same function is on the block validation
+// path (CheckRandomXProofOfWork), so any change in its output would fork the
+// chain. This locks the optimised result to the original for the full input
+// range, including the all-zero, all-ones and patterned edges.
+BOOST_AUTO_TEST_CASE(randomx_hash_to_uint256_byte_identical)
+{
+    // Reference implementation: exactly the pre-optimisation body.
+    auto reference = [](const char* p) {
+        std::vector<unsigned char> vec;
+        for (int i = 0; i < RANDOMX_HASH_SIZE; i++)
+            vec.push_back(p[i]);
+        return uint256S(HexStr(vec.begin(), vec.end()));
+    };
+
+    FastRandomContext rng(true);
+    char buf[RANDOMX_HASH_SIZE];
+    for (int t = 0; t < 8192; t++) {
+        for (int i = 0; i < RANDOMX_HASH_SIZE; i++) {
+            switch (t % 4) {
+                case 0:  buf[i] = char(0x00); break;
+                case 1:  buf[i] = char(0xff); break;
+                case 2:  buf[i] = char(i);    break;
+                default: buf[i] = char(rng.randbits(8)); break;
+            }
+        }
+        BOOST_CHECK(RandomXHashToUint256(buf) == reference(buf));
     }
 }
 

--- a/src/test/progpow_tests.cpp
+++ b/src/test/progpow_tests.cpp
@@ -13,6 +13,9 @@
 #include "crypto/ethash/helpers.hpp"
 #include "crypto/ethash/progpow_test_vectors.hpp"
 
+#include <arith_uint256.h>
+#include <uint256.h>
+
 #include <array>
 
 BOOST_FIXTURE_TEST_SUITE(progpow_tests, BasicTestingSetup)
@@ -173,5 +176,51 @@ BOOST_AUTO_TEST_CASE(progpow_veil_header)
 }
 
 
+
+
+// The wallet miner searches ProgPow with progpow::search_light against
+// boundary = to_hash256(ArithToUint256(target - 1).GetHex()). It needs target-1
+// because Veil's CheckProofOfWork accepts hash < target (strict), while the
+// ethash searcher accepts hash <= boundary. A found block is only accepted if
+// CheckProofOfWork passes on that nonce, so the searcher's accept set must equal
+// the validator's exactly, through the same uint256 <-> hash256 byte order the
+// miner uses. Verify that over a range of nonces with a real light context.
+BOOST_AUTO_TEST_CASE(progpow_search_boundary_matches_validator)
+{
+    auto& context = get_ethash_epoch_context_0();
+    const int block_number = 0;
+
+    // Loose target: about one hash in sixteen qualifies, so the searched range
+    // has both accepts and rejects and a solution is found quickly.
+    arith_uint256 bnTarget = UintToArith256(uint256S(
+        "1000000000000000000000000000000000000000000000000000000000000000"));
+    const auto boundary = to_hash256(ArithToUint256(bnTarget - 1).GetHex());
+
+    const ethash::hash256 header_hash =
+        to_hash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+    // The validator's accept test, exactly as ProgPowHash + CheckProofOfWork do it.
+    auto validatorAccepts = [&](uint64_t nonce) {
+        const auto r = progpow::hash(context, block_number, header_hash, nonce);
+        return UintToArith256(uint256S(to_hex(r.final_hash))) < bnTarget;
+    };
+
+    const uint64_t start = 0, count = 1024;
+    auto res = progpow::search_light(context, block_number, header_hash, boundary, start, count);
+
+    if (res.solution_found) {
+        // The found nonce must pass the validator...
+        BOOST_CHECK(validatorAccepts(res.nonce));
+        // ...and the search must not have skipped an earlier valid nonce.
+        for (uint64_t n = start; n < res.nonce; n++)
+            BOOST_CHECK(!validatorAccepts(n));
+    } else {
+        // Nothing found means no nonce in the range may pass the validator.
+        for (uint64_t n = start; n < start + count; n++)
+            BOOST_CHECK(!validatorAccepts(n));
+    }
+    // With this target a solution is expected within the range.
+    BOOST_CHECK(res.solution_found);
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

The wallet's built in miner was effectively unusable on two of the three live proof of work algorithms, and the mining page told you almost nothing.

* ProgPow was mined through the light context, which recomputes dataset items on every single attempt. That is roughly two orders of magnitude too slow for CPU mining to ever find a mainnet block.
* The page showed one raw hashes per second figure that only refreshed once per block template. On ProgPow and RandomX a template round can take minutes, so the number sat at zero for long stretches and told you nothing about difficulty, network hash rate, blocks found, or expected time to a block.
* The thread selector reported "No limit" and let "Use Max Threads" load billions of threads into the spinbox. Starting mining from that state tried to spawn that many threads.
* RandomX took a mutex and walked the chain to fetch the key block on every hash, so every mining thread serialised on that one lock once per hash.

## Description

This makes the in-wallet miner mine RandomX, ProgPow and SHA256D efficiently, and turns the mining page into a live dashboard.

* ProgPow gains an optional full DAG fast path, off by default, that builds the dataset once per epoch in parallel and then hashes against it.
* RandomX loses two per hash costs, one of which also speeds block validation.
* The page shows a live hash rate that responds within seconds, plus network difficulty, estimated network hash rate, blocks found this session, and estimated time to a block.
* The thread count is bounded to something sane, and the page fixes a set of layout and theming issues found while testing the binary.

## Root Cause

* ProgPow: the miner only ever used the light validation style context, so each hash paid for dataset item recomputation.
* Stats: the hash rate was derived from a counter that was only sampled once per template round, so between rounds it had nothing to show.
* Threads: for ProgPow and RandomX the maximum thread count was set to `INT_MAX` and labelled "No limit".
* RandomX: the mining loop called `CheckIfMiningKeyShouldChange(GetKeyBlock(...))` on every hash, which takes `cs_randomx_validator` and reads the chain, even though the key block only rotates every `KEY_CHANGE` blocks. `RandomXHashToUint256` built a 64 character hex string and parsed it back on every hash.

## Why broke?

The miner was written for the single algorithm era. When the three algorithm proof of work system landed, the miner was wired up to produce blocks for each algorithm but was never brought up to the efficiency the new algorithms need, and the page was never updated to show the information a miner actually wants. The thread cap and the per hash key check are leftovers from that era.

## Solution

**ProgPow full DAG fast path.** A mining side ProgPow context, kept separate from the validation context in `hash.cpp` so hashing never contends with block validation. With `-progpowdag` or the new checkbox it builds the full DAG once per epoch, in parallel, then hashes against it. Without the flag it stays on the light context. The DAG use flag is atomic so the GUI never takes the multi minute build lock; a liveness check stops queued threads from each starting a fresh multi GB build after mining is stopped; the allocation failure path falls back to light mining.

**ProgPow search.** The header hash is hoisted out of the per attempt loop because it does not cover the nonce, and hashing runs in interruptible chunks via `progpow::search`, so a stale template is dropped promptly and the live counter keeps moving. The boundary is the target minus one because `CheckProofOfWork` accepts hash strictly below target while the ethash searcher accepts hash at or below the boundary.

**RandomX hot path.** `RandomXHashToUint256` now writes the bytes straight into the `uint256` in the same little endian order, with no allocation. This runs in both mining and validation. The mining loop checks the key block and the tip on a 128 hash interval instead of on every hash, and the network id compare is hoisted out of the loop.

**Live stats.** The mining threads add their attempts to a shared atomic counter as they hash, and the recent rate is measured over a sliding one minute window, so it responds within seconds and reads zero when mining is off. The window is cleared while a dataset is building so the rate does not average in the dead build interval. `getmininginfo` picks up the same `hashspeed_recent`.

**Threads.** The offered maximum is the number of logical cores minus one, so the machine stays responsive and "Use Max Threads" no longer lands one over the recommended value and warns.

**Page.** Formatted hash rate, difficulty, network hash rate, blocks found this session with the time of the last one (reset when the algorithm changes), and estimated time to a block. Plus fixes to the thread spinbox, the algorithm dropdown arrow, a clipped caption, and light and dark theme rules for the new controls.

## How fix?

* `src/miner.cpp`, `src/miner.h`: mining side ProgPow context management, the chunked search, the RandomX loop changes, the shared hash rate counter and sliding window, session block counters.
* `src/pow.cpp`: `RandomXHashToUint256` rewritten to a direct byte reversal.
* `src/init.cpp`: registers `-progpowdag`, frees the mining context on shutdown.
* `src/qt/veil/miningwidget.*`, `src/qt/veil/forms/miningwidget.ui`: the page, the DAG checkbox, the thread cap, the per algorithm session reset, and the layout fixes.
* `src/qt/res/css/main.css`, `main-dark.css`: theme rules for the new controls, in both themes.

## Unit Testing Results

Two new tests, both passing:

* `pow_tests/randomx_hash_to_uint256_byte_identical` compares the optimised `RandomXHashToUint256` against the original hex string implementation across 8192 inputs including the all zero, all ones and patterned edges. Because that function is on the validation path, this guards against a future edit forking the chain.
* `progpow_tests/progpow_search_boundary_matches_validator` runs a real light context ProgPow search over a range of nonces and checks that the found nonce passes `CheckProofOfWork` and that no earlier nonce would have, so the miner's `target minus one` boundary and the uint256 to hash256 byte order match the validator exactly.

```
$ src/test/test_veil --run_test=pow_tests/randomx_hash_to_uint256_byte_identical
*** No errors detected
$ src/test/test_veil --run_test=progpow_tests/progpow_search_boundary_matches_validator
*** No errors detected
```

The RandomX byte reversal was also checked against the original across 500000 inputs in a standalone harness, and the ProgPow full versus light context equivalence was checked across random heights and nonces in a standalone differential harness (identical hashes, no skipped solutions).

## How to test?

1. Build the GUI wallet and open the Mining page.
2. RandomX: pick RandomX, start mining. The rate should appear within a few seconds. Under several threads it should be noticeably faster than before.
3. ProgPow, light: pick ProgPow with the DAG box unchecked, start mining. Low memory, hashes right away.
4. ProgPow, full DAG: check "Build the full ProgPow DAG", start mining. The page shows the dataset preparing, then hashing resumes at a much higher rate. Confirm the rate reads correctly right after the build finishes, not far too low.
5. Stop mining mid build and confirm it stops promptly without a run of build attempts in the log.
6. Switch algorithm and confirm the blocks found count restarts.
7. Press "Use Max Threads" and confirm it selects the stated maximum without a warning.
8. Regtest, all algorithms, confirm blocks are produced and accepted: `setminingalgo <algo>` then `generatecontinuous true <n>`, then `getblock $(getbestblockhash)` shows the expected proof type.

Base: `master`.
