### PR TITLE
Fix remote crash from an unvalidated ProgPow header height

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -69,6 +69,7 @@ BITCOIN_TESTS =\
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
   test/progpow_tests.cpp \
+  test/progpow_epoch_tests.cpp \
   test/proofofstaketests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -21,6 +21,20 @@ ethash::epoch_context_ptr progpow_context{nullptr, nullptr};
 // blocks at 120s spacing), so this never rejects a valid block; an over-range header fails PoW.
 static const int MAX_PROGPOW_EPOCH = 4096;
 
+// Clamp a raw ProgPow epoch into the range the node is willing to build a light cache for.
+// Extracted from ProgPowHash so the bound can be exercised directly, without allocating a cache.
+int ProgPowClampEpoch(int epoch)
+{
+    if (epoch < 0)
+        return 0;
+    if (epoch > MAX_PROGPOW_EPOCH)
+        return MAX_PROGPOW_EPOCH;
+    return epoch;
+}
+
+// Expose the epoch ceiling to callers (tests) without giving the constant external linkage.
+int ProgPowMaxEpoch() { return MAX_PROGPOW_EPOCH; }
+
 inline uint32_t ROTL32(uint32_t x, int8_t r)
 {
     return (x << r) | (x >> (32 - r));
@@ -282,11 +296,7 @@ uint256 ProgPowHash(const CBlockHeader& blockHeader, uint256& mix_hash)
 
     // Get the context from the block height, bounding the epoch so an unvalidated / out-of-range
     // nHeight cannot drive an unbounded ethash light-cache allocation (see MAX_PROGPOW_EPOCH).
-    int epoch_number = Params().GetProgPowEpochNumber(blockHeader.nHeight);
-    if (epoch_number < 0)
-        epoch_number = 0;
-    else if (epoch_number > MAX_PROGPOW_EPOCH)
-        epoch_number = MAX_PROGPOW_EPOCH;
+    int epoch_number = ProgPowClampEpoch(Params().GetProgPowEpochNumber(blockHeader.nHeight));
 
     if (!progpow_context || progpow_context->epoch_number != epoch_number)
         progpow_context = ethash::create_epoch_context(epoch_number);

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -13,6 +13,14 @@
 CCriticalSection cs_context_builder;
 ethash::epoch_context_ptr progpow_context{nullptr, nullptr};
 
+// Upper bound on the ProgPow ethash epoch when hashing a header. A header's nHeight is read from
+// the wire and, on the header-accept path, is validated only after the proof-of-work hash is
+// computed, so an out-of-range nHeight would otherwise drive an unbounded ethash light-cache
+// allocation (tens of GB) and crash the node. At epoch 4096 the light cache is ~528 MiB, which
+// legit heights do not reach for well over a century (post-DAG-reduction epoch length is 8175
+// blocks at 120s spacing), so this never rejects a valid block; an over-range header fails PoW.
+static const int MAX_PROGPOW_EPOCH = 4096;
+
 inline uint32_t ROTL32(uint32_t x, int8_t r)
 {
     return (x << r) | (x >> (32 - r));
@@ -270,12 +278,24 @@ uint256 ProgPowHash(const CBlockHeader& blockHeader)
 
 uint256 ProgPowHash(const CBlockHeader& blockHeader, uint256& mix_hash)
 {
-    {
-        LOCK(cs_context_builder);
-        // Get the context from the block height
-        const auto epoch_number = Params().GetProgPowEpochNumber(blockHeader.nHeight);
-        if (!progpow_context || progpow_context->epoch_number != epoch_number)
-            progpow_context = ethash::create_epoch_context(epoch_number);
+    LOCK(cs_context_builder);
+
+    // Get the context from the block height, bounding the epoch so an unvalidated / out-of-range
+    // nHeight cannot drive an unbounded ethash light-cache allocation (see MAX_PROGPOW_EPOCH).
+    int epoch_number = Params().GetProgPowEpochNumber(blockHeader.nHeight);
+    if (epoch_number < 0)
+        epoch_number = 0;
+    else if (epoch_number > MAX_PROGPOW_EPOCH)
+        epoch_number = MAX_PROGPOW_EPOCH;
+
+    if (!progpow_context || progpow_context->epoch_number != epoch_number)
+        progpow_context = ethash::create_epoch_context(epoch_number);
+
+    // Fail closed if the light cache could not be allocated, rather than dereferencing a null
+    // context: return a hash that cannot satisfy any target so the proof-of-work check rejects it.
+    if (!progpow_context) {
+        mix_hash.SetNull();
+        return uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     }
 
     // Build the header_hash

--- a/src/hash.h
+++ b/src/hash.h
@@ -544,5 +544,9 @@ inline uint256 HashX16R(const T1 pbegin, const T1 pend, const uint256 PrevBlockH
 uint256 ProgPowHash(const CBlockHeader& blockHeader);
 uint256 ProgPowHash(const CBlockHeader& blockHeader, uint256& mix_hash);
 
+// Bound a raw ProgPow epoch to the allocatable range, and report that ceiling. See hash.cpp.
+int ProgPowClampEpoch(int epoch);
+int ProgPowMaxEpoch();
+
 
 #endif // BITCOIN_HASH_H

--- a/src/test/progpow_epoch_tests.cpp
+++ b/src/test/progpow_epoch_tests.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/test_veil.h>
+
+#include <arith_uint256.h>
+#include <chainparams.h>
+#include <hash.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(progpow_epoch_tests, BasicTestingSetup)
+
+// A header's nHeight is attacker controlled on the header accept path and reaches ProgPowHash
+// before it has been validated. Without a bound the ethash light cache is sized straight from
+// that height (tens of GB for a large nHeight, a remote OOM / null deref). ProgPowClampEpoch caps
+// the epoch so the allocation stays bounded. These checks exercise the bound directly and never
+// build a cache.
+BOOST_AUTO_TEST_CASE(clamp_bounds_out_of_range_epoch)
+{
+    const int maxEpoch = ProgPowMaxEpoch();
+    BOOST_CHECK_EQUAL(ProgPowClampEpoch(maxEpoch + 1), maxEpoch);
+    BOOST_CHECK_EQUAL(ProgPowClampEpoch(1 << 28), maxEpoch);   // ~268M, far past the ceiling
+    BOOST_CHECK_EQUAL(ProgPowClampEpoch(-1), 0);               // a negative epoch is floored
+}
+
+// The clamp must never change a legitimate header's epoch, or valid blocks would hash differently
+// and split consensus. Every epoch in [0, ceiling] is returned unchanged.
+BOOST_AUTO_TEST_CASE(clamp_is_identity_over_legit_range)
+{
+    const int maxEpoch = ProgPowMaxEpoch();
+    for (int e = 0; e <= maxEpoch; ++e)
+        BOOST_CHECK_EQUAL(ProgPowClampEpoch(e), e);
+}
+
+// Tie the bound to the real epoch formula and a realistic attacker height: a large wire nHeight
+// maps to an epoch far above the ceiling, and the clamp brings it back to the ceiling. That epoch
+// is exactly what would otherwise size the light cache.
+BOOST_AUTO_TEST_CASE(clamp_catches_attacker_height)
+{
+    const int maxEpoch = ProgPowMaxEpoch();
+    const int rawEpoch = Params().GetProgPowEpochNumber(2000000000); // ~2e9, fits a header int nHeight
+    BOOST_CHECK_GT(rawEpoch, maxEpoch);                              // the over range epoch is reachable
+    BOOST_CHECK_EQUAL(ProgPowClampEpoch(rawEpoch), maxEpoch);        // and the clamp bounds it
+}
+
+// Fail closed sentinel: when the bounded light cache still cannot be allocated, ProgPowHash returns
+// the maximum possible hash instead of dereferencing a null context. The maximum hash is greater
+// than every valid PoW target, so a header hashed this way can never pass hash <= target. This is
+// the constant returned on the null context branch in ProgPowHash.
+BOOST_AUTO_TEST_CASE(fail_closed_hash_is_unsatisfiable)
+{
+    const uint256 failClosed = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    BOOST_CHECK(UintToArith256(failClosed) == (~arith_uint256(0)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Problem

A single HEADERS message can make every node allocate multiple GB during header processing and either run out of memory or crash on a null dereference. No proof of work and no valid chain state are needed.

### Description

`CheckBlockHeader` computes `ProgPowHash` for a ProgPow header inside `AcceptBlockHeader`, before the previous block lookup and `ContextualCheckBlockHeader`, so the header's `nHeight` is still attacker controlled and unvalidated at that point.

### Root Cause

`ProgPowHash` derived the ethash epoch from that `nHeight` through `GetProgPowEpochNumber`, which had no upper bound, called `create_epoch_context`, and dereferenced the result with no null check. A ProgPow header carrying a large `nHeight` (with `fProofOfStake=0` and `nTime >= PowUpdateTimestamp`) forced a multi GB light cache allocation during header processing: out of memory, or a null deref SIGSEGV when the allocation failed.

### Why broke?

Header acceptance hashes before it validates height, on the assumption that the epoch derived from a header is always near the real chain height. That assumption holds for honest headers and fails for a forged one, and nothing bounded the epoch or handled an allocation failure.

### Solution

Bound the epoch before allocating, and fail closed rather than dereferencing null if the cache still cannot be built.

### How fix?

The epoch is clamped to `MAX_PROGPOW_EPOCH` before allocation. Legitimate heights stay far below it for over a century, and an over range header fails proof of work regardless, so no valid block is affected. If the context still cannot be allocated the code fails closed instead of dereferencing null, and the context builder lock is held across the hash so the shared context cannot be swapped out mid dereference. The clamp logic is extracted into a small helper so it can be tested directly. The proper long term fix is to validate `nHeight == pindexPrev->nHeight+1` before any proof of work hashing; this bounds the damage without reordering header acceptance.

### Unit Testing Results

`src/test/progpow_epoch_tests.cpp` asserts the clamp on the real production helper across in range and over range heights. 4 of 4 test cases pass, exit 0, no regressions. The out of memory condition is asserted by property (the clamp holds and an over range header cannot pass proof of work) rather than triggered, so no multi GB allocation is performed by the test. Results captured during the security validation; the Boost 1.85 build shim used locally on Apple Silicon is not part of this PR.

### How to test?

Build with tests and run `test_veil --run_test=progpow_epoch_tests`. The helper returns a bounded epoch for any input height, so an attacker supplied `nHeight` can no longer drive an unbounded ethash allocation during header acceptance.
