### PR TITLE
Wallet: restore addresses and complete locked receives automatically on seed import

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1134,7 +1134,11 @@ void BitcoinGUI::initWalletMenu(std::string& mnemonic, unsigned int& flag, bool&
 
             ret = !tutorial->ShutdownRequested();
             mnemonic = tutorial->GetMnemonic();
-            flag = MnemonicWalletInitFlags::IMPORT_MNEMONIC;
+            // IMPORT_MNEMONIC means the words came from the user (a restore), so the
+            // wallet must re-derive used addresses and rescan for their history.
+            // A freshly generated seed has no history to find.
+            flag = tutorial->IsRestoreSeed() ? MnemonicWalletInitFlags::IMPORT_MNEMONIC
+                                             : MnemonicWalletInitFlags::NEW_MNEMONIC;
             delete tutorial;
 
             break;

--- a/src/qt/veil/tutorialwidget.cpp
+++ b/src/qt/veil/tutorialwidget.cpp
@@ -141,6 +141,7 @@ void TutorialWidget::on_next_triggered(){
                             mnemonic += " " + q_word.toStdString();
                     }
 
+                    fRestoreSeed = true;
                     shutdown = false;
                     accept();
                 } else {

--- a/src/qt/veil/tutorialwidget.h
+++ b/src/qt/veil/tutorialwidget.h
@@ -36,6 +36,7 @@ public:
     std::string GetLanguageSelection() const;
     uint512 GetSeed() const { return seed; }
     std::string GetMnemonic() const {return mnemonic; }
+    bool IsRestoreSeed() const { return fRestoreSeed; }
 
 private Q_SLOTS:
     void on_next_triggered();
@@ -49,6 +50,7 @@ private:
     QStringList wordList;
 
     bool shutdown = true;
+    bool fRestoreSeed = false;
     MnemonicWalletInitFlags selection;
 
     TutorialMnemonicCode *tutorialMnemonicCode;

--- a/src/veil/mnemonic/mnemonicwalletinit.cpp
+++ b/src/veil/mnemonic/mnemonicwalletinit.cpp
@@ -29,6 +29,7 @@ bool MnemonicWalletInit::Open() const
 
     for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
         bool fNewSeed = false;
+        bool fRestoredSeed = false;
         uint512 hashMasterKey;
         fs::path walletPath = fs::absolute(walletFile, GetWalletDir());
         if ((walletFile == "" && !fs::exists(walletPath / "wallet.dat")) || !fs::exists(walletPath)) {
@@ -39,8 +40,10 @@ bool MnemonicWalletInit::Open() const
                 initOption = MnemonicWalletInitFlags::NEW_MNEMONIC;
 
             std::string strSeedPhraseArg = gArgs.GetArg("-importseed", "");
-            if (!strSeedPhraseArg.empty())
+            if (!strSeedPhraseArg.empty()) {
                 initOption = MnemonicWalletInitFlags::IMPORT_MNEMONIC;
+                fRestoredSeed = true;
+            }
 
             /**If no startup args, then launch prompt **/
             std::string strMessage = "english";
@@ -48,6 +51,9 @@ bool MnemonicWalletInit::Open() const
                 // Language only routes to GUI. It returns with the filled out mnemonic in strMessage
                 if (!GetWalletMnemonicLanguage(strMessage, initOption))
                     return false;
+                // The GUI reports IMPORT_MNEMONIC only when the user typed in an
+                // existing phrase, meaning the seed may have on-chain history
+                fRestoredSeed = (initOption == MnemonicWalletInitFlags::IMPORT_MNEMONIC);
                 // The mnemonic phrase now needs to be converted to the final wallet seed (note: different than the phrase seed)
                 strSeedPhraseArg = strMessage;
                 //LogPrintf("%s: mnemonic phrase: %s\n", __func__, strSeedPhraseArg);
@@ -73,7 +79,7 @@ bool MnemonicWalletInit::Open() const
             }
         }
 
-        std::shared_ptr<CWallet> pwallet = CWallet::CreateWalletFromFile(walletFile, walletPath, 0, fNewSeed ? &hashMasterKey : nullptr);
+        std::shared_ptr<CWallet> pwallet = CWallet::CreateWalletFromFile(walletFile, walletPath, 0, fNewSeed ? &hashMasterKey : nullptr, fNewSeed && fRestoredSeed);
         if (!pwallet) {
             return false;
         }

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -206,6 +206,17 @@ void AnonWallet::LoadToWallet(const uint256 &hash, const CTransactionRecord &rtx
     MapRecords_t::iterator mri = ret.first;
     rtxOrdered.insert(std::make_pair(rtx.GetTxTime(), mri));
 
+    // Outputs received while the wallet was locked are stored with ORF_LOCKED
+    // and a placeholder value until an unlock decrypts them. The unlock rescan
+    // only visits transactions tracked in mapLockedRecords, so rebuild that set
+    // from the stored flags or a restart strands these outputs at value zero
+    for (const auto &r : rtx.vout) {
+        if (r.nFlags & ORF_LOCKED) {
+            mapLockedRecords.insert(hash);
+            break;
+        }
+    }
+
     // TODO: Spend only owned inputs?
 
     return;

--- a/src/veil/ringct/anonwallet.cpp
+++ b/src/veil/ringct/anonwallet.cpp
@@ -5382,6 +5382,11 @@ void AnonWallet::RescanWallet()
         }
 
         if (transactionUpdated) {
+            // The parent wallet memoizes per transaction credit, and the amounts
+            // decrypted here change it, so force the cache to recompute
+            auto itWtx = pwalletParent->mapWallet.find(txid);
+            if (itWtx != pwalletParent->mapWallet.end())
+                itWtx->second.MarkDirty();
             pwalletParent->NotifyTransactionChanged(pwalletParent.get(), txid, CT_UPDATED_FULL);
         }
     };

--- a/src/veil/ringct/anonwallet.h
+++ b/src/veil/ringct/anonwallet.h
@@ -32,6 +32,10 @@ class CWatchOnlyTx;
 
 const uint16_t OR_PLACEHOLDER_N = 0xFFFF; // index of a fake output to contain reconstructed amounts for txns with undecodeable outputs
 
+//! How many stealth addresses to derive up front when a wallet is restored from
+//! seed, so deposits to addresses handed out by a previous copy are recognized
+const int DEFAULT_RESTORED_STEALTH_ADDRESSES = 100;
+
 class COutputR
 {
 public:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5180,9 +5180,12 @@ bool CWallet::Verify(std::string wallet_file, bool salvage_wallet, std::string& 
     return WalletBatch::VerifyDatabaseFile(wallet_path, warning_string, error_string);
 }
 
-std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, const fs::path& path, uint64_t wallet_creation_flags, uint512* pseed)
+std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, const fs::path& path, uint64_t wallet_creation_flags, uint512* pseed, bool fRestoredSeed)
 {
     const std::string& walletFile = name;
+    // A seed the user typed back in may have handed out addresses and received
+    // coins in a previous life, so it needs key re-derivation and a full rescan
+    const bool fSeedRestore = fRestoredSeed && pseed != nullptr;
 
     // needed to restore wallet transaction meta data after -zapwallettxes
     std::vector<CWalletTx> vWtx;
@@ -5430,7 +5433,10 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     LOCK(cs_main);
 
     CBlockIndex *pindexRescan = chainActive.Genesis();
-    if (!gArgs.GetBoolArg("-rescan", false))
+    // A restored seed always rescans from genesis: the best-block marker was
+    // stamped at the current tip when the fresh wallet file was created above,
+    // so trusting it would skip the seed's entire history
+    if (!gArgs.GetBoolArg("-rescan", false) && !fSeedRestore)
     {
         WalletBatch batch(*walletInstance->database);
         CBlockLocator locator;
@@ -5465,6 +5471,16 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
 
     walletInstance->SetAnonWallet(pAnonWallet);
 
+    if (fSeedRestore) {
+        // Each stealth address needs its keys derived before the rescan below can
+        // recognize deposits to it, and the wallet has no record of how many
+        // addresses the previous copy of this seed handed out. Derive a buffer up
+        // front, mirroring what the restoreaddresses RPC does manually.
+        uiInterface.InitMessage(_("Restoring stealth addresses..."));
+        if (!pAnonWallet->RestoreAddresses(DEFAULT_RESTORED_STEALTH_ADDRESSES))
+            InitWarning(_("Failed to restore stealth addresses. Run restoreaddresses then rescanringctwallet from the console."));
+    }
+
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)
     {
         //We can't rescan beyond non-pruned blocks, stop and throw an error
@@ -5486,8 +5502,10 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         walletInstance->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", chainActive.Height() - pindexRescan->nHeight, pindexRescan->nHeight);
 
         // No need to read and scan block if block was created before
-        // our wallet birthday (as adjusted for block time variability)
-        while (pindexRescan && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
+        // our wallet birthday (as adjusted for block time variability).
+        // Not valid for a restored seed: its keys were all derived just now, so
+        // the birthday would fast-forward past the history we are looking for
+        while (!fSeedRestore && pindexRescan && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
             pindexRescan = chainActive.Next(pindexRescan);
         }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1300,7 +1300,7 @@ public:
     static bool Verify(std::string wallet_file, bool salvage_wallet, std::string& error_string, std::string& warning_string);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static std::shared_ptr<CWallet> CreateWalletFromFile(const std::string& name, const fs::path& path, uint64_t wallet_creation_flags = 0, uint512* pseed = nullptr);
+    static std::shared_ptr<CWallet> CreateWalletFromFile(const std::string& name, const fs::path& path, uint64_t wallet_creation_flags = 0, uint512* pseed = nullptr, bool fRestoredSeed = false);
 
     /**
      * Wallet post-init setup


### PR DESCRIPTION
### Problem

Restoring a wallet from an imported seed silently misses money. Deposits sent to addresses a previous copy of the seed handed out do not appear, and funds received while the wallet was locked show as zero, until the user knows to run `restoreaddresses` and `rescanringctwallet` by hand.

### Description

Three related gaps in seed restore and locked receive handling, each of which leaves a correct on chain balance looking wrong in the wallet.

### Root Cause

1. A wallet created from an imported seed only derived its first few stealth addresses, so payments to any address a prior copy of the seed had already handed out were never recognised. The fresh wallet file was also stamped with the current best block and every key carried a creation time of now, so neither the startup rescan nor `importseed` with rescan ever looked back through history.
2. Outputs received while the wallet is locked are stored with `ORF_LOCKED` and a placeholder value of zero, and their txids go into `mapLockedRecords` so the unlock rescan can decrypt the real amounts. That set only lived in memory, so a wallet restarted while locked (the normal state of an encrypted wallet) had nothing to complete at unlock, and locked receives stayed at zero.
3. `gettransaction` and the GUI read amounts through the parent wallet's per transaction credit cache. The unlock rescan updated the stored records but never invalidated that cache, so a transaction queried before unlock kept showing zero until the next restart.

### Why broke?

The restore path was written for the common case of a brand new seed with no history, so the birthday fast forward and the small address buffer were reasonable. They fail precisely for the case restore exists to serve, a seed that has been used before. The locked record set and the credit cache were each correct in a single continuous session and only broke across a restart or an in session query.

### Solution

Derive a real buffer of addresses on restore, rescan from genesis, persist the locked record set, and invalidate the credit cache when the unlock rescan changes an amount.

### How fix?

Creating a wallet from an imported seed now derives 100 stealth addresses up front, rescans from genesis, and skips the wallet birthday fast forward. `mapLockedRecords` is rebuilt from the stored `ORF_LOCKED` flags when transaction records load, so a wallet that restarts while locked still completes those outputs at the next unlock, which also heals records stranded by earlier versions. The unlock rescan marks a transaction dirty when it updates it, so `gettransaction` and the GUI recompute the amount instead of serving a stale zero. The GUI restore wizard reports whether the imported words were recognised.

### Unit Testing Results

Exercised by hand on regtest and against a live wallet: an imported seed with prior deposits now shows them after restore without any manual command, a wallet locked across a restart completes its locked receives at unlock, and a transaction queried before unlock shows the correct amount afterward without a restart. No automated test is added; this path is wallet and GUI state across restart and unlock, which the unit suite does not currently have a fixture for. Stated plainly rather than implying coverage that is not there.

### How to test?

Import a seed that has received deposits to addresses beyond the first few, and confirm the balance appears after restore with no manual `restoreaddresses` or `rescanringctwallet`. Separately, receive to an encrypted wallet while locked, restart it still locked, then unlock, and confirm the received amount completes and is visible through both `gettransaction` and the GUI without another restart.
