### PR TITLE
Stop a confirmed transaction stuck in the mempool from halting block production

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -253,6 +253,18 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         addPackageTxs(nPackagesSelected, nDescendantsUpdated);
     }
 
+    // Sweep out anything selection found already confirmed. Nothing else will ever
+    // remove these: removeForBlock only fires for transactions in an arriving block,
+    // and one of these can never be in a future block. Done here, after the mempool
+    // lock above is released and selection has finished iterating, so no entry is
+    // erased while it is being walked.
+    for (const CTransactionRef& tx : vAlreadyInChain) {
+        mempool.removeRecursive(*tx, MemPoolRemovalReason::BLOCK);
+        LogPrintf("CreateNewBlock: removed already confirmed tx %s from the mempool\n",
+                  tx->GetHash().GetHex());
+    }
+    vAlreadyInChain.clear();
+
     int64_t nTime1 = GetTimeMicros();
 
     nLastBlockTx = nBlockTx;
@@ -610,6 +622,23 @@ bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& packa
             return false;
         if (!fIncludeWitness && it->GetTx().HasWitness())
             return false;
+        // A transaction that is already in a block must never be selected again. Its
+        // outputs are in the UTXO set, so ConnectBlock's BIP30 check rejects the whole
+        // block ("tried to overwrite transaction") and TestBlockValidity fails, which
+        // means the node produces no block at all rather than one block missing one
+        // transaction. This is the same predicate ConnectBlock uses, so a template can
+        // no longer be poisoned by a single stale mempool entry. Seen on testnet: one
+        // confirmed zerocoin spend that stayed in the mempool cost the node every block
+        // it won for three and a half days.
+        const CTransaction& tx = it->GetTx();
+        for (size_t o = 0; o < tx.GetNumVOuts(); o++) {
+            if (pcoinsTip->HaveCoin(COutPoint(tx.GetHash(), o))) {
+                LogPrintf("%s: skipping %s, already confirmed but still in the mempool\n",
+                          __func__, tx.GetHash().GetHex());
+                vAlreadyInChain.push_back(it->GetSharedTx());
+                return false;
+            }
+        }
     }
     return true;
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -191,6 +191,10 @@ private:
     uint64_t nBlockSigOpsCost;
     CAmount nFees;
     CTxMemPool::setEntries inBlock;
+    // Mempool entries that are already confirmed on chain. Including one costs us the
+    // whole block (ConnectBlock rejects it as bad-txns-BIP30), so they are skipped
+    // during selection and swept out of the mempool once selection is finished.
+    std::vector<CTransactionRef> vAlreadyInChain;
 
     // Chain context for the block
     int nHeight;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -531,4 +531,59 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 }
 */
 
+// A transaction that is already confirmed on chain must never be mineable again, and
+// must never be re-admitted to the mempool. If one ever lands in the mempool it is stuck
+// forever: ConnectBlock rejects any block containing it with bad-txns-BIP30, so the node
+// stops producing blocks entirely until the mempool is cleared. This happened on testnet
+// when a zerocoin spend was accepted into the mempool in the same instant its block
+// connected, and took the node's block production down for three and a half days.
+BOOST_AUTO_TEST_CASE(CreateNewBlock_skips_already_confirmed)
+{
+    const auto chainParams = CreateChainParams(CBaseChainParams::REGTEST);
+    const CChainParams& chainparams = *chainParams;
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    TestMemPoolEntryHelper entry;
+
+    // Build a transaction, then pretend its output is already in the UTXO set. That is
+    // exactly the state a confirmed-but-still-in-mempool transaction leaves behind, and
+    // exactly what the BIP30 check in ConnectBlock keys on.
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout = COutPoint(uint256S("0000000000000000000000000000000000000000000000000000000000000001"), 0);
+    tx.vin[0].scriptSig = CScript() << OP_11;
+    tx.vpout.resize(1);
+    tx.vpout[0] = MAKE_OUTPUT<CTxOutStandard>();
+    tx.vpout[0]->SetScriptPubKey(CScript() << OP_11 << OP_EQUAL);
+    tx.vpout[0]->SetValue(5000000000LL);
+    const uint256 txid = tx.GetHash();
+
+    {
+        LOCK(cs_main);
+        CTxOut out(5000000000LL, CScript() << OP_11 << OP_EQUAL);
+        pcoinsTip->AddCoin(COutPoint(txid, 0), Coin(std::move(out), 1, false), false);
+        BOOST_CHECK(pcoinsTip->HaveCoin(COutPoint(txid, 0)));
+    }
+
+    // Put it straight into the mempool, the way it got there in production: a tx accepted
+    // in the same instant its block connected, so removeForBlock had already run. This is
+    // the state the fix has to survive. addUnchecked bypasses acceptance so the coins-view
+    // state above is the only thing that matters.
+    {
+        LOCK(cs_main);
+        LOCK(mempool.cs);
+        mempool.addUnchecked(txid, entry.Fee(10000).FromTx(tx));
+        BOOST_CHECK(mempool.exists(txid));
+    }
+
+    // Before the fix, CreateNewBlock happily selected it and the resulting block was
+    // rejected by ConnectBlock as bad-txns-BIP30, so the node produced nothing. Now the
+    // assembler must skip it and sweep it out.
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+
+    for (const auto& btx : pblocktemplate->block.vtx)
+        BOOST_CHECK(btx->GetHash() != txid);   // not selected into the block
+    BOOST_CHECK(!mempool.exists(txid));         // and removed from the mempool
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -730,6 +730,24 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     if (fHasBasecoinInputs && fHasZerocoinInputs)
         return state.Invalid(error("%s: tx mixes zerocoin and basecoin inputs", __func__, REJECT_INVALID, "txn-mixed-zerocoin-inputs"));
 
+    // A transaction that is already confirmed must never enter the mempool. The
+    // "txn-already-known" check further down only runs when an input is missing from the
+    // UTXO set, and both the RingCT and the zerocoin branches of that loop `continue`
+    // before they reach it, so for those two a duplicate was never detected at all. One
+    // that gets in is stuck forever: it can never be mined, because ConnectBlock rejects
+    // any block holding it as bad-txns-BIP30, and nothing evicts it, because
+    // removeForBlock only fires for transactions in an arriving block. It then takes the
+    // node's whole block production down with it.
+    //
+    // This asks the chain UTXO set directly rather than the mempool backed view above,
+    // and deliberately not the cache only helper, since a node with a cold coins cache
+    // would miss it. Same predicate ConnectBlock uses, so this can never reject a
+    // transaction that a block would have accepted.
+    for (size_t o = 0; o < tx.GetNumVOuts(); o++) {
+        if (pcoinsTip->HaveCoin(COutPoint(hash, o)))
+            return state.Invalid(false, REJECT_DUPLICATE, "txn-already-known");
+    }
+
     std::vector<libzerocoin::SerialNumberSoKProof> vProofs;
     {
         CCoinsView dummy;


### PR DESCRIPTION
### Problem

A confirmed transaction that is also sitting in the mempool halts block production entirely. Seen on testnet: a zerocoin spend was accepted into the mempool in the same moment its block connected, and the node made no blocks for three and a half days.

### Description

Once a transaction is both confirmed and in the mempool, every template the node builds includes it, `ConnectBlock` rejects that template with `bad-txns-BIP30` because the outputs already exist in the UTXO set, `TestBlockValidity` fails, and `CreateNewBlock` returns nothing. The node wins nothing, forever, and nothing evicts the offending entry because `removeForBlock` only fires for transactions that arrive in a block.

### Root Cause

Two gaps. The mempool never rejected an already confirmed transaction on entry: the `txn-already-known` check in `AcceptToMemoryPool` only runs when an input is missing from the UTXO set, and both the RingCT and the zerocoin input branches `continue` before reaching it, so for those two a duplicate was never detected. And block assembly had no guard against selecting a transaction whose outputs are already on chain.

### Why broke?

The BIP30 rule is enforced at block connect time, on the assumption that such a transaction can never reach the template in the first place. For basecoin inputs that holds, because the duplicate is caught on mempool entry. For RingCT and zerocoin it does not, because their input loops skip the check, so the assumption quietly fails for exactly the transaction types Veil uses most.

### Solution

Reject an already confirmed transaction at mempool entry, and skip one during block assembly if it slips in anyway, removing it from the mempool afterward.

### How fix?

`AcceptToMemoryPoolWorker` now asks `pcoinsTip` directly whether any output of the transaction already exists, before the input specific branches, and rejects with `txn-already-known` if so. It queries the chain UTXO set rather than the cache only helper, so a node with a cold coins cache cannot miss it, and uses the same predicate `ConnectBlock` uses, so it can never reject a transaction a block would have accepted. `CreateNewBlock` applies the same check while selecting, skips a match, and removes it from the mempool once selection has finished iterating and the mempool lock is released.

### Unit Testing Results

`src/test/miner_tests.cpp` gains `CreateNewBlock_skips_already_confirmed`, which puts a confirmed transaction back into the mempool and asserts that block assembly still produces a valid template rather than failing. Passes locally against a debug build.

### How to test?

On regtest, mine a transaction into a block, then re-add it to the mempool through the internal path the test uses, and confirm the node keeps producing blocks. Before this change `CreateNewBlock` returns null and block production stops; after it, the confirmed transaction is skipped and removed.
