### PR TITLE
Wipe transient mnemonic and seed material from wallet init memory

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -107,6 +107,7 @@ BITCOIN_TESTS =\
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \
+  test/mnemonic_cleanse_tests.cpp \
   wallet/test/psbt_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \
   wallet/test/wallet_crypto_tests.cpp \

--- a/src/test/mnemonic_cleanse_tests.cpp
+++ b/src/test/mnemonic_cleanse_tests.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Veil developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/test_veil.h>
+
+#include <uint256.h>
+#include <veil/mnemonic/generateseed.h>
+#include <veil/mnemonic/mnemonic.h>
+
+#include <cstring>
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(mnemonic_cleanse_tests, BasicTestingSetup)
+
+// GenerateNewMnemonicSeed wipes its transient private key and intermediate seed after use. This
+// checks the wipe did not change the result: the phrase it returns still re-derives exactly the
+// master seed it returned, so a wallet created through this path derives identically to before.
+BOOST_AUTO_TEST_CASE(generated_seed_round_trips_after_cleanse)
+{
+    std::string mnemonic;
+    uint512 seed = veil::GenerateNewMnemonicSeed(mnemonic, "english");
+
+    BOOST_CHECK(!mnemonic.empty());
+    BOOST_CHECK(seed != uint512());
+
+    // The wallet re-derives the master seed from the phrase; it must match what was returned.
+    long_hash reDerived = decode_mnemonic(mnemonic);
+    uint512 seedFromPhrase;
+    memcpy(seedFromPhrase.begin(), reDerived.data(), reDerived.size());
+    BOOST_CHECK(seed == seedFromPhrase);
+}
+
+// The wallet-open path wipes the phrase and the decoded seed after decode_mnemonic runs. The wipe
+// is on caller-side copies, not inside the derivation, so decode_mnemonic must stay a pure,
+// deterministic function. Confirm it still returns a stable, non-zero seed.
+BOOST_AUTO_TEST_CASE(decode_mnemonic_is_deterministic_and_nonzero)
+{
+    const std::string phrase = "abandon abandon abandon abandon abandon abandon "
+                               "abandon abandon abandon abandon abandon about";
+    long_hash a = decode_mnemonic(phrase);
+    long_hash b = decode_mnemonic(phrase);
+    BOOST_CHECK(a == b);
+
+    bool anyNonZero = false;
+    for (uint8_t c : a)
+        if (c != 0) { anyNonZero = true; break; }
+    BOOST_CHECK(anyNonZero);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/veil/mnemonic/generateseed.cpp
+++ b/src/veil/mnemonic/generateseed.cpp
@@ -4,6 +4,7 @@
 
 #include <veil/mnemonic/generateseed.h>
 #include <key.h>
+#include <support/cleanse.h>
 #include <veil/mnemonic/mnemonic.h>
 
 namespace veil {
@@ -34,6 +35,12 @@ uint512 GenerateNewMnemonicSeed(std::string& mnemonic, const std::string& strLan
     auto blob_512 = decode_mnemonic(mnemonic_words);
     uint512 seed512;
     memcpy(seed512.begin(), blob_512.begin(), blob_512.size());
+
+    // Wipe the transient plaintext copies of the private key and the derived seed so they do not
+    // linger in swappable, un-cleansed memory. The caller receives the mnemonic phrase (and
+    // re-derives the seed from it); these intermediates are no longer needed.
+    memory_cleanse(keyData.data(), keyData.size());
+    memory_cleanse(blob_512.data(), blob_512.size());
 
     return seed512;
 }

--- a/src/veil/mnemonic/mnemonicwalletinit.cpp
+++ b/src/veil/mnemonic/mnemonicwalletinit.cpp
@@ -10,6 +10,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 #include <veil/ringct/anonwallet.h>
+#include <support/cleanse.h>
 #include "mnemonic.h"
 #include "generateseed.h"
 
@@ -61,6 +62,7 @@ bool MnemonicWalletInit::Open() const
                 if (!DisplayWalletMnemonic(mnemonic))
                     return false;
                 strSeedPhraseArg = mnemonic;
+                memory_cleanse(&mnemonic[0], mnemonic.size());
                 initOption = MnemonicWalletInitFlags::IMPORT_MNEMONIC;
             }
 
@@ -69,11 +71,17 @@ bool MnemonicWalletInit::Open() const
                 // Convert the BIP39 mnemonic phrase into the final 512bit wallet seed
                 auto hashRet = decode_mnemonic(strSeedPhraseArg);
                 memcpy(hashMasterKey.begin(), hashRet.begin(), hashRet.size());
+                memory_cleanse(hashRet.data(), hashRet.size());
                 //LogPrintf("%s: Staging for loading seed %s\n", __func__, hashMasterKey.GetHex());
             }
+            // Wipe the plaintext mnemonic phrase now that the 512-bit seed has been derived from it.
+            memory_cleanse(&strSeedPhraseArg[0], strSeedPhraseArg.size());
+            memory_cleanse(&strMessage[0], strMessage.size());
         }
 
         std::shared_ptr<CWallet> pwallet = CWallet::CreateWalletFromFile(walletFile, walletPath, 0, fNewSeed ? &hashMasterKey : nullptr);
+        // The wallet has taken the seed; wipe our copy so the root seed does not linger in memory.
+        memory_cleanse(hashMasterKey.begin(), hashMasterKey.size());
         if (!pwallet) {
             return false;
         }


### PR DESCRIPTION
### Problem

The HD mnemonic phrase and the derived master seed, the root of every wallet, stealth, RingCT and zerocoin key, were left in ordinary process memory after wallet creation, where a swap file, core dump, or local attacker could recover them.

### Description

During wallet creation the mnemonic phrase and the 512 bit master seed pass through plain `std::string`, `std::vector` and `uint512` buffers. Those buffers were never cleansed, so the secret material lingered in memory and could be paged to disk.

### Root Cause

The transient copies of the phrase and seed in `GenerateNewMnemonicSeed` and `MnemonicWalletInit::Open` were normal heap buffers with no cleanse on the way out, so their contents survived until the memory was eventually reused, and were swappable in the meantime.

### Why broke?

Wallet creation was written for correctness, not for secret hygiene, so the transient phrase and seed copies were treated like any other local. They are correct functionally; they simply were not wiped, which only matters for secret material.

### Solution

Cleanse the transient mnemonic and seed copies once they are no longer needed.

### How fix?

`memory_cleanse` is called on the raw private key copy and the intermediate seed in `GenerateNewMnemonicSeed`, and on the mnemonic phrase strings, the decoded seed and the staged master key seed in `MnemonicWalletInit::Open`, the last wiped right after `CreateWalletFromFile` has taken it. `memory_cleanse` is a compiler barrier, so the wipes are not optimised away. This is the pragmatic main path fix; a fuller change would hold the phrase in `SecureString` and the seed in a `secure_allocator` or `LockedPool` so it is never swappable and every error path is covered too, and that is noted for a follow up.

### Unit Testing Results

`src/test/mnemonic_cleanse_tests.cpp` confirms seed derivation is unchanged by the cleanse, so the wipes do not alter wallet creation behaviour. 2 of 2 test cases pass, exit 0, no regressions. The cleanse itself is a memory property rather than an observable output, so the test guards behaviour rather than asserting the wipe directly. Results captured during the security validation; the Boost 1.85 build shim used locally on Apple Silicon is not part of this PR.

### How to test?

Build with tests and run `test_veil --run_test=mnemonic_cleanse_tests`, and confirm a wallet created from a known mnemonic still derives the same addresses as before, since the cleanse must not change any derived key.
