### PR TITLE
Fix Dandelion: stem routing was silently off, plus a P2P hang and crash

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -46,6 +46,7 @@ BITCOIN_TESTS =\
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
+  test/dandelion_tests.cpp \
   test/denialofservice_tests.cpp \
   test/descriptor_tests.cpp \
   test/getarg_tests.cpp \

--- a/src/test/dandelion_tests.cpp
+++ b/src/test/dandelion_tests.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/test_veil.h>
+
+#include <uint256.h>
+#include <util/time.h>
+#include <veil/dandelioninventory.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using veil::DandelionInventory;
+using veil::SelectDandelionNextHop;
+
+BOOST_FIXTURE_TEST_SUITE(dandelion_tests, BasicTestingSetup)
+
+// IsInStemPhase must be true while the stem timer is in the future and false once it has passed.
+// The predicate was inverted (end < now), which made it always false, so stem routing was silently
+// off and every transaction fluffed from its origin.
+BOOST_AUTO_TEST_CASE(is_in_stem_phase_tracks_future_end_time)
+{
+    const int64_t t0 = 1600000000;
+    SetMockTime(t0);
+
+    DandelionInventory dinv;
+    const uint256 hash = uint256S("01");
+    dinv.Add(hash, t0 + 60, /*nNodeIDFrom=*/2);   // clamped into [t0, t0+120]; stays in the future
+
+    BOOST_CHECK(dinv.IsInStemPhase(hash));         // future end time -> in the stem phase
+
+    SetMockTime(t0 + 1000);                        // advance well past the end time
+    BOOST_CHECK(!dinv.IsInStemPhase(hash));        // past end time -> no longer in the stem phase
+
+    SetMockTime(0);
+}
+
+// The peer-supplied stem end time is clamped to the honest window, so a peer cannot pin an entry in
+// the stem phase forever: even an end time far in the future expires at now + nDefaultStemTime (120s).
+BOOST_AUTO_TEST_CASE(add_clamps_peer_supplied_end_time)
+{
+    const int64_t t0 = 1600000000;
+    SetMockTime(t0);
+
+    DandelionInventory dinv;
+    const uint256 hash = uint256S("02");
+    dinv.Add(hash, t0 + 10LL * 365 * 24 * 3600, /*nNodeIDFrom=*/2); // ~10 years in the future
+
+    BOOST_CHECK(dinv.IsInStemPhase(hash));
+    SetMockTime(t0 + 121);                         // just past now + nDefaultStemTime
+    BOOST_CHECK(!dinv.IsInStemPhase(hash));         // the clamp expired it; it was not pinned for years
+
+    SetMockTime(0);
+}
+
+// No eligible peer -> skip (return false) instead of the old behaviour: a single origin-only peer
+// looped forever in the do/while, and an empty list underflowed size()-1 and indexed out of range.
+BOOST_AUTO_TEST_CASE(next_hop_zero_eligible_is_skipped)
+{
+    int64_t chosen = -999;
+    BOOST_CHECK(!SelectDandelionNextHop({}, /*origin=*/7, chosen));   // empty peer list
+    BOOST_CHECK(!SelectDandelionNextHop({7}, /*origin=*/7, chosen));  // only the origin is connected
+}
+
+// Exactly one eligible peer -> terminates and picks it (the case that used to loop forever).
+BOOST_AUTO_TEST_CASE(next_hop_single_eligible_terminates_and_picks_it)
+{
+    int64_t chosen = -999;
+    BOOST_CHECK(SelectDandelionNextHop({4}, /*origin=*/7, chosen));
+    BOOST_CHECK_EQUAL(chosen, 4);
+
+    chosen = -999;
+    BOOST_CHECK(SelectDandelionNextHop({7, 4}, /*origin=*/7, chosen)); // origin present, one eligible
+    BOOST_CHECK_EQUAL(chosen, 4);
+}
+
+// Larger list -> always an in-range peer that is never the origin, across many random draws.
+BOOST_AUTO_TEST_CASE(next_hop_many_peers_excludes_origin_in_range)
+{
+    const std::vector<int64_t> peers = {1, 2, 3, 7, 4, 5};
+    const int64_t origin = 7;
+    for (int i = 0; i < 1000; ++i) {
+        int64_t chosen = -999;
+        BOOST_CHECK(SelectDandelionNextHop(peers, origin, chosen));
+        BOOST_CHECK(chosen != origin);
+        BOOST_CHECK(std::find(peers.begin(), peers.end(), chosen) != peers.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/veil/dandelioninventory.cpp
+++ b/src/veil/dandelioninventory.cpp
@@ -11,6 +11,23 @@ namespace veil {
 
 DandelionInventory dandelion;
 
+bool SelectDandelionNextHop(const std::vector<int64_t>& vNodeIds, int64_t nNodeIDFrom, int64_t& nNodeIDOut)
+{
+    // Choose a random peer other than the one the tx came from. Return false (skip this round)
+    // when no eligible peer exists, rather than looping forever on a single origin-only peer or
+    // indexing an empty list out of range.
+    std::vector<int64_t> vEligible;
+    vEligible.reserve(vNodeIds.size());
+    for (int64_t id : vNodeIds) {
+        if (id != nNodeIDFrom)
+            vEligible.push_back(id);
+    }
+    if (vEligible.empty())
+        return false;
+    nNodeIDOut = vEligible[GetRandInt(static_cast<int>(vEligible.size()))];
+    return true;
+}
+
 void DandelionInventory::Add(const uint256& hashInventory, const int64_t& nTimeStemEnd, const int64_t& nNodeIDFrom)
 {
     Stem stem;
@@ -121,15 +138,13 @@ void DandelionInventory::Process(const std::vector<CNode*>& vNodes)
         //skip this entry until the next round rather than looping forever or indexing out of range.
         //The old code used GetRandInt(vNodes.size() - 1) with a do/while on the origin id, which
         //never terminated with a single eligible peer and underflowed on an empty peer list.
-        std::vector<int64_t> vEligible;
-        vEligible.reserve(vNodes.size());
-        for (CNode* pnode : vNodes) {
-            if (pnode->GetId() != stem.nNodeIDFrom)
-                vEligible.push_back(pnode->GetId());
-        }
-        if (vEligible.empty())
+        std::vector<int64_t> vNodeIds;
+        vNodeIds.reserve(vNodes.size());
+        for (CNode* pnode : vNodes)
+            vNodeIds.push_back(pnode->GetId());
+        int64_t nNodeID;
+        if (!SelectDandelionNextHop(vNodeIds, stem.nNodeIDFrom, nNodeID))
             continue;
-        int64_t nNodeID = vEligible[GetRandInt(static_cast<int>(vEligible.size()))];
         mapNodeToSentTo.insert(std::make_pair(hash, nNodeID));
 
         // Randomly decide to send this if it is in stem phase

--- a/src/veil/dandelioninventory.cpp
+++ b/src/veil/dandelioninventory.cpp
@@ -5,6 +5,8 @@
 #include <timedata.h>
 #include "dandelioninventory.h"
 
+#include <algorithm>
+
 namespace veil {
 
 DandelionInventory dandelion;
@@ -12,7 +14,10 @@ DandelionInventory dandelion;
 void DandelionInventory::Add(const uint256& hashInventory, const int64_t& nTimeStemEnd, const int64_t& nNodeIDFrom)
 {
     Stem stem;
-    stem.nTimeStemEnd = nTimeStemEnd;
+    // Clamp the stem end time so a peer-supplied value cannot pin an entry in the stem phase
+    // indefinitely; the honest stem window is nDefaultStemTime.
+    int64_t nNow = GetAdjustedTime();
+    stem.nTimeStemEnd = std::max(nNow, std::min(nTimeStemEnd, nNow + nDefaultStemTime));
     stem.nNodeIDFrom = nNodeIDFrom;
     mapStemInventory.emplace(std::make_pair(hashInventory, stem));
 }
@@ -38,7 +43,9 @@ bool DandelionInventory::IsInStemPhase(const uint256& hash) const
     if (!mapStemInventory.count(hash))
         return false;
 
-    return mapStemInventory.at(hash).nTimeStemEnd < GetAdjustedTime();
+    // In the stem phase while the end time is still in the future (this was inverted, which made
+    // IsInStemPhase always false and silently disabled stem routing, fluffing every tx from its origin).
+    return GetAdjustedTime() < mapStemInventory.at(hash).nTimeStemEnd;
 }
 
 //Only send to a node that requests the tx if the inventory was broadcast to this node
@@ -109,14 +116,21 @@ void DandelionInventory::Process(const std::vector<CNode*>& vNodes)
             continue;
         mapStemInventory.at(hash).nTimeLastRoll = GetAdjustedTime();
 
-        //Set the index to send to
-        int64_t nNodeID;
-        do {
-            int nRand = GetRandInt(static_cast<int>(vNodes.size() - 1));
-            nNodeID = vNodes[nRand]->GetId();
+        //Set the index to send to: choose a random peer other than the one the tx came from.
+        //If no eligible peer exists (e.g. only the origin is connected, or the peer list is empty)
+        //skip this entry until the next round rather than looping forever or indexing out of range.
+        //The old code used GetRandInt(vNodes.size() - 1) with a do/while on the origin id, which
+        //never terminated with a single eligible peer and underflowed on an empty peer list.
+        std::vector<int64_t> vEligible;
+        vEligible.reserve(vNodes.size());
+        for (CNode* pnode : vNodes) {
+            if (pnode->GetId() != stem.nNodeIDFrom)
+                vEligible.push_back(pnode->GetId());
         }
-        while (nNodeID == stem.nNodeIDFrom);
-        mapNodeToSentTo.insert(std::make_pair<uint256&, int64_t& >(hash, nNodeID));
+        if (vEligible.empty())
+            continue;
+        int64_t nNodeID = vEligible[GetRandInt(static_cast<int>(vEligible.size()))];
+        mapNodeToSentTo.insert(std::make_pair(hash, nNodeID));
 
         // Randomly decide to send this if it is in stem phase
         auto n = GetRandInt(3);

--- a/src/veil/dandelioninventory.h
+++ b/src/veil/dandelioninventory.h
@@ -13,10 +13,10 @@ namespace veil {
 
 struct Stem
 {
-    int64_t nTimeStemEnd;
-    int64_t nTimeLastRoll;
-    int64_t nNodeIDFrom;
-    int64_t nNodeIDSentTo;
+    int64_t nTimeStemEnd = 0;
+    int64_t nTimeLastRoll = 0;
+    int64_t nNodeIDFrom = 0;
+    int64_t nNodeIDSentTo = 0;
 };
 
 class DandelionInventory;

--- a/src/veil/dandelioninventory.h
+++ b/src/veil/dandelioninventory.h
@@ -22,6 +22,10 @@ struct Stem
 class DandelionInventory;
 extern DandelionInventory dandelion;
 
+// Choose a Dandelion next hop from the connected peer ids, excluding the origin the tx came from.
+// Returns false (skip this round) when no eligible peer exists; otherwise nNodeIDOut is the pick.
+bool SelectDandelionNextHop(const std::vector<int64_t>& vNodeIds, int64_t nNodeIDFrom, int64_t& nNodeIDOut);
+
 class DandelionInventory
 {
 private:


### PR DESCRIPTION
### Problem

The Dandelion privacy layer was silently doing nothing, so transaction origin was never hidden, and a peer could wedge or crash a node's P2P thread.

### Description

Two defects that have to be fixed together, plus two smaller hardening fixes in the same code.

### Root Cause

1. `IsInStemPhase` returned `nTimeStemEnd < GetAdjustedTime()`, i.e. true only once the stem timer had already expired. Entries are created with a future end time, so the function was effectively always false. Every stem gate in net_processing was skipped and each transaction was fluffed to all peers straight from its origin, so the advertised IP privacy did nothing.
2. `Process()` chose the next hop with `GetRandInt(vNodes.size() - 1)` in a do/while that retried while the pick equalled the origin. `GetRandInt(n)` returns `[0, n)`, so it could never pick the last peer; with a single eligible peer it looped forever and wedged the whole P2P message thread, and with an empty peer list `size()-1` underflowed and the vector was indexed out of range and crashed. Both are remotely reachable through `tx_dand` from a node's only Dandelion peer.

### Why broke?

The stem phase predicate is inverted, so the whole feature reads as inactive and the buggy next hop path is rarely entered. Because nothing appears to break with it inactive, neither defect surfaced in normal use. Activating the feature is what makes the loop reachable, which is why they must land together.

### Solution

Correct the stem phase test, select the next hop safely, initialise the struct members, and clamp the peer supplied stem end time.

### How fix?

`IsInStemPhase` now compares against a future end time so stem routing actually engages. `Process()` builds the eligible peer list explicitly, skips the entry when none exists, and indexes with the correct range, so it can neither spin nor read out of bounds. `struct Stem` gets member initialisers (`Add()` left `nTimeLastRoll` and `nNodeIDSentTo` indeterminate, later read in relay and timing decisions), and the peer supplied stem end time is clamped to the honest window so a peer cannot pin an entry in the stem phase.

### Unit Testing Results

`src/test/dandelion_tests.cpp` covers stem phase detection before and after, the next hop selector across the empty, single peer and origin only conditions, and the stem time clamp. 5 of 5 test cases pass, exit 0. On the unpatched build the `IsInStemPhase` case fails both assertions, confirming the inverted predicate. Results captured during the security validation; the Boost 1.85 build shim used locally on Apple Silicon is not part of this PR.

### How to test?

Build with tests and run `test_veil --run_test=dandelion_tests`. On a live network, confirm a transaction now routes through a stem peer before fluffing rather than broadcasting to all peers from its origin, and that a node with a single Dandelion peer no longer wedges its message thread.
