### PR TITLE
Fix remote node crash from malformed RingCT anon inputs

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -74,6 +74,7 @@ BITCOIN_TESTS =\
   test/random_tests.cpp \
   test/randomx_tests.cpp \
   test/reverselock_tests.cpp \
+  test/ringct_anon_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \
   test/scheduler_tests.cpp \

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -21,6 +21,7 @@
 #include <script/standard.h>
 #include <key_io.h>
 #include <veil/ringct/blind.h>
+#include <veil/ringct/anon.h>
 #include <validation.h>
 #include <tinyformat.h>
 #include <libzerocoin/CoinSpend.h>
@@ -469,9 +470,17 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
 
         uint32_t nInputs, nRingSize;
         tx.vin[i].GetAnonInfo(nInputs, nRingSize);
-        const std::vector<uint8_t> &vKeyImages = tx.vin[i].scriptData.stack[0];
 
         if (tx.vin[i].IsAnonInput()) {
+            // Validate the anon input structure before indexing scriptData.stack. nInputs is
+            // attacker-controlled (from prevout.hash) and stack can deserialize empty; without
+            // this guard vKeyImages[k*33] reads out of bounds and crashes the node during
+            // block validation (ConnectBlock runs this before VerifyMLSAG bounds nInputs).
+            if (tx.vin[i].scriptData.stack.size() != 1 || nInputs < 1 || nInputs > MAX_ANON_INPUTS
+                    || tx.vin[i].scriptData.stack[0].size() != nInputs * 33)
+                return state.DoS(100, false, REJECT_INVALID, "bad-anonin-scriptdata");
+
+            const std::vector<uint8_t> &vKeyImages = tx.vin[i].scriptData.stack[0];
             for (size_t k = 0; k < nInputs; ++k) {
                 const CCmpPubKey &ki = *((CCmpPubKey*)&vKeyImages[k*33]);
 

--- a/src/test/ringct_anon_tests.cpp
+++ b/src/test/ringct_anon_tests.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/test_veil.h>
+
+#include <amount.h>
+#include <coins.h>
+#include <consensus/tx_verify.h>
+#include <consensus/validation.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+
+#include <cstring>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(ringct_anon_tests, BasicTestingSetup)
+
+// Build a single-input transaction whose only input is a RingCT anon input with the
+// given declared ring-input count and scriptData stack. This lets us drive the anon
+// input structural guard in Consensus::CheckTxInputs with no valid crypto: an anon
+// input is defined solely by prevout.n == ANON_MARKER, and GetAnonInfo() reads nInputs
+// from the first four bytes of prevout.hash.
+static CMutableTransaction MakeAnonInputTx(uint32_t nInputs, const std::vector<std::vector<uint8_t>>& stack)
+{
+    uint256 hashPrevout; // zero initialised
+    memcpy(hashPrevout.begin(), &nInputs, sizeof(nInputs));
+
+    CTxIn in;
+    in.prevout = COutPoint(hashPrevout, COutPoint::ANON_MARKER);
+    in.scriptData.stack = stack;
+
+    CMutableTransaction mtx;
+    mtx.vin.push_back(in);
+    return mtx;
+}
+
+static bool CheckInputsRejects(const CMutableTransaction& mtx, std::string& reason)
+{
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+
+    CValidationState state;
+    CAmount nFee = 0, nValueIn = 0, nValueOut = 0;
+    bool ok = Consensus::CheckTxInputs(CTransaction(mtx), state, coins, /*nSpendHeight=*/1,
+                                       nFee, nValueIn, nValueOut, /*test_accept=*/false);
+    reason = state.GetRejectReason();
+    return !ok;
+}
+
+// An anon input carrying an empty scriptData.stack must be rejected, not indexed.
+// Regression for the unauthenticated out-of-bounds read (empty stack -> stack[0]).
+BOOST_AUTO_TEST_CASE(anon_input_empty_stack_rejected)
+{
+    CMutableTransaction mtx = MakeAnonInputTx(/*nInputs=*/2, /*stack=*/{});
+    std::string reason;
+    BOOST_CHECK(CheckInputsRejects(mtx, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-anonin-scriptdata");
+}
+
+// An anon input whose key-image blob length does not equal nInputs*33 must be rejected.
+BOOST_AUTO_TEST_CASE(anon_input_bad_keyimage_size_rejected)
+{
+    // nInputs = 2 requires 66 key-image bytes; provide 10.
+    CMutableTransaction mtx = MakeAnonInputTx(2, {std::vector<uint8_t>(10, 0)});
+    std::string reason;
+    BOOST_CHECK(CheckInputsRejects(mtx, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-anonin-scriptdata");
+}
+
+// A huge attacker-declared nInputs must be rejected before any key-image indexing.
+// Regression for the unbounded out-of-bounds read during block validation.
+BOOST_AUTO_TEST_CASE(anon_input_huge_ninputs_rejected)
+{
+    CMutableTransaction mtx = MakeAnonInputTx(0xFFFFFFFF, {std::vector<uint8_t>(33, 0)});
+    std::string reason;
+    BOOST_CHECK(CheckInputsRejects(mtx, reason));
+    BOOST_CHECK_EQUAL(reason, "bad-anonin-scriptdata");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ringct_anon_tests.cpp
+++ b/src/test/ringct_anon_tests.cpp
@@ -10,6 +10,7 @@
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
+#include <veil/ringct/anon.h>
 
 #include <cstring>
 #include <vector>
@@ -78,6 +79,41 @@ BOOST_AUTO_TEST_CASE(anon_input_huge_ninputs_rejected)
     std::string reason;
     BOOST_CHECK(CheckInputsRejects(mtx, reason));
     BOOST_CHECK_EQUAL(reason, "bad-anonin-scriptdata");
+}
+
+// Build a bare RingCT anon input with attacker-chosen ring dimensions. GetAnonInfo() reads
+// nInputs from the first four bytes of prevout.hash and nRingSize from the next four.
+static CTxIn MakeAnonRingTxIn(uint32_t nInputs, uint32_t nRingSize)
+{
+    uint256 hashPrevout; // zero initialised
+    memcpy(hashPrevout.begin(), &nInputs, sizeof(nInputs));
+    memcpy(hashPrevout.begin() + 4, &nRingSize, sizeof(nRingSize));
+
+    CTxIn in;
+    in.prevout = COutPoint(hashPrevout, COutPoint::ANON_MARKER);
+    return in;
+}
+
+// GetRingCtInputs sizes a vM(nCols*nRows*33) scratch buffer directly from nRingSize/nInputs.
+// With ring dimensions taken unbounded from prevout.hash an attacker can request a multi-terabyte
+// allocation (nRingSize 0xFFFFFFFF, nInputs 32 -> ~4.3 TB), so the dimensions must be range checked
+// and the call must return empty before that sizing. We assert the reject path for values above the
+// permitted maxima and below the permitted minima; we never drive the unbounded allocation itself.
+BOOST_AUTO_TEST_CASE(getringctinputs_vector_rejects_out_of_range_dimensions)
+{
+    BOOST_CHECK(GetRingCtInputs(MakeAnonRingTxIn(1, 0xFFFFFFFF)).empty());          // ring > MAX_RINGSIZE
+    BOOST_CHECK(GetRingCtInputs(MakeAnonRingTxIn(1, MIN_RINGSIZE - 1)).empty());    // ring < MIN_RINGSIZE
+    BOOST_CHECK(GetRingCtInputs(MakeAnonRingTxIn(MAX_ANON_INPUTS + 1, MIN_RINGSIZE)).empty()); // inputs > max
+    BOOST_CHECK(GetRingCtInputs(MakeAnonRingTxIn(0, MIN_RINGSIZE)).empty());        // inputs == 0
+}
+
+BOOST_AUTO_TEST_CASE(getringctinputs_bool_rejects_out_of_range_dimensions)
+{
+    std::vector<std::vector<COutPoint>> vInputs;
+    BOOST_CHECK(!GetRingCtInputs(MakeAnonRingTxIn(1, 0xFFFFFFFF), vInputs));
+    BOOST_CHECK(vInputs.empty());
+    BOOST_CHECK(!GetRingCtInputs(MakeAnonRingTxIn(MAX_ANON_INPUTS + 1, MIN_RINGSIZE), vInputs));
+    BOOST_CHECK(vInputs.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -748,13 +748,17 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         for (const CTxIn& txin : tx.vin) {
             if (txin.IsAnonInput()) {
                 state.fHasAnonInput = true;
-                const std::vector<uint8_t> &vKeyImages = txin.scriptData.stack[0];
-
 
                 uint32_t nInputs, nRingSize;
                 txin.GetAnonInfo(nInputs, nRingSize);
-                if (vKeyImages.size() != nInputs * 33)
-                    return state.Invalid(false, REJECT_DUPLICATE, "anonin-badkeyimagesize");
+                // Validate the anon input structure before indexing scriptData.stack.
+                // nInputs is attacker-controlled (from prevout.hash) and stack can deserialize
+                // empty, so an unchecked stack[0]/stack[0][k*33] is a remote OOB read/crash.
+                if (txin.scriptData.stack.size() != 1 || nInputs < 1 || nInputs > MAX_ANON_INPUTS
+                        || txin.scriptData.stack[0].size() != nInputs * 33)
+                    return state.Invalid(false, REJECT_INVALID, "bad-anonin-scriptdata");
+
+                const std::vector<uint8_t> &vKeyImages = txin.scriptData.stack[0];
 
                 for (size_t k = 0; k < nInputs; ++k) {
                     const CCmpPubKey &ki = *((CCmpPubKey *) &vKeyImages[k * 33]);

--- a/src/veil/ringct/anon.cpp
+++ b/src/veil/ringct/anon.cpp
@@ -314,6 +314,12 @@ std::vector<COutPoint> GetRingCtInputs(const CTxIn& txin)
     uint32_t nInputs, nRingSize;
     txin.GetAnonInfo(nInputs, nRingSize);
 
+    // Reject out-of-range ring dimensions before sizing the vM scratch buffer. nInputs/nRingSize
+    // come straight from the attacker-controlled prevout.hash and are otherwise only bounded later
+    // in VerifyMLSAG, so an uncapped nRingSize here would request hundreds of GB.
+    if (nInputs < 1 || nInputs > MAX_ANON_INPUTS || nRingSize < MIN_RINGSIZE || nRingSize > MAX_RINGSIZE)
+        return vInputs;
+
     size_t nCols = nRingSize;
     size_t nRows = nInputs + 1;
 
@@ -356,6 +362,12 @@ bool GetRingCtInputs(const CTxIn& txin, std::vector<std::vector<COutPoint> >& vI
     vInputs.clear();
     uint32_t nInputs, nRingSize;
     txin.GetAnonInfo(nInputs, nRingSize);
+
+    // Reject out-of-range ring dimensions before sizing the vM scratch buffer. nInputs/nRingSize
+    // come straight from the attacker-controlled prevout.hash and are otherwise only bounded later
+    // in VerifyMLSAG, so an uncapped nRingSize here would request hundreds of GB.
+    if (nInputs < 1 || nInputs > MAX_ANON_INPUTS || nRingSize < MIN_RINGSIZE || nRingSize > MAX_RINGSIZE)
+        return false;
 
     size_t nCols = nRingSize;
     size_t nRows = nInputs + 1;


### PR DESCRIPTION
### Problem

Any peer can crash every reachable node over transaction relay, with no proof of work and no valid signature, and a mined block can crash nodes during block validation.

### Description

A RingCT anon input is identified only by `prevout.n == ANON_MARKER`, and its `scriptData.stack`, declared `nInputs` and `nRingSize` all come straight from the attacker controlled `prevout.hash`. Several code paths consumed that data before validating its shape.

### Root Cause

- `AcceptToMemoryPool` (validation.cpp) bound `scriptData.stack[0]` with no size check, so an anon input with an empty stack read out of bounds and crashed the node.
- `Consensus::CheckTxInputs` (tx_verify.cpp) looped `k < nInputs` reading `vKeyImages[k*33]` with `nInputs` unbounded, so a block carrying such a transaction read far past the buffer during validation. The same unbounded `nInputs` also overflowed the 32 bit `vKeyImages.size() != nInputs*33` check, letting a huge count slip past a naive guard.
- `GetRingCtInputs` (anon.cpp, both overloads) sized a scratch buffer as `nRingSize * (nInputs+1) * 33` with no bound, so an uncapped ring size requested hundreds of GB.

### Why broke?

The `DisconnectBlock` and `ConnectBlock` paths already validate the anon input shape before indexing, so the invariant held where anyone had looked. The mempool acceptance path and `CheckTxInputs` were written assuming that same shape without enforcing it, so the guarantee quietly did not hold for exactly the untrusted entry points.

### Solution

Validate the anon input shape everywhere before any indexing or allocation: `stack.size() == 1`, `1 <= nInputs <= MAX_ANON_INPUTS`, ring size in `[MIN_RINGSIZE, MAX_RINGSIZE]`, and `stack[0].size() == nInputs*33`.

### How fix?

The checks are hoisted ahead of the first access in each path, matching what `DisconnectBlock` and `ConnectBlock` already do and the bounds `VerifyMLSAG` enforces. An oversized or empty input is now rejected cleanly instead of indexing or allocating on attacker numbers.

### Unit Testing Results

`src/test/ringct_anon_tests.cpp` covers the empty stack case and the oversized `nInputs` case, and asserts the guard rejects before any allocation. 5 of 5 test cases pass, exit 0. On the unpatched build the empty stack case crashes (Boost exit 201, and a null deref under lldb), confirming the bug and the fix. Results captured during the security validation; the Boost 1.85 build shim used locally on Apple Silicon is deliberately not part of this PR.

### How to test?

Build with tests and run `test_veil --run_test=ringct_anon_tests`. To see the pre fix crash, feed a transaction with an anon input whose `scriptData.stack` is empty through `AcceptToMemoryPool`: unpatched it segfaults, patched it is rejected.
